### PR TITLE
Fix passing credentials that are not URL-safe

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -702,7 +702,9 @@ def _coursier_fetch_impl(repository_ctx):
         repository_ctx.file("exclusion-file.txt", "\n".join(exclusion_lines), False)
         cmd.extend(["--local-exclude-file", "exclusion-file.txt"])
     for repository in repositories:
-        cmd.extend(["--repository", utils.repo_url(repository)])
+        cmd.extend(["--repository", repository["repo_url"]])
+        if "credentials" in repository:
+            cmd.extend(["--credentials", utils.repo_credentials(repository)])
     for a in excluded_artifacts:
         cmd.extend(["--exclude", ":".join([a["group"], a["artifact"]])])
     if not repository_ctx.attr.use_unsafe_shared_cache:

--- a/specs.bzl
+++ b/specs.bzl
@@ -251,14 +251,22 @@ def _artifact_to_coord(artifact):
     classifier = (",classifier=" + artifact["classifier"]) if artifact.get("classifier") != None else ""
     return artifact["group"] + ":" + artifact["artifact"] + ":" + artifact["version"] + classifier
 
-def _repository_url(repository_spec):
-    (protocol, remainder) = repository_spec["repo_url"].split("//")
+#
+# Returns a string "{hostname} {user}:{password}" for a repository_spec
+#
+def _repository_credentials(repository_spec):
+    if "credentials" not in repository_spec:
+        fail("Asked to generate credentials for a repository that does not need it")
 
-    credentials = repository_spec.get("credentials")
-    auth_string = (credentials["user"] + ":" + credentials["password"] + "@") if credentials != None else ""
-    return protocol + "//" + auth_string + remainder
+    (_, remainder) = repository_spec["repo_url"].split("//")
+    hostname = remainder.split("/")[0]
+
+    credentials = repository_spec["credentials"]
+
+    # See https://get-coursier.io/docs/other-credentials.html#inline for docs on this format
+    return hostname + " " + credentials["user"] + ":" + credentials["password"]
 
 utils = struct(
     artifact_coordinate = _artifact_to_coord,
-    repo_url = _repository_url,
+    repo_credentials = _repository_credentials,
 )

--- a/tests/unit/specs_test.bzl
+++ b/tests/unit/specs_test.bzl
@@ -225,22 +225,16 @@ def _artifact_to_json_test_impl(ctx):
 
 artifact_spec_to_json_test = unittest.make(_artifact_to_json_test_impl)
 
-def _repo_url_test_impl(ctx):
+def _repo_credentials_test_impl(ctx):
     repo_url = "https://maven.google.com/"
     env = unittest.begin(ctx)
     asserts.equals(
         env,
-        "https://maven.google.com/",
-        utils.repo_url({"repo_url": repo_url}),
-    )
-    asserts.equals(
-        env,
-        "https://bob:l0bl4w@maven.google.com/",
-        utils.repo_url({"repo_url": repo_url, "credentials": {"user": "bob", "password": "l0bl4w"}}),
+        "maven.google.com bob:l0bl4w",
+        utils.repo_credentials({ "repo_url": repo_url, "credentials": { "user": "bob", "password": "l0bl4w" } })
     )
     return unittest.end(env)
-
-repo_url_test = unittest.make(_repo_url_test_impl)
+repo_credentials_test = unittest.make(_repo_credentials_test_impl)
 
 def artifact_specs_test_suite():
     unittest.suite(
@@ -268,5 +262,5 @@ def artifact_specs_test_suite():
 
     unittest.suite(
         "util_tests",
-        repo_url_test,
+        repo_credentials_test,
     )


### PR DESCRIPTION
Passing the credentials as part of the repository URL is deprecated in coursier and has some unfortunate side-effects, such as the escaping of non-URL-safe usernames/password does not work correctly. (if you pass it in URL-escaped it does not work, if you pass it in plain it does not work either)

This PR does two things:

1. Use `--credentials` for `coursier` if the user passes in the credentials explicitly. If the user supplies an string for the repository URL it is passed-through as-is to coursier (which is also the current behavior). This means the having the basic-auth in the URL still works.
