### PR TITLE
Add support for Coursier checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    # Fail if a checksum file for the artifact is missing in the repository.
+    # Falls through "SHA-1" and "MD5". Defaults to True.
+    fail_on_missing_checksum = False,
     # Fetch srcjars. Defaults to False.
     fetch_sources = True,
 )

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -141,6 +141,7 @@ def generate_imports(repository_ctx, dep_tree, neverlink_artifacts = {}):
                         artifact_relative_path = _normalize_to_unix_path(artifact_path)
                     target_label = _escape(_strip_packaging_and_classifier(artifact["coord"]))
                     srcjar_paths[target_label] = artifact_relative_path
+
     # Iterate through the list of artifacts, and generate the target declaration strings.
     for artifact in dep_tree["dependencies"]:
         artifact_path = artifact["file"]
@@ -499,6 +500,12 @@ def _coursier_fetch_impl(repository_ctx):
     cmd.append("--quiet")
     cmd.append("--no-default")
     cmd.extend(["--json-output-file", "dep-tree.json"])
+
+    if repository_ctx.attr.fail_on_missing_checksum:
+        cmd.extend(["--checksum", "SHA-1,MD5"])
+    else:
+        cmd.extend(["--checksum", "SHA-1,MD5,None"])
+
     if len(exclusion_lines) > 0:
         repository_ctx.file("exclusion-file.txt", "\n".join(exclusion_lines), False)
         cmd.extend(["--local-exclude-file", "exclusion-file.txt"])
@@ -554,6 +561,7 @@ coursier_fetch = repository_rule(
         "_jvm_import": attr.label(default = "//:private/jvm_import.bzl"),
         "repositories": attr.string_list(),  # list of repository objects, each as json
         "artifacts": attr.string_list(),  # list of artifact objects, each as json
+        "fail_on_missing_checksum": attr.bool(default = True),
         "fetch_sources": attr.bool(default = False),
         "use_unsafe_shared_cache": attr.bool(default = False),
     },

--- a/defs.bzl
+++ b/defs.bzl
@@ -21,6 +21,7 @@ def maven_install(
         name = DEFAULT_REPOSITORY_NAME,
         repositories = [],
         artifacts = [],
+        fail_on_missing_checksum = True,
         fetch_sources = False,
         use_unsafe_shared_cache = False):
 
@@ -36,6 +37,7 @@ def maven_install(
         name = name,
         repositories = repositories_json_strings,
         artifacts = artifacts_json_strings,
+        fail_on_missing_checksum = fail_on_missing_checksum,
         fetch_sources = fetch_sources,
         use_unsafe_shared_cache = use_unsafe_shared_cache,
     )


### PR DESCRIPTION
This PR adds support for Coursier's `--checksum` flag.

While it's not SHA pinning or verified with the actual SHA of the downloaded artifact, it's still better than *nothing* which is the case today.

Also, if one uses HTTPS Maven repositories, in-transit tampering should be reasonably secure.