### PR TITLE
Add an else clause to generate_imports to guide users to open an issue

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -311,6 +311,18 @@ Parsed artifact data: {parsed_artifact}""".format(
             )
 
             fail(error_message)
+        else:
+            error_message = """Unable to generate a target for this artifact.
+
+Please file an issue on https://github.com/bazelbuild/rules_jvm_external/issues/new
+and include the following snippet:
+
+Artifact coordinates: {artifact}
+Parsed data: {parsed_artifact}""".format(
+                artifact = artifact["coord"],
+                parsed_artifact = repr(artifact)
+            )
+            fail(error_message)
 
     return "\n".join(all_imports)
 


### PR DESCRIPTION
This assumes that every artifact in the parsed Coursier output corresponds to a Bazel target, and will help us catch issues like the pom-only artifact.