### PR TITLE
Don't build test android aars on Windows

### DIFF
--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -10,6 +10,5 @@ build_test(
         "@regression_testing//:com_github_fommil_netlib_all_1_1_2",
         "@regression_testing//:nz_ac_waikato_cms_weka_weka_stable_3_8_1",
         "@regression_testing//:com_digitalasset_damlc_osx_100_12_1",
-        "@regression_testing//:com_android_support_appcompat_v7",
     ],
 )


### PR DESCRIPTION
https://buildkite.com/bazel/rules-jvm-external/builds/357#41f8a0b3-3c13-4c63-9a1e-c22a192c9c38

The regression testing still works because the failure from #111 comes from the repository rule, and not during the build.