### PR TITLE
Fix missing yaml config and remove gmaven_rules app from CI

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -38,6 +38,8 @@ tasks:
     working_directory: examples/android_instrumentation_test
     # Android instrumentation tests don't work on Windows yet.
     build_targets:
+      - "//src/main:greeter_app"
+      - "//src/test:greeter_test_app"
   android-local-test-linux:
     name: "Android Robolectric test example"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,8 +6,6 @@ platforms:
     - ./tests/integration/simple_integration_test.sh
     - ./tests/integration/artifact_exclusions_integration_test.sh
     - ./tests/integration/unsafe_shared_cache_integration_test.sh
-    build_targets:
-    - "//examples:app"
     test_targets:
     - "//tests/unit/..."
   ubuntu1604:
@@ -15,8 +13,6 @@ platforms:
     - ./tests/integration/simple_integration_test.sh
     - ./tests/integration/artifact_exclusions_integration_test.sh
     - ./tests/integration/unsafe_shared_cache_integration_test.sh
-    build_targets:
-    - "//examples:app"
     test_targets:
     - "//tests/unit/..."
   ubuntu1804:
@@ -24,16 +20,9 @@ platforms:
     - ./tests/integration/simple_integration_test.sh
     - ./tests/integration/artifact_exclusions_integration_test.sh
     - ./tests/integration/unsafe_shared_cache_integration_test.sh
-    build_targets:
-    - "//examples:app"
     test_targets:
     - "//tests/unit/..."
   macos:
-    build_targets:
-    # TODO(jin): Fix concurrent download failure on macOS
-    # https://github.com/bazelbuild/rules_jvm_external/issues/54
-    # - "//tests/integration:all"
-    - "//examples:app"
     test_targets:
     - "//tests/unit/..."
   windows:
@@ -41,8 +30,6 @@ platforms:
     # TODO(jin): Fix JSON parsing error on Windows
     # https://github.com/bazelbuild/rules_jvm_external/issues/53
     # - "//tests/integration:all"
-    # TODO(jin): fix long paths issue on Windows
-    # - "//examples:app"
     test_targets:
     - "--"
     - "//tests/unit/..."


### PR DESCRIPTION
This CL fixes the one breakage in the examples pipeline.