### PR TITLE
Fix the build for the simple example

### DIFF
--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -19,6 +19,6 @@ maven_install(
     ],
     repositories = [
         "https://maven.google.com",
-        "https://repo1.maven.org",
+        "https://repo1.maven.org/maven2",
     ],
 )


### PR DESCRIPTION
The correct repository URL is https://repo1.maven.org/maven2.