### PR TITLE
Add tests for maven_install.excluded_artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ maven_install(
 You can specify the exclusion using either the `maven.exclusion` helper or the
 `group-id:artifact-id` string directly.
 
-You can also exclude artifacts globally using the `excluded_artifacts` attribute in `maven_install`:
+You can also exclude artifacts globally using the `excluded_artifacts`
+attribute in `maven_install`:
 
 
 ```python
@@ -333,7 +334,6 @@ maven_install(
     repositories = [
         # ...
     ],
-    # Exclude packages from being pulled in by automatic dependency resolution
     excluded_artifacts = [
         "com.google.guava:guava",
     ],

--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
-    # Exclude packages from being pulled in by automatic dependency resolution
-    excluded_artifacts = [
-        "com.google.guava:guava",
-    ],
 )
 ```
 
@@ -325,6 +321,24 @@ maven_install(
 
 You can specify the exclusion using either the `maven.exclusion` helper or the
 `group-id:artifact-id` string directly.
+
+You can also exclude artifacts globally using the `excluded_artifacts` attribute in `maven_install`:
+
+
+```python
+maven_install(
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    # Exclude packages from being pulled in by automatic dependency resolution
+    excluded_artifacts = [
+        "com.google.guava:guava",
+    ],
+)
+```
 
 ### Compile-only dependencies
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,7 +55,11 @@ maven_install(
 
 maven_install(
     name = "global_exclusion_testing",
-    artifacts = ["com.google.guava:guava:27.0-jre"],
+    artifacts = [
+        "com.google.guava:guava:27.0-jre", # depends on animal-sniffer-annotations and j2objc-annotations
+        "com.squareup.okhttp3:okhttp:3.14.1", # depends on animal-sniffer-annotations
+        "com.diffplug.durian:durian-core:1.2.0", # depends on animal-sniffer-annotations and j2objc-annotations
+    ],
     excluded_artifacts = [
         maven.exclusion(group = "org.codehaus.mojo", artifact = "animal-sniffer-annotations"),
         "com.google.j2objc:j2objc-annotations",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,6 +53,18 @@ maven_install(
     ],
 )
 
+maven_install(
+    name = "global_exclusion_testing",
+    artifacts = ["com.google.guava:guava:27.0-jre"],
+    excluded_artifacts = [
+        maven.exclusion(group = "org.codehaus.mojo", artifact = "animal-sniffer-annotations"),
+        "com.google.j2objc:j2objc-annotations",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+
 # These artifacts helped discover limitations by the Maven resolver. Each
 # artifact listed here *must have* an accompanying issue. We build_test these
 # targets to ensure that they remain supported by the rule.

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -12,6 +12,17 @@ java_test(
 )
 
 java_test(
+    name = "GlobalArtifactExclusionsTest",
+    srcs = ["GlobalArtifactExclusionsTest.java"],
+    test_class = "com.jvm.external.GlobalArtifactExclusionsTest",
+    deps = [
+        "@global_exclusion_testing//:com_google_guava_guava",
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)
+
+java_test(
     name = "NeverlinkTest",
     srcs = ["NeverlinkTest.java"],
     test_class = "com.jvm.external.NeverlinkTest",

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -17,6 +17,8 @@ java_test(
     test_class = "com.jvm.external.GlobalArtifactExclusionsTest",
     deps = [
         "@global_exclusion_testing//:com_google_guava_guava",
+        "@global_exclusion_testing//:com_squareup_okhttp3_okhttp",
+        "@global_exclusion_testing//:com_diffplug_durian_durian_core",
         "@maven//:org_hamcrest_hamcrest_core",
         "@maven//:org_hamcrest_hamcrest",
     ],

--- a/tests/integration/GlobalArtifactExclusionsTest.java
+++ b/tests/integration/GlobalArtifactExclusionsTest.java
@@ -1,12 +1,9 @@
 package com.jvm.external;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import java.io.IOException;
 import org.junit.Test;
-import java.net.URL;
-import java.net.URLClassLoader;
 import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringContains.containsString;

--- a/tests/integration/GlobalArtifactExclusionsTest.java
+++ b/tests/integration/GlobalArtifactExclusionsTest.java
@@ -1,0 +1,22 @@
+package com.jvm.external;
+
+
+import org.junit.Test;
+import java.net.URL;
+import java.net.URLClassLoader;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.StringContains.containsString;
+
+public class GlobalArtifactExclusionsTest {
+
+  @Test
+  public void test_globallyExcludedArtifacts_notOnClassPath() {
+    ClassLoader cl = ClassLoader.getSystemClassLoader();
+    for (URL url : ((URLClassLoader) cl).getURLs()){
+      assertThat(url.getFile().toString(), not(containsString("org/codehaus/mojo/animal-sniffer-annotations")));
+      assertThat(url.getFile().toString(), not(containsString("com/google/j2objc/j2objc-annotations")));
+    }
+  }
+
+}

--- a/tests/integration/GlobalArtifactExclusionsTest.java
+++ b/tests/integration/GlobalArtifactExclusionsTest.java
@@ -1,6 +1,9 @@
 package com.jvm.external;
 
-
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+import java.io.IOException;
 import org.junit.Test;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -11,11 +14,13 @@ import static org.hamcrest.core.StringContains.containsString;
 public class GlobalArtifactExclusionsTest {
 
   @Test
-  public void test_globallyExcludedArtifacts_notOnClassPath() {
-    ClassLoader cl = ClassLoader.getSystemClassLoader();
-    for (URL url : ((URLClassLoader) cl).getURLs()){
-      assertThat(url.getFile().toString(), not(containsString("org/codehaus/mojo/animal-sniffer-annotations")));
-      assertThat(url.getFile().toString(), not(containsString("com/google/j2objc/j2objc-annotations")));
+  public void test_globallyExcludedArtifacts_notOnClassPah() throws IOException {
+    ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+    ClassPath classPath = ClassPath.from(classLoader);
+    ImmutableSet<ClassInfo> set = classPath.getTopLevelClasses();
+    for (ClassInfo ci : set) {
+      assertThat(ci.getName(), not(containsString("org.codehaus.mojo.animal_sniffer")));
+      assertThat(ci.getName(), not(containsString("com.google.j2objc.annotations")));
     }
   }
 

--- a/tests/integration/GlobalArtifactExclusionsTest.java
+++ b/tests/integration/GlobalArtifactExclusionsTest.java
@@ -15,10 +15,8 @@ public class GlobalArtifactExclusionsTest {
 
   @Test
   public void test_globallyExcludedArtifacts_notOnClassPah() throws IOException {
-    ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-    ClassPath classPath = ClassPath.from(classLoader);
-    ImmutableSet<ClassInfo> set = classPath.getTopLevelClasses();
-    for (ClassInfo ci : set) {
+    ClassPath classPath = ClassPath.from(ClassLoader.getSystemClassLoader());
+    for (ClassInfo ci : classPath.getTopLevelClasses()) {
       assertThat(ci.getName(), not(containsString("org.codehaus.mojo.animal_sniffer")));
       assertThat(ci.getName(), not(containsString("com.google.j2objc.annotations")));
     }

--- a/tests/integration/GlobalArtifactExclusionsTest.java
+++ b/tests/integration/GlobalArtifactExclusionsTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.core.StringContains.containsString;
 public class GlobalArtifactExclusionsTest {
 
   @Test
-  public void test_globallyExcludedArtifacts_notOnClassPah() throws IOException {
+  public void test_globallyExcludedArtifacts_notOnClassPath() throws IOException {
     ClassPath classPath = ClassPath.from(ClassLoader.getSystemClassLoader());
     for (ClassInfo ci : classPath.getTopLevelClasses()) {
       assertThat(ci.getName(), not(containsString("org.codehaus.mojo.animal_sniffer")));


### PR DESCRIPTION
This PR adds an JDK-11 compatible integration test for globally excluded artifacts using `maven_install.excluded_artifacts`.