### PR TITLE
Add maven_coordinates tags to generated java_imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ java_import(
   jars = ["@maven//:https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar"],
   srcjar = "@maven//:https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
   deps = ["@maven//:org_hamcrest_hamcrest_core_1_3"],
+  tags = ["maven_coordinates=junit:junit:4.12"],
 )
 
 java_import(
@@ -95,6 +96,7 @@ java_import(
   jars = ["@maven//:https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"],
   srcjar = "@maven//:https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
   deps = [],
+  tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
 )
 ```
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -181,6 +181,7 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             target_import_string.append("".join(target_import_labels) + "\t],")
 
             # 5. Add a tag with the original maven coordinates for use generating pom files
+            # For use with this rule https://github.com/google/bazel-common/blob/f1115e0f777f08c3cdb115526c4e663005bec69b/tools/maven/pom_file.bzl#L177
             #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library_1_3",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -180,7 +180,19 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
 
             target_import_string.append("".join(target_import_labels) + "\t],")
 
-            # 5. Finish the java_import rule.
+            # 5. Add a tag with the original maven coordinates for use generating pom files
+            #
+            # java_import(
+            # 	name = "org_hamcrest_hamcrest_library_1_3",
+            # 	jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
+            # 	srcjar = "https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+            # 	deps = [
+            # 		":org_hamcrest_hamcrest_core_1_3",
+            # 	],
+            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            target_import_string.append("\ttags = [\"maven_coordinates=%s\"]," % artifact["coord"])
+
+            # 6. Finish the java_import rule.
             #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library_1_3",
@@ -194,7 +206,7 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
 
             all_imports.append("\n".join(target_import_string))
 
-            # 6. Create a versionless alias target
+            # 7. Create a versionless alias target
             #
             # alias(
             #   name = "org_hamcrest_hamcrest_library",


### PR DESCRIPTION
This tag can be used by rules to generate a pom file that includes the
coordinates of all of a target's dependencies

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/47