### PR TITLE
Use versionless jvm_import name

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -275,8 +275,8 @@ def generate_imports(repository_ctx, dep_tree, neverlink_artifacts = {}):
             #   name = "org_hamcrest_hamcrest_library_1_3",
             #   actual = "org_hamcrest_hamcrest_library",
             # )
-            versionless_target_alias_label = _escape(_strip_packaging_and_classifier(artifact["coord"]))
-            all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
+            versioned_target_alias_label = _escape(_strip_packaging_and_classifier(artifact["coord"]))
+            all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versioned_target_alias_label, target_label))
 
         elif artifact_path == None and POM_ONLY_ARTIFACTS.get(_strip_packaging_and_classifier_and_version(artifact["coord"])):
             # Special case for certain artifacts that only come with a POM file. Such artifacts "aggregate" their dependencies,
@@ -288,7 +288,7 @@ def generate_imports(repository_ctx, dep_tree, neverlink_artifacts = {}):
 
             target_import_labels = []
             for dep in artifact["dependencies"]:
-                dep_target_label = _escape(_strip_packaging_and_classifier(dep))
+                dep_target_label = _escape(_strip_packaging_and_classifier_and_version(dep))
                 target_import_labels.append("\t\t\":%s\",\n" % dep_target_label)
             target_import_labels = _deduplicate_list(target_import_labels)
 
@@ -298,8 +298,8 @@ def generate_imports(repository_ctx, dep_tree, neverlink_artifacts = {}):
 
             all_imports.append("\n".join(target_import_string))
 
-            versionless_target_alias_label = _escape(_strip_packaging_and_classifier_and_version(artifact["coord"]))
-            all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
+            versioned_target_alias_label = _escape(_strip_packaging_and_classifier(artifact["coord"]))
+            all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versioned_target_alias_label, target_label))
 
         elif artifact_path == None:
             # Possible reasons that the artifact_path is None:

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -5,7 +5,7 @@ java_test(
     srcs = ["ArtifactExclusionsTest.java"],
     test_class = "com.jvm.external.ArtifactExclusionsTest",
     deps = [
-        "@exclusion_testing//:com_google_guava_guava_27_0_jre",
+        "@exclusion_testing//:com_google_guava_guava",
         "@maven//:org_hamcrest_hamcrest_core",
         "@maven//:org_hamcrest_hamcrest",
     ],
@@ -28,7 +28,7 @@ java_test(
     srcs = ["UnsafeSharedCacheTest.java"],
     test_class = "com.jvm.external.UnsafeSharedCacheTest",
     deps = [
-        "@unsafe_shared_cache//:com_google_guava_guava_27_0_jre",
+        "@unsafe_shared_cache//:com_google_guava_guava",
         "@maven//:org_hamcrest_hamcrest_core",
         "@maven//:org_hamcrest_hamcrest",
     ],

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -6,11 +6,11 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 build_test(
     name = "all_artifacts",
     targets = [
-        "@regression_testing//:org_pantsbuild_jarjar_1_6_6",
-        "@regression_testing//:com_github_fommil_netlib_all_1_1_2",
-        "@regression_testing//:nz_ac_waikato_cms_weka_weka_stable_3_8_1",
-        "@regression_testing//:com_digitalasset_damlc_osx_100_12_1",
-        "@regression_testing//:org_eclipse_jetty_orbit_javax_servlet_3_0_0_v201112011016",
-        "@regression_testing//:org_apache_flink_flink_test_utils_2_12_1_8_0",
+        "@regression_testing//:org_pantsbuild_jarjar",
+        "@regression_testing//:com_github_fommil_netlib_all",
+        "@regression_testing//:nz_ac_waikato_cms_weka_weka_stable",
+        "@regression_testing//:com_digitalasset_damlc_osx",
+        "@regression_testing//:org_eclipse_jetty_orbit_javax_servlet",
+        "@regression_testing//:org_apache_flink_flink_test_utils_2_12",
     ],
 )


### PR DESCRIPTION
Attempt to use versionless name in `jvm_import` and use versioned name in `alias`. 

Fix: #136 