### PR TITLE
Bump dependency on android/android-test to address Bazel incompatible changes

### DIFF
--- a/examples/android_instrumentation_test/WORKSPACE
+++ b/examples/android_instrumentation_test/WORKSPACE
@@ -31,11 +31,11 @@ maven_install(
 # Everything below this line is used for the Android testing tools and their dependencies
 # ---------------------------------------------------------------------------------------
 
-ATS_TAG = "66e4740af2b27dedf30a145fc60653bf19586424"
+ATS_TAG = "2e990782519786bca2f8bf23b2c5933f0d69da8d"
 
 http_archive(
     name = "android_test_support",
-    sha256 = "8696f228aa4b9ce9c0b77de764909e638b509aa25d5b6bf16bb45963f6591506",
+    sha256 = "de74535cc212a5d9f3e2d24d9a6cf9e1a3734e834563458ad6dd5474dd6aa9c7",
     strip_prefix = "android-test-%s" % ATS_TAG,
     urls = ["https://github.com/android/android-test/archive/%s.tar.gz" % ATS_TAG],
 )


### PR DESCRIPTION
```
$ bazel test --nobuild -k //... --incompatible_new_actions_api  --incompatible_no_transitive_loads  --incompatible_depset_is_not_iterable --incompatible_disable_deprecated_attr_params
INFO: Analyzed 6 targets (12 packages loaded, 870 targets configured).
INFO: Found 5 targets and 1 test target...
INFO: Elapsed time: 2.158s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
INFO: Build completed successfully, 0 total actions
```

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/148

fyi @laurentlb 