### PR TITLE
A better error message when Coursier fails to download artifacts.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,6 @@ load("//:specs.bzl", "maven")
 
 maven_install(
     artifacts = [
-        "com.google.firebase:firebase-firestore:18.1.0",
         "androidx.test.espresso:espresso-core:3.1.1",
         "androidx.test.espresso:espresso-web:3.1.1",
         "androidx.test.ext:junit:1.1.0",
@@ -49,16 +48,6 @@ maven_install(
     name = "other_maven",
     artifacts = [
         "com.google.guava:guava:27.0-jre",
-    ],
-    fetch_sources = True,
-    repositories = [
-        "https://repo1.maven.org/maven2",
-    ],
-)
-
-maven_install(
-    name = "other_maven",
-    artifacts = [
     ],
     fetch_sources = True,
     repositories = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,6 +20,7 @@ load("//:specs.bzl", "maven")
 
 maven_install(
     artifacts = [
+        "com.google.firebase:firebase-firestore:18.1.0",
         "androidx.test.espresso:espresso-core:3.1.1",
         "androidx.test.espresso:espresso-web:3.1.1",
         "androidx.test.ext:junit:1.1.0",
@@ -48,6 +49,16 @@ maven_install(
     name = "other_maven",
     artifacts = [
         "com.google.guava:guava:27.0-jre",
+    ],
+    fetch_sources = True,
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+
+maven_install(
+    name = "other_maven",
+    artifacts = [
     ],
     fetch_sources = True,
     repositories = [
@@ -89,12 +100,29 @@ maven_install(
     use_unsafe_shared_cache = True,
 )
 
-BAZEL_SKYLIB_TAG = "0.6.0"
+# These artifacts helped discover limitations by the Maven resolver. Each
+# artifact listed here *must have* an accompanying issue. We build_test these
+# targets to ensure that they remain supported by the rule.
+maven_install(
+    name = "regression_testing",
+    artifacts = [
+        # https://github.com/bazelbuild/rules_jvm_external/issues/74
+        "org.pantsbuild:jarjar:1.6.6",
+    ],
+    fetch_sources = True,
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
 
+BAZEL_SKYLIB_TAG = "0.7.0"
 http_archive(
     name = "bazel_skylib",
     strip_prefix = "bazel-skylib-%s" % BAZEL_SKYLIB_TAG,
     url = "https://github.com/bazelbuild/bazel-skylib/archive/%s.tar.gz" % BAZEL_SKYLIB_TAG,
+    sha256 = "2c62d8cd4ab1e65c08647eb4afe38f51591f43f7f0885e7769832fa137633dcb",
 )
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
 
 # End test dependencies

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -238,6 +238,7 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
 
             # Get the reverse deps of the missing artifact.
             reverse_deps = []
+
             # For all potential artifacts, which may be an rdep,
             for maybe_rdep in dep_tree["dependencies"]:
                 # For all dependencies of this artifact,
@@ -250,7 +251,8 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             reverse_dep_coords = [reverse_dep["coord"] for reverse_dep in reverse_deps]
             reverse_dep_pom_paths = [
                 repository_ctx.path(reverse_dep["file"].replace(".jar", ".pom").replace(".aar", ".pom"))
-                for reverse_dep in reverse_deps]
+                for reverse_dep in reverse_deps
+            ]
 
             error_message = """
 The artifact for {artifact} was not downloaded. Perhaps its packaging type is

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -208,7 +208,8 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
             target_import_string.append("\ttags = [\"maven_coordinates=%s\"]," % artifact["coord"])
 
-            # 6. Finish the java_import rule. #
+            # 6. Finish the java_import rule.
+            #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library_1_3",
             # 	jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
@@ -239,13 +240,13 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             # Get the reverse deps of the missing artifact.
             reverse_deps = []
 
-            # For all potential artifacts, which may be an rdep,
+            # For all potential reverse dep artifacts,
             for maybe_rdep in dep_tree["dependencies"]:
                 # For all dependencies of this artifact,
                 for coord in maybe_rdep["dependencies"]:
                     # If this artifact depends on the missing artifact,
                     if coord == artifact["coord"]:
-                        # This artifact is an rdep :-)
+                        # Then this artifact is an rdep :-)
                         reverse_deps.append(maybe_rdep)
 
             reverse_dep_coords = [reverse_dep["coord"] for reverse_dep in reverse_deps]

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -19,6 +19,13 @@ package(default_visibility = ["//visibility:public"])
 {imports}
 """
 
+# Coursier uses these types to determine what files it should resolve and fetch.
+# For example, some jars have the type "eclipse-plugin", and Coursier would not
+# download them if it's not asked to to resolve "eclipse-plugin".
+#
+# Also see: https://github.com/bazelbuild/rules_jvm_external/issues/74
+_COURSIER_ARTIFACT_TYPES = ["jar", "aar", "bundle", "eclipse-plugin"]
+
 # Super hacky :(
 def _strip_packaging_and_classifier(coord):
     return coord.replace(":jar:", ":").replace(":aar:", ":").replace(":sources:", ":")
@@ -201,8 +208,7 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
             target_import_string.append("\ttags = [\"maven_coordinates=%s\"]," % artifact["coord"])
 
-            # 6. Finish the java_import rule.
-            #
+            # 6. Finish the java_import rule. #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library_1_3",
             # 	jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
@@ -225,10 +231,40 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
 
         elif artifact_path == None:
-            fail("The artifact for " +
-                 artifact["coord"] +
-                 " was not downloaded. Perhaps the packaging type is not one of: jar, aar, bundle?\n" +
-                 "Parsed artifact data:" + repr(artifact))
+            # Possible reasons that the artifact_path is None:
+            #
+            # https://github.com/bazelbuild/rules_jvm_external/issues/70
+            # https://github.com/bazelbuild/rules_jvm_external/issues/74
+
+            # Get the reverse deps of the missing artifact.
+            reverse_deps = []
+            # For all potential artifacts, which may be an rdep,
+            for maybe_rdep in dep_tree["dependencies"]:
+                # For all dependencies of this artifact,
+                for coord in maybe_rdep["dependencies"]:
+                    # If this artifact depends on the missing artifact,
+                    if coord == artifact["coord"]:
+                        # This artifact is an rdep :-)
+                        reverse_deps.append(maybe_rdep["coord"])
+
+            error_message = """
+The artifact for {artifact} was not downloaded. Perhaps its packaging type is not one of: {packaging_types}?
+
+These artifact(s) depend on {artifact}:
+
+{reverse_deps}
+
+It is also possible that the type of {artifact} is specified incorrectly in the POM file of the artifact that depends on it. For example, {artifact} may be an AAR, but the dependent's POM file specified its `<type>` value to be a JAR.
+
+Parsed artifact data: {parsed_artifact}
+            """.format(
+                artifact = artifact["coord"],
+                packaging_types = ",".join(_COURSIER_ARTIFACT_TYPES),
+                reverse_deps = "\n".join(reverse_deps),
+                parsed_artifact = repr(artifact),
+            )
+
+            fail(error_message)
 
     return ("\n".join(all_imports), checksums)
 
@@ -326,7 +362,7 @@ def _coursier_fetch_impl(repository_ctx):
     cmd = _generate_coursier_command(repository_ctx)
     cmd.extend(["fetch"])
     cmd.extend(artifact_coordinates)
-    cmd.extend(["--artifact-type", "jar,aar,bundle"])
+    cmd.extend(["--artifact-type", ",".join(_COURSIER_ARTIFACT_TYPES)])
     cmd.append("--quiet")
     cmd.append("--no-default")
     cmd.extend(["--json-output-file", "dep-tree.json"])
@@ -358,7 +394,7 @@ def _coursier_fetch_impl(repository_ctx):
         cmd = _generate_coursier_command(repository_ctx)
         cmd.extend(["fetch"])
         cmd.extend(artifact_coordinates)
-        cmd.extend(["--artifact-type", "jar,aar,bundle,src"])
+        cmd.extend(["--artifact-type", ",".join(_COURSIER_ARTIFACT_TYPES + ["src"])])
         cmd.append("--quiet")
         cmd.append("--no-default")
         cmd.extend(["--sources", "true"])

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -4,6 +4,6 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 # project.
 
 build_test(
-    name = "org_pantsbuild_jarjar",
+    name = "all_artifacts",
     targets = ["@regression_testing//:org_pantsbuild_jarjar_1_6_6"],
 )

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -1,0 +1,9 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+# Regression tests for particular artifacts that revealed problems for this
+# project.
+
+build_test(
+    name = "org_pantsbuild_jarjar",
+    targets = ["@regression_testing//:org_pantsbuild_jarjar_1_6_6"],
+)


### PR DESCRIPTION
For example, the new error message for https://github.com/bazelbuild/rules_jvm_external/issues/70 looks like this:

```
The artifact for io.grpc:grpc-android:jar:1.16.1 was not downloaded. Perhaps its packaging type is
not one of: jar,aar,bundle,eclipse-plugin?

It is also possible that the packaging type of io.grpc:grpc-android:jar:1.16.1 is specified
incorrectly in the POM file of an artifact that depends on it. For example,
io.grpc:grpc-android:jar:1.16.1 may be an AAR, but the dependent's POM file specified its `<type>`
value to be a JAR.

The artifact(s) depending on io.grpc:grpc-android:jar:1.16.1 are:

com.google.firebase:firebase-firestore:18.1.0

and their POM files are located at:

/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/regression_testing/v1/https/maven.google.com/com/google/firebase/firebase-firestore/18.1.0/firebase-firestore-18.1.0.pom

---

Parsed artifact data: {"coord": "io.grpc:grpc-android:jar:1.16.1", "file": None, "dependencies": ["io.opencensus:opencensus-contrib-grpc-metrics:0.12.3", "com.google.code.findbugs:jsr305:3.0.2", "io.grpc:grpc-context:1.16.1", "com.google.code.gson:gson:2.7", "io.grpc:grpc-core:1.16.1", "org.checkerframework:checker-compat-qual:2.5.2", "org.codehaus.mojo:animal-sniffer-annotations:1.17", "com.google.j2objc:j2objc-annotations:1.1", "com.google.errorprone:error_prone_annotations:2.2.0", "io.opencensus:opencensus-api:0.12.3", "com.google.guava:guava:26.0-android"]}

```

If `use_unsafe_shared_cache = True`, then the POM file path will be `/usr/local/google/home/jingwen/.cache/coursier/v1/https/maven.google.com/com/google/firebase/firebase-firestore/18.1.0/firebase-firestore-18.1.0.pom`.

This PR also adds `eclipse-plugin` to the list of `--artifact-type` values for Coursier in order to fix https://github.com/bazelbuild/rules_jvm_external/issues/74, and adds a `build_test` for the artifact in question.

Fixes #74 
