### PR TITLE
Allow passing in global package excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    # Exclude packages from being pulled in by automatic dependency resolution
+    excluded_artifacts = [
+        "com.google.guava:guava",
+    ],
 )
 ```
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -476,6 +476,10 @@ def _coursier_fetch_impl(repository_ctx):
     for a in repository_ctx.attr.artifacts:
         artifacts.append(json_parse(a))
 
+    excluded_artifacts = []
+    for a in repository_ctx.attr.excluded_artifacts:
+        excluded_artifacts.append(json_parse(a))
+
     artifact_coordinates = []
 
     # Set up artifact exclusion, if any. From coursier fetch --help:
@@ -511,6 +515,8 @@ def _coursier_fetch_impl(repository_ctx):
         cmd.extend(["--local-exclude-file", "exclusion-file.txt"])
     for repository in repositories:
         cmd.extend(["--repository", utils.repo_url(repository)])
+    for a in excluded_artifacts:
+        cmd.extend(["--exclude", ":".join([a["group"], a["artifact"]])])
     if not repository_ctx.attr.use_unsafe_shared_cache:
         cmd.extend(["--cache", "v1"])  # Download into $output_base/external/$maven_repo_name/v1
     if repository_ctx.attr.fetch_sources:
@@ -564,6 +570,7 @@ coursier_fetch = repository_rule(
         "fail_on_missing_checksum": attr.bool(default = True),
         "fetch_sources": attr.bool(default = False),
         "use_unsafe_shared_cache": attr.bool(default = False),
+        "excluded_artifacts": attr.string_list(default = []),  # list of artifacts to exclude
     },
     environ = [
         "JAVA_HOME",

--- a/defs.bzl
+++ b/defs.bzl
@@ -23,7 +23,8 @@ def maven_install(
         artifacts = [],
         fail_on_missing_checksum = True,
         fetch_sources = False,
-        use_unsafe_shared_cache = False):
+        use_unsafe_shared_cache = False,
+        excluded_artifacts = []):
 
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -33,6 +34,10 @@ def maven_install(
     for artifact in parse.parse_artifact_spec_list(artifacts):
         artifacts_json_strings.append(json.write_artifact_spec(artifact))
 
+    excluded_artifacts_json_strings = []
+    for exclusion in parse.parse_exclusion_spec_list(excluded_artifacts):
+        excluded_artifacts_json_strings.append(json.write_exclusion_spec(exclusion))
+
     coursier_fetch(
         name = name,
         repositories = repositories_json_strings,
@@ -40,6 +45,7 @@ def maven_install(
         fail_on_missing_checksum = fail_on_missing_checksum,
         fetch_sources = fetch_sources,
         use_unsafe_shared_cache = use_unsafe_shared_cache,
+        excluded_artifacts = excluded_artifacts_json_strings,
     )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):


### PR DESCRIPTION
Coursier allows users to pass in global package excludes (along-side artifact specific excludes) using the `--exclude` parameter.

This extends the `maven_install` rule to enable users to pass in exclude specs that apply globally.

```
maven_install(
    ....
    excluded_artifacts = [
        "com.google.guava:guava"
    ],
)
```

This is useful for porting over large code-bases that still mix pulling in explicit versions of packages and using `maven_install` for automatic package resolution.

Fixes #110