### PR TITLE
Add a example for Spring Boot

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -81,3 +81,27 @@ tasks:
   #   working_directory: examples/android_kotlin_app
   #   build_targets:
   #   - "//:app"
+  spring-boot-linux:
+    name: "Spring boot example"
+    platform: ubuntu1804
+    working_directory: examples/spring_boot
+    build_targets:
+    - "//src/main/java/hello:app"
+    test_targets:
+    - "//src/test/java/hello:test"
+  spring-boot-macos:
+    name: "Spring boot example"
+    platform: macos
+    working_directory: examples/spring_boot
+    build_targets:
+    - "//src/main/java/hello:app"
+    test_targets:
+    - "//src/test/java/hello:test"
+  spring-boot-windows:
+    name: "Spring boot example"
+    platform: windows 
+    working_directory: examples/spring_boot
+    build_targets:
+    - "//src/main/java/hello:app"
+    test_targets:
+    - "//src/test/java/hello:test"

--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -86,22 +86,22 @@ tasks:
     platform: ubuntu1804
     working_directory: examples/spring_boot
     build_targets:
-    - "//src/main/java/hello:app"
+    - "//..."
     test_targets:
-    - "//src/test/java/hello:test"
+    - "//..."
   spring-boot-macos:
     name: "Spring boot example"
     platform: macos
     working_directory: examples/spring_boot
     build_targets:
-    - "//src/main/java/hello:app"
+    - "//..."
     test_targets:
-    - "//src/test/java/hello:test"
+    - "//..."
   spring-boot-windows:
     name: "Spring boot example"
     platform: windows 
     working_directory: examples/spring_boot
     build_targets:
-    - "//src/main/java/hello:app"
+    - "//..."
     test_targets:
-    - "//src/test/java/hello:test"
+    - "//..."

--- a/examples/spring_boot/README.md
+++ b/examples/spring_boot/README.md
@@ -1,0 +1,21 @@
+# Spring Boot Example
+
+This is an example of the tutorial app from [Spring's website](https://spring.io/guides/gs/spring-boot/).
+
+To build the Spring Boot application:
+
+```
+$ bazel build //src/main/java/hello:app
+```
+
+To run the Spring Boot application:
+
+```
+$ bazel run //src/main/java/hello:app
+```
+
+To run the test:
+
+```
+$ bazel test //src/test/java/hello:test
+```

--- a/examples/spring_boot/README.md
+++ b/examples/spring_boot/README.md
@@ -15,10 +15,10 @@ To run the Spring Boot application:
 $ bazel run //src/main/java/hello:app
 ```
 
-To run the test:
+To run the tests:
 
 ```
-$ bazel test //src/test/java/hello:test
+$ bazel test //src/test/...
 ```
 
 This tutorial code is [licensed under Apache 2.0, copyright GoPivotal

--- a/examples/spring_boot/README.md
+++ b/examples/spring_boot/README.md
@@ -1,6 +1,7 @@
 # Spring Boot Example
 
-This is an example of the tutorial app from [Spring's website](https://spring.io/guides/gs/spring-boot/).
+This is an example of the tutorial app from [Spring's
+website](https://spring.io/guides/gs/spring-boot/).
 
 To build the Spring Boot application:
 
@@ -19,3 +20,6 @@ To run the test:
 ```
 $ bazel test //src/test/java/hello:test
 ```
+
+This tutorial code is [licensed under Apache 2.0, copyright GoPivotal
+Inc.](https://github.com/spring-guides/gs-spring-boot/blob/d0f3a942f1b31ee73d2896c1e201f11cd8efd6ba/LICENSE.code.txt)

--- a/examples/spring_boot/WORKSPACE
+++ b/examples/spring_boot/WORKSPACE
@@ -1,0 +1,16 @@
+local_repository(
+    name = "rules_jvm_external",
+    path = "../../",
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        "org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE",
+        "org.springframework.boot:spring-boot-starter-test:2.1.3.RELEASE",
+    ],
+    repositories = [
+        "https://jcenter.bintray.com",
+    ]
+)

--- a/examples/spring_boot/WORKSPACE
+++ b/examples/spring_boot/WORKSPACE
@@ -7,8 +7,16 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
+        "org.hamcrest:hamcrest-library:1.3",
+        "org.springframework.boot:spring-boot-autoconfigure:2.1.3.RELEASE",
+        "org.springframework.boot:spring-boot-test-autoconfigure:2.1.3.RELEASE",
+        "org.springframework.boot:spring-boot-test:2.1.3.RELEASE",
+        "org.springframework.boot:spring-boot:2.1.3.RELEASE",
         "org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE",
-        "org.springframework.boot:spring-boot-starter-test:2.1.3.RELEASE",
+        "org.springframework:spring-beans:5.1.5.RELEASE",
+        "org.springframework:spring-context:5.1.5.RELEASE",
+        "org.springframework:spring-test:5.1.5.RELEASE",
+        "org.springframework:spring-web:5.1.5.RELEASE",
     ],
     repositories = [
         "https://jcenter.bintray.com",

--- a/examples/spring_boot/src/main/java/hello/Application.java
+++ b/examples/spring_boot/src/main/java/hello/Application.java
@@ -1,0 +1,33 @@
+package hello;
+
+import java.util.Arrays;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  public CommandLineRunner commandLineRunner(ApplicationContext ctx) {
+    return args -> {
+
+      System.out.println("Let's inspect the beans provided by Spring Boot:");
+
+      String[] beanNames = ctx.getBeanDefinitionNames();
+      Arrays.sort(beanNames);
+      for (String beanName : beanNames) {
+        System.out.println(beanName);
+      }
+
+    };
+  }
+
+}

--- a/examples/spring_boot/src/main/java/hello/BUILD.bazel
+++ b/examples/spring_boot/src/main/java/hello/BUILD.bazel
@@ -1,0 +1,20 @@
+java_library(
+    name = "lib",
+    srcs = glob(["*.java"]),
+    deps = [
+        "@maven//:org_springframework_boot_spring_boot_starter_web",
+        "@maven//:org_springframework_spring_web",
+        "@maven//:org_springframework_spring_context",
+        "@maven//:org_springframework_boot_spring_boot",
+        "@maven//:org_springframework_boot_spring_boot_autoconfigure",
+    ],
+    visibility = ["//src/test:__subpackages__"]
+)
+
+java_binary(
+    name = "app",
+    main_class = "hello.Application",
+    runtime_deps = [
+        ":lib",
+    ]
+)

--- a/examples/spring_boot/src/main/java/hello/HelloController.java
+++ b/examples/spring_boot/src/main/java/hello/HelloController.java
@@ -1,0 +1,14 @@
+package hello;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RestController
+public class HelloController {
+
+  @RequestMapping("/")
+  public String index() {
+    return "Greetings from Spring Boot!";
+  }
+
+}

--- a/examples/spring_boot/src/test/java/hello/BUILD.bazel
+++ b/examples/spring_boot/src/test/java/hello/BUILD.bazel
@@ -1,0 +1,16 @@
+java_test(
+    name = "test",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//src/main/java/hello:lib",
+        "@maven//:org_springframework_boot_spring_boot_starter_test",
+        "@maven//:org_springframework_boot_spring_boot_test_autoconfigure",
+        "@maven//:org_hamcrest_hamcrest_library",
+        "@maven//:org_springframework_boot_spring_boot_test",
+        "@maven//:org_springframework_spring_test",
+        "@maven//:org_springframework_spring_beans",
+        "@maven//:org_springframework_spring_web",
+        "@maven//:org_springframework_boot_spring_boot",
+    ],
+    test_class = "hello.HelloControllerIT",
+)

--- a/examples/spring_boot/src/test/java/hello/BUILD.bazel
+++ b/examples/spring_boot/src/test/java/hello/BUILD.bazel
@@ -1,10 +1,24 @@
 java_test(
-    name = "test",
-    srcs = glob(["*.java"]),
+    name = "HelloControllerTest",
+    srcs = ["HelloControllerTest.java"],
     deps = [
         "//src/main/java/hello:lib",
-        "@maven//:org_springframework_boot_spring_boot_starter_test",
         "@maven//:org_springframework_boot_spring_boot_test_autoconfigure",
+        "@maven//:org_hamcrest_hamcrest_library",
+        "@maven//:org_springframework_boot_spring_boot_test",
+        "@maven//:org_springframework_spring_test",
+        "@maven//:org_springframework_spring_beans",
+        "@maven//:org_springframework_spring_web",
+    ],
+    test_class = "hello.HelloControllerTest",
+)
+
+
+java_test(
+    name = "HelloControllerIntegrationTest",
+    srcs = ["HelloControllerIT.java"],
+    deps = [
+        "//src/main/java/hello:lib",
         "@maven//:org_hamcrest_hamcrest_library",
         "@maven//:org_springframework_boot_spring_boot_test",
         "@maven//:org_springframework_spring_test",

--- a/examples/spring_boot/src/test/java/hello/HelloControllerIT.java
+++ b/examples/spring_boot/src/test/java/hello/HelloControllerIT.java
@@ -1,0 +1,41 @@
+package hello;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class HelloControllerIT {
+
+  @LocalServerPort
+  private int port;
+
+  private URL base;
+
+  @Autowired
+  private TestRestTemplate template;
+
+  @Before
+  public void setUp() throws Exception {
+    this.base = new URL("http://localhost:" + port + "/");
+  }
+
+  @Test
+  public void getHello() throws Exception {
+    ResponseEntity<String> response = template.getForEntity(base.toString(),
+        String.class);
+    assertThat(response.getBody(), equalTo("Greetings from Spring Boot!"));
+  }
+}

--- a/examples/spring_boot/src/test/java/hello/HelloControllerTest.java
+++ b/examples/spring_boot/src/test/java/hello/HelloControllerTest.java
@@ -1,0 +1,31 @@
+package hello;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HelloControllerTest {
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Test
+  public void getHello() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(equalTo("Greetings from Spring Boot!")));
+  }
+}


### PR DESCRIPTION
This adds an example web application built with Spring Boot and rules_jvm_external, as requested by a user.

https://spring.io/guides/gs/spring-boot/

