### PR TITLE
Fix incompatible change with python toolchains

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -23,6 +23,8 @@ tasks:
     platform: ubuntu1804
     working_directory: examples/android_instrumentation_test
     test_flags:
+      # Compatibility with --incompatible_use_python_toolchains
+      # https://github.com/bazelbuild/bazel/issues/7899
       - "--host_force_python=PY2"
     test_targets:
       - "//src/test:greeter_test"

--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -22,6 +22,8 @@ tasks:
     name: "Android instrumentation test example"
     platform: ubuntu1804
     working_directory: examples/android_instrumentation_test
+    test_flags:
+      - "--host_force_python=PY2"
     test_targets:
       - "//src/test:greeter_test"
   android-instrumentation-test-macos:


### PR DESCRIPTION
Passes with `$ bazel test //... --host_force_python=PY2 --incompatible_use_python_toolchains`

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/157