### PR TITLE
fix crashing when http_proxy is set but empty

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -405,14 +405,14 @@ def _get_java_proxy_args(repository_ctx):
 
     # Extract the host and port from a standard proxy URL:
     # http://proxy.example.com:3128 -> ["proxy.example.com", "3128"]
-    if http_proxy != None:
+    if http_proxy:
         proxy = http_proxy.split("://", 1)[1].split(":", 1)
         proxy_args.extend([
             "-Dhttp.proxyHost=%s" % proxy[0],
             "-Dhttp.proxyPort=%s" % proxy[1],
         ])
 
-    if https_proxy != None:
+    if https_proxy:
         proxy = https_proxy.split("://", 1)[1].split(":", 1)
         proxy_args.extend([
             "-Dhttps.proxyHost=%s" % proxy[0],


### PR DESCRIPTION
Here I faced an ERROR when using rules_jvm_external with $http_proxy set but is empty, and this pull request fix it.

```
ERROR: Analysis of target '//java:org_ray_ray_test_pom' failed; build aborted: no such package '@maven//': Traceback (most recent call last):
	File "/private/var/tmp/_bazel_d-star/3d549a4d78f384e911df15e31f784ebc/external/rules_jvm_external/coursier.bzl", line 438
		repository_ctx.execute(_generate_coursier_command(repos...))
	File "/private/var/tmp/_bazel_d-star/3d549a4d78f384e911df15e31f784ebc/external/rules_jvm_external/coursier.bzl", line 438, in repository_ctx.execute
		_generate_coursier_command(repository_ctx)
	File "/private/var/tmp/_bazel_d-star/3d549a4d78f384e911df15e31f784ebc/external/rules_jvm_external/coursier.bzl", line 371, in _generate_coursier_command
		_get_java_proxy_args(repository_ctx)
	File "/private/var/tmp/_bazel_d-star/3d549a4d78f384e911df15e31f784ebc/external/rules_jvm_external/coursier.bzl", line 394, in _get_java_proxy_args
		http_proxy.split("://", 1)[1]
```

I just change `if proxy != None` to `if proxy` , then empty string will also return false.