### PR TITLE
Add general support for POM-only artifacts by detecting the resolved `pom` packaging type in the artifact coordinate

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,8 @@ maven_install(
         # https://github.com/bazelbuild/rules_jvm_external/issues/111
         "com.android.support:appcompat-v7:aar:28.0.0",
         "com.google.android.gms:play-services-base:16.1.0",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/119#issue-434484351
+        "io.vavr:vavr-parent:0.10.0",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -268,7 +268,7 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None, neverlink_a
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
 
         elif artifact_path == None and (
-                artifact["coord"].find(":pom") or
+                artifact["coord"].find(":pom") != -1 or
                 POM_ONLY_ARTIFACTS.get(
                     _strip_packaging_and_classifier_and_version(artifact["coord"]))):
             # Special case for certain artifacts that only come with a POM file. Such artifacts "aggregate" their dependencies,

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -267,29 +267,31 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None, neverlink_a
             versionless_target_alias_label = _escape(_strip_packaging_and_classifier_and_version(artifact["coord"]))
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
 
-        elif artifact_path == None and POM_ONLY_ARTIFACTS.get(_strip_packaging_and_classifier_and_version(artifact["coord"])):
+        elif artifact_path == None and (
+                artifact["coord"].find(":pom") or
+                POM_ONLY_ARTIFACTS.get(
+                    _strip_packaging_and_classifier_and_version(artifact["coord"]))):
             # Special case for certain artifacts that only come with a POM file. Such artifacts "aggregate" their dependencies,
             # so they don't have a JAR for download.
-            if target_label not in seen_imports:
-                seen_imports[target_label] = True
-                target_import_string = ["java_library("]
-                target_import_string.append("\tname = \"%s\"," % target_label)
-                target_import_string.append("\texports = [")
+            seen_imports[target_label] = True
+            target_import_string = ["java_library("]
+            target_import_string.append("\tname = \"%s\"," % target_label)
+            target_import_string.append("\texports = [")
 
-                target_import_labels = []
-                for dep in artifact["dependencies"]:
-                    dep_target_label = _escape(_strip_packaging_and_classifier(dep))
-                    target_import_labels.append("\t\t\":%s\",\n" % dep_target_label)
-                target_import_labels = _deduplicate_list(target_import_labels)
+            target_import_labels = []
+            for dep in artifact["dependencies"]:
+                dep_target_label = _escape(_strip_packaging_and_classifier(dep))
+                target_import_labels.append("\t\t\":%s\",\n" % dep_target_label)
+            target_import_labels = _deduplicate_list(target_import_labels)
 
-                target_import_string.append("".join(target_import_labels) + "\t],")
-                target_import_string.append("\ttags = [\"maven_coordinates=%s\"]," % artifact["coord"])
-                target_import_string.append(")")
+            target_import_string.append("".join(target_import_labels) + "\t],")
+            target_import_string.append("\ttags = [\"maven_coordinates=%s\"]," % artifact["coord"])
+            target_import_string.append(")")
 
-                all_imports.append("\n".join(target_import_string))
+            all_imports.append("\n".join(target_import_string))
 
-                versionless_target_alias_label = _escape(_strip_packaging_and_classifier_and_version(artifact["coord"]))
-                all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
+            versionless_target_alias_label = _escape(_strip_packaging_and_classifier_and_version(artifact["coord"]))
+            all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
 
         elif artifact_path == None:
             # Possible reasons that the artifact_path is None:

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -268,7 +268,7 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None, neverlink_a
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
 
         elif artifact_path == None and (
-                artifact["coord"].find(":pom") != -1 or
+                artifact["coord"].find(":pom:") != -1 or
                 POM_ONLY_ARTIFACTS.get(
                     _strip_packaging_and_classifier_and_version(artifact["coord"]))):
             # Special case for certain artifacts that only come with a POM file. Such artifacts "aggregate" their dependencies,

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -11,5 +11,6 @@ build_test(
         "@regression_testing//:nz_ac_waikato_cms_weka_weka_stable_3_8_1",
         "@regression_testing//:com_digitalasset_damlc_osx_100_12_1",
         "@regression_testing//:org_eclipse_jetty_orbit_javax_servlet_3_0_0_v201112011016",
+        "@regression_testing//:io_vavr_vavr_parent_0_10_0"
     ],
 )


### PR DESCRIPTION
I'm leaving the whitelist because some pom-only artifacts don't contain `:pom:` in the coordinates.

Fixes #119 