### PR TITLE
Fix Windows builds on fresh instances, like CI

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -295,7 +295,7 @@ def _coursier_fetch_impl(repository_ctx):
             fail("Please set the BAZEL_SH environment variable to the path of MSYS2 bash. " +
                  "This is typically `c:\\msys64\\usr\\bin\\bash.exe`. For more information, read " +
                  "https://docs.bazel.build/versions/master/install-windows.html#getting-bazel")
-        repository_ctx.execute([bash])
+        repository_ctx.execute([bash, "-lc", "echo", "works"])
 
     # Deserialize the spec blobs
     repositories = []

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -337,11 +337,11 @@ def _coursier_fetch_impl(repository_ctx):
         cmd.extend(["--repository", utils.repo_url(repository)])
     if not repository_ctx.attr.use_unsafe_shared_cache:
         cmd.extend(["--cache", "v1"])  # Download into $output_base/external/$maven_repo_name/v1
-    if _is_windows(repository_ctx):
+    # if _is_windows(repository_ctx):
         # Unfortunately on Windows, coursier crashes while trying to acquire the
         # cache's .structure.lock file while running in parallel. This does not
         # happen on *nix.
-        cmd.extend(["--parallel", "1"])
+        # cmd.extend(["--parallel", "1"])
 
     repository_ctx.report_progress("Resolving and fetching the transitive closure of %s artifact(s).." % len(artifact_coordinates))
     exec_result = repository_ctx.execute(cmd)

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -295,7 +295,7 @@ def _coursier_fetch_impl(repository_ctx):
             fail("Please set the BAZEL_SH environment variable to the path of MSYS2 bash. " +
                  "This is typically `c:\\msys64\\usr\\bin\\bash.exe`. For more information, read " +
                  "https://docs.bazel.build/versions/master/install-windows.html#getting-bazel")
-        exec_result = repository_ctx.execute([bash])
+        repository_ctx.execute([bash])
 
     # Deserialize the spec blobs
     repositories = []

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -345,7 +345,9 @@ def _coursier_fetch_impl(repository_ctx):
     # Once coursier finishes a fetch, it generates a tree of artifacts and their
     # transitive dependencies in a JSON file. We use that as the source of truth
     # to generate the repository's BUILD file.
-    dep_tree = json_parse(_cat_file(repository_ctx, "dep-tree.json"))
+    dep_tree_str = _cat_file(repository_ctx, "dep-tree.json")
+    print(dep_tree_str)
+    dep_tree = json_parse(dep_tree_str)
 
     srcs_dep_tree = None
     if repository_ctx.attr.fetch_sources:

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -337,11 +337,11 @@ def _coursier_fetch_impl(repository_ctx):
         cmd.extend(["--repository", utils.repo_url(repository)])
     if not repository_ctx.attr.use_unsafe_shared_cache:
         cmd.extend(["--cache", "v1"])  # Download into $output_base/external/$maven_repo_name/v1
-    # if _is_windows(repository_ctx):
+    if _is_windows(repository_ctx):
         # Unfortunately on Windows, coursier crashes while trying to acquire the
         # cache's .structure.lock file while running in parallel. This does not
         # happen on *nix.
-        # cmd.extend(["--parallel", "1"])
+        cmd.extend(["--parallel", "1"])
 
     repository_ctx.report_progress("Resolving and fetching the transitive closure of %s artifact(s).." % len(artifact_coordinates))
     exec_result = repository_ctx.execute(cmd)

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -347,6 +347,8 @@ def _coursier_fetch_impl(repository_ctx):
     # to generate the repository's BUILD file.
     dep_tree_str = _cat_file(repository_ctx, "dep-tree.json")
     print(dep_tree_str)
+    dep_tree_str = _cat_file(repository_ctx, "dep-tree.json")
+    print(dep_tree_str)
     dep_tree = json_parse(dep_tree_str)
 
     srcs_dep_tree = None

--- a/third_party/bazel_json/lib/json_parser.bzl
+++ b/third_party/bazel_json/lib/json_parser.bzl
@@ -239,7 +239,7 @@ _STATE_TRANSITION_TABLE = [
 
 
 _MAX_DEPTH = 20
-_DEBUG = False
+_DEBUG = True
 
 def _reject(checker, reason = "unknown reason"):
     if (checker["rejected"]):

--- a/third_party/bazel_json/lib/json_parser.bzl
+++ b/third_party/bazel_json/lib/json_parser.bzl
@@ -239,7 +239,7 @@ _STATE_TRANSITION_TABLE = [
 
 
 _MAX_DEPTH = 20
-_DEBUG = True
+_DEBUG = False 
 
 def _reject(checker, reason = "unknown reason"):
     if (checker["rejected"]):

--- a/third_party/bazel_json/lib/json_parser.bzl
+++ b/third_party/bazel_json/lib/json_parser.bzl
@@ -239,7 +239,7 @@ _STATE_TRANSITION_TABLE = [
 
 
 _MAX_DEPTH = 20
-_DEBUG = False 
+_DEBUG = False
 
 def _reject(checker, reason = "unknown reason"):
     if (checker["rejected"]):


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_jvm_external/issues/53

When running any command on Windows via msys bash for the first time, msys bash prints:

```
Copying skeleton files.
--
These files are for the users to personalise their msys2 experience.
 
They will never be overwritten nor automatically updated.
 
'./.bashrc' -> '/home/SYSTEM/.bashrc'
'./.bash_logout' -> '/home/SYSTEM/.bash_logout'
'./.bash_profile' -> '/home/SYSTEM/.bash_profile'
'./.inputrc' -> '/home/SYSTEM/.inputrc'
'./.profile' -> '/home/SYSTEM/.profile'

<actual json>
```

and causes the JSON parser to choke on the first "C" character. Let's run `bash` once at rule initialization to do a simple `echo`, so further calls to `cat` don't result in this.

Successful build: https://buildkite.com/bazel/rules-jvm-external-examples/builds/12#3215fbf6-a2a2-4591-bfd8-07eed30dbda1

The other macOS and Windows failures will be fixed by https://github.com/bazelbuild/rules_jvm_external/pull/63