### PR TITLE
Add an environment variable, COURSIER_CACHE, to set the location of the unsafe shared cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ This is **not safe** as Bazel is currently not able to detect changes in the
 shared cache. For example, if an artifact is deleted from the shared cache,
 Bazel will not re-run the repository rule automatically.
 
+To change the location to another directory, set the environment variable
+`COURSIER_CACHE=/absolute/path/to/directory`.
+
 The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
 will create independent caches for each `maven_install` repository, located at
 `$(bazel info output_base)/external/@repository_name/v1`.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,7 +84,6 @@ maven_install(
         "https://digitalassetsdk.bintray.com/DigitalAssetSDK",
         "https://maven.google.com",
     ],
-    use_unsafe_shared_cache = True,
 )
 
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,7 @@ maven_install(
         "https://digitalassetsdk.bintray.com/DigitalAssetSDK",
         "https://maven.google.com",
     ],
+    use_unsafe_shared_cache = True,
 )
 
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"


### PR DESCRIPTION
This is really a convenience thing: sometimes users don't want to use ~/.cache/coursier (for Linux), but the path to the shared cache should not be a WORKSPACE-level configuration. The paths tend to differ between users and environment, so we use an environment variable instead.

The path needs to be absolute because Bazel parses relative paths rooted at output_base/external/@repo, and we don't want users to be able to change the structure of that directory.