### PR TITLE
(example): add scala akka http application.

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -99,8 +99,33 @@ tasks:
     - "//..."
   spring-boot-windows:
     name: "Spring boot example"
-    platform: windows 
+    platform: windows
     working_directory: examples/spring_boot
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+
+  scala-akka-linux:
+    name: "Scala example"
+    platform: ubuntu1804
+    working_directory: examples/scala_akka
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+  scala-akka-macos:
+    name: "Scala example"
+    platform: macos
+    working_directory: examples/scala_akka
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+  scala-akka-windows:
+    name: "Scala example"
+    platform: windows
+    working_directory: examples/scala_akka
     build_targets:
     - "//..."
     test_targets:

--- a/examples/scala_akka/.gitignore
+++ b/examples/scala_akka/.gitignore
@@ -1,0 +1,6 @@
+.ijwb
+bazel-bin
+bazel-genfiles
+bazel-out
+bazel-scala
+bazel-testlogs

--- a/examples/scala_akka/BUILD.bazel
+++ b/examples/scala_akka/BUILD.bazel
@@ -1,0 +1,80 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_test", "scala_test_suite")
+
+lib_dependencies = [
+   "@maven//:com_chuusai_shapeless_2_12",
+   "@maven//:com_github_pureconfig_pureconfig_2_12",
+   "@maven//:com_github_pureconfig_pureconfig_core_2_12",
+   "@maven//:com_github_pureconfig_pureconfig_generic_2_12",
+   "@maven//:com_github_pureconfig_pureconfig_macros_2_12",
+   "@maven//:com_typesafe_akka_akka_actor_2_12",
+   "@maven//:com_typesafe_akka_akka_http_2_12",
+   "@maven//:com_typesafe_akka_akka_http_core_2_12",
+   "@maven//:com_typesafe_akka_akka_stream_2_12",
+   "@maven//:com_typesafe_config",
+   "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
+   "@maven//:org_scalaz_scalaz_core_2_12",
+   "@maven//:org_scalaz_scalaz_concurrent_2_12",
+   "@maven//:org_slf4j_slf4j_api",
+   "@maven//:org_slf4j_slf4j_simple",
+]
+
+test_dependencies = [
+    "@maven//:com_typesafe_akka_akka_testkit_2_12",
+    "@maven//:com_typesafe_akka_akka_http_testkit_2_12",
+    "@maven//:com_typesafe_akka_akka_stream_testkit_2_12",
+    "@maven//:org_mockito_mockito_core",
+] + lib_dependencies
+
+scala_library(
+    name = "lib",
+    srcs = glob([
+        "src/main/scala/**/*.scala"
+    ]),
+    resources = glob([
+        "src/main/resources/**/*",
+    ]),
+    deps = lib_dependencies,
+    scalacopts = [
+        "-target:jvm-1.8",
+        "-encoding",
+        "UTF-8",
+        "-Xfuture",
+        "-Xlint",
+        "-Xlint:unsound-match",
+        "-Xmacro-settings:materialize-derivations",
+        "-Yno-adapted-args",
+        "-Ypartial-unification",
+        "-Ywarn-unused-import",
+        "-Ywarn-value-discard",
+        "-Ywarn-dead-code",
+        "-Ywarn-numeric-widen",
+        "-language:existentials",
+        "-language:experimental.macros",
+        "-language:higherKinds",
+        "-deprecation",
+        "-feature",
+        "-unchecked",
+    ],
+)
+
+scala_binary(
+    name = "app",
+    main_class = "hello.Application",
+    runtime_deps = [
+        ":lib",
+    ]
+)
+
+scala_test_suite(
+    name = "test",
+    size = "small",
+    srcs = glob([
+        "src/test/**/*Spec.scala",
+    ]),
+    resources = glob([
+        "src/test/resources/**/*",
+    ]),
+    deps = [
+        ":lib",
+    ] + test_dependencies,
+)

--- a/examples/scala_akka/README.md
+++ b/examples/scala_akka/README.md
@@ -1,0 +1,19 @@
+# Scala Example
+
+To build the Scala application:
+
+```
+$ bazel build app
+```
+
+To run the Scala application:
+
+```
+$ bazel run app
+```
+
+To run the tests:
+
+```
+$ bazel test test
+```

--- a/examples/scala_akka/WORKSPACE
+++ b/examples/scala_akka/WORKSPACE
@@ -1,0 +1,53 @@
+local_repository(
+    name = "rules_jvm_external",
+    path = "../../",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_SCALA_VERSION = "88ad68b3b9d2b533099cdd3d88a41d106edfeecb"
+
+http_archive(
+    name = "io_bazel_rules_scala",
+    sha256 = "96b79ceec705bf6e81c4099bb9dcf0aec15747e658dc9406cb4bbf8b108ca38a",
+    strip_prefix = "rules_scala-%s" % RULES_SCALA_VERSION,
+    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % RULES_SCALA_VERSION,
+)
+
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+
+scala_repositories((
+    "2.12.8",
+    {
+        "scala_compiler": "f34e9119f45abd41e85b9e121ba19dd9288b3b4af7f7047e86dc70236708d170",
+        "scala_library": "321fb55685635c931eba4bc0d7668349da3f2c09aee2de93a70566066ff25c28",
+        "scala_reflect": "4d6405395c4599ce04cea08ba082339e3e42135de9aae2923c9f5367e957315a",
+    },
+))
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+
+scala_register_toolchains()
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        "com.github.pureconfig:pureconfig_2.12:0.10.2",
+        "com.typesafe.akka:akka-actor_2.12:2.5.22",
+        "com.typesafe.akka:akka-http_2.12:10.1.8",
+        "com.typesafe.akka:akka-http-testkit_2.12:10.1.8",
+        "com.typesafe.akka:akka-stream_2.12:2.5.22",
+        "com.typesafe.akka:akka-stream-testkit_2.12:2.5.22",
+        "com.typesafe.akka:akka-testkit_2.12:2.5.22",
+        "com.typesafe.scala-logging:scala-logging_2.12:3.9.2",
+        "org.mockito:mockito-core:2.26.0",
+        "org.scalaz:scalaz-core_2.12:7.2.27",
+        "org.scalaz:scalaz-concurrent_2.12:7.2.27",
+        "org.slf4j:slf4j-api:1.7.26",
+        "org.slf4j:slf4j-simple:1.7.26",
+    ],
+    repositories = [
+        "https://jcenter.bintray.com",
+    ]
+)

--- a/examples/scala_akka/src/main/resources/application.conf
+++ b/examples/scala_akka/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+application {
+  host = "0.0.0.0"
+  port = 9000
+}

--- a/examples/scala_akka/src/main/scala/hello/Application.scala
+++ b/examples/scala_akka/src/main/scala/hello/Application.scala
@@ -1,0 +1,27 @@
+package hello
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.typesafe.scalalogging.LazyLogging
+import scalaz.EitherT.{eitherT, fromDisjunction => pure}
+import scalaz.Scalaz._
+import scalaz.\/
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object Application extends App with LazyLogging {
+  implicit val system: ActorSystem = ActorSystem("sample")
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val executionContext: ExecutionContext = system.dispatcher
+
+  val run: () => Future[String \/ Unit] = { () =>
+    (for {
+      c <- pure[Future](Configuration.parse)
+      s <- eitherT(Server.start(c.host, c.port, Endpoint.route))
+    } yield {
+      logger.info(s"Started server on host = ${c.host} and port = ${c.port}")
+    }).run
+  }
+
+  run()
+}

--- a/examples/scala_akka/src/main/scala/hello/Configuration.scala
+++ b/examples/scala_akka/src/main/scala/hello/Configuration.scala
@@ -1,0 +1,14 @@
+package hello
+
+import pureconfig._
+import pureconfig.generic.auto._
+import scalaz.\/
+
+case class ApplicationConfiguration(host: String, port: Int)
+
+object Configuration {
+  val parse: String \/ ApplicationConfiguration = {
+    \/.fromEither(loadConfig[ApplicationConfiguration]("application"))
+      .leftMap(f => s"Failed to load configuration due to: ${f.toString}")
+  }
+}

--- a/examples/scala_akka/src/main/scala/hello/Endpoint.scala
+++ b/examples/scala_akka/src/main/scala/hello/Endpoint.scala
@@ -1,0 +1,14 @@
+package hello
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
+object Endpoint {
+  val route: Route =
+    get {
+      pathSingleSlash {
+        complete(HttpResponse(StatusCodes.OK))
+      }
+    }
+}

--- a/examples/scala_akka/src/main/scala/hello/Server.scala
+++ b/examples/scala_akka/src/main/scala/hello/Server.scala
@@ -1,0 +1,23 @@
+package hello
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import scalaz.{-\/, \/, \/-}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+object Server {
+  def start(host: String, port: Int, services: Route)(
+      implicit ec: ExecutionContext,
+      mat: Materializer,
+      system: ActorSystem): Future[String \/ Http.ServerBinding] =
+    Http()
+      .bindAndHandle(services, host, port)
+      .map(b => \/-(b))
+      .recover {
+        case NonFatal(t) =>
+          -\/(s"Failed to initialize server due to: ${t.getMessage}")
+      }
+}

--- a/examples/scala_akka/src/test/resources/application.conf
+++ b/examples/scala_akka/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+application {
+  host = "0.0.0.0"
+  port = 9000
+}

--- a/examples/scala_akka/src/test/scala/hello/ConfigurationSpec.scala
+++ b/examples/scala_akka/src/test/scala/hello/ConfigurationSpec.scala
@@ -1,0 +1,17 @@
+package hello
+
+import org.scalatest.{Inside, Matchers, WordSpec}
+import scalaz.\/-
+
+class ConfigurationSpec extends WordSpec with Matchers with Inside {
+  Configuration.getClass.getSimpleName should {
+    "should parse reference configuration" in {
+      val sut = Configuration.parse
+      inside(sut) {
+        case \/-(c) =>
+          c.host shouldBe "0.0.0.0"
+          c.port shouldBe 9000
+      }
+    }
+  }
+}

--- a/examples/scala_akka/src/test/scala/hello/EndpointSpec.scala
+++ b/examples/scala_akka/src/test/scala/hello/EndpointSpec.scala
@@ -1,0 +1,14 @@
+package hello
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.{Matchers, WordSpec}
+
+class EndpointSpec extends WordSpec with Matchers with ScalatestRouteTest {
+  Endpoint.getClass.getSimpleName should {
+    "should return status OK" in {
+      Get() ~> Endpoint.route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds and example of a fairly complex Scala application, and how to use the rules to successfully build / run / test it. In comparison to `bazel-deps`, we now need to define extra `deps` in order for `rules_scala` to pick them up. No big deal! @jin awesome job on this project!