### PR TITLE
Fix target labels in examples CI configuration

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -29,12 +29,12 @@ tasks:
     platform: macos
     working_directory: examples/android_instrumentation_test
     build_targets:
-    - "//src/test:greeter_app"
+    - "//src/main:greeter_app"
     - "//src/test:greeter_test_app"
   android-instrumentation-test-windows:
     name: "Android instrumentation test example"
     platform: windows
     working_directory: examples/android_instrumentation_test
     build_targets:
-    - "//src/test:greeter_app"
+    - "//src/main:greeter_app"
     - "//src/test:greeter_test_app"


### PR DESCRIPTION
The Windows failures will be fixed by https://github.com/bazelbuild/rules_jvm_external/pull/65