### PR TITLE
Add generate_compat_repositories attribute to maven_install for top level repository aliases and cross-workspace dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,33 @@ As with other Bazel repository rules, the standard `http_proxy`, `https_proxy`
 and `no_proxy` environment variables (and their uppercase counterparts) are
 supported.
 
+### Repository aliases
+
+Maven artifact rules like `maven_jar` and `jvm_import_external` generate targets
+labels in the form of `@group_artifact//jar`, like `@com_google_guava_guava//jar`. This 
+is different from the `@maven//:group_artifact` naming style used in this project.
+
+As some Bazel projects depend on the `@group_artifact//jar` style labels, we
+provide a `generate_compat_repositories` attribute in `maven_install`. If
+enabled, JAR artifacts can also be referenced using the `@group_artifact//jar`
+target label. For example, `@maven//:com_google_guava_guava` can also be
+referenced using `@com_google_guava_guava//jar`.
+
+```python
+maven_install(
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    generate_compat_repositories = True
+)
+
+load("@maven//:compat.bzl", "compat_repositories")
+compat_repositories()
+```
+
 ## Demo
 
 You can find demos in the [`examples/`](./examples/) directory.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,7 +107,11 @@ maven_install(
         "https://digitalassetsdk.bintray.com/DigitalAssetSDK",
         "https://maven.google.com",
     ],
+    generate_compat_repositories = True,
 )
+
+load("@regression_testing//:compat.bzl", "compat_repositories")
+compat_repositories()
 
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -584,7 +584,7 @@ def _coursier_fetch_impl(repository_ctx):
             compat_repositories_bzl.append("    )")
 
         repository_ctx.file(
-            "repositories.bzl",
+            "compat.bzl",
             "\n".join(compat_repositories_bzl),
             False,  # not executable
         )

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -572,12 +572,16 @@ def _coursier_fetch_impl(repository_ctx):
     if repository_ctx.attr.generate_compat_repositories:
         compat_repositories_bzl = ["def compat_repositories():"]
         for versionless_target_label in jar_imports:
-            repository_ctx.file(versionless_target_label + "/WORKSPACE",
-                                "",
-                                executable = False)
-            repository_ctx.file(versionless_target_label + "/jar/BUILD",
-                                "alias(name = \"jar\", actual = \"@maven//:%s\")" % versionless_target_label,
-                                executable = False)
+            repository_ctx.file(
+                versionless_target_label + "/WORKSPACE",
+                "",
+                executable = False,
+            )
+            repository_ctx.file(
+                versionless_target_label + "/jar/BUILD",
+                "alias(name = \"jar\", actual = \"@maven//:%s\", visibility = [\"//visibility:public\"])" % versionless_target_label,
+                executable = False,
+            )
             compat_repositories_bzl.append("    native.local_repository(")
             compat_repositories_bzl.append("        name = \"%s\"," % versionless_target_label)
             compat_repositories_bzl.append("        path = \"%s\"," % repository_ctx.path(versionless_target_label))

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -580,9 +580,12 @@ def _coursier_fetch_impl(repository_ctx):
         compat_repositories_bzl = ["load(\"@%s//:compat_repository.bzl\", \"compat_repository\")" % repository_ctx.name]
         compat_repositories_bzl.append("def compat_repositories():")
         for versionless_target_label in jar_versionless_target_labels:
-            compat_repositories_bzl.append(
-                "    compat_repository(name = \"" + versionless_target_label + "\")"
-            )
+            compat_repositories_bzl.extend([
+                "    compat_repository(",
+                "        name = \"%s\"," % versionless_target_label,
+                "        generating_repository = \"%s\"," % repository_ctx.name,
+                "    )",
+            ])
         repository_ctx.file(
             "compat.bzl",
             "\n".join(compat_repositories_bzl) + "\n",

--- a/defs.bzl
+++ b/defs.bzl
@@ -24,7 +24,8 @@ def maven_install(
         fail_on_missing_checksum = True,
         fetch_sources = False,
         use_unsafe_shared_cache = False,
-        excluded_artifacts = []):
+        excluded_artifacts = [],
+        generate_compat_repositories = False):
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
         repositories_json_strings.append(json.write_repository_spec(repository))
@@ -45,6 +46,7 @@ def maven_install(
         fetch_sources = fetch_sources,
         use_unsafe_shared_cache = use_unsafe_shared_cache,
         excluded_artifacts = excluded_artifacts_json_strings,
+        generate_compat_repositories = generate_compat_repositories,
     )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -3,11 +3,11 @@ load("@rules_jvm_external//:defs.bzl", "artifact")
 android_library(
     name = "my_lib",
     exports = [
-        artifact("android.arch.lifecycle:common"),
-        artifact("android.arch.lifecycle:viewmodel"),
-        artifact("androidx.test.espresso:espresso-web"),
-        artifact("junit:junit"),
-        artifact("com.android.support:design"),
+        "@maven//:android_arch_lifecycle_common",
+        "@maven//:android_arch_lifecycle_viewmodel",
+        "@maven//:androidx_test_espresso_espresso_web",
+        "@junit_junit//jar", # alias to @maven//:junit_junit
+        "@maven//:com_android_support_design",
     ],
 )
 

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -22,5 +22,5 @@ maven_install(
     generate_compat_repositories = True,
 )
 
-load("@maven//:repositories.bzl", "compat_repositories")
+load("@maven//:compat.bzl", "compat_repositories")
 compat_repositories()

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -19,4 +19,8 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    generate_compat_repositories = True,
 )
+
+load("@maven//:repositories.bzl", "compat_repositories")
+compat_repositories()

--- a/private/compat_repository.bzl
+++ b/private/compat_repository.bzl
@@ -1,0 +1,18 @@
+_BUILD = """
+alias(
+    name = "jar",
+    actual = "@maven//:%s",
+    visibility = ["//visibility:public"]
+)
+"""
+
+def _compat_repository_impl(repository_ctx):
+    repository_ctx.file(
+        "jar/BUILD",
+        _BUILD % repository_ctx.name,
+        executable = False,
+    )
+
+compat_repository = repository_rule(
+    implementation = _compat_repository_impl
+)

--- a/private/compat_repository.bzl
+++ b/private/compat_repository.bzl
@@ -1,7 +1,7 @@
 _BUILD = """
 alias(
     name = "jar",
-    actual = "@maven//:%s",
+    actual = "@{generating_repository}//:{target_name}",
     visibility = ["//visibility:public"]
 )
 """
@@ -9,10 +9,16 @@ alias(
 def _compat_repository_impl(repository_ctx):
     repository_ctx.file(
         "jar/BUILD",
-        _BUILD % repository_ctx.name,
+        _BUILD.format(
+            generating_repository = repository_ctx.attr.generating_repository,
+            target_name = repository_ctx.name,
+        ),
         executable = False,
     )
 
 compat_repository = repository_rule(
-    implementation = _compat_repository_impl
+    implementation = _compat_repository_impl,
+    attrs = {
+        "generating_repository": attr.string(default = "maven"),
+    }
 )

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -14,3 +14,13 @@ build_test(
         "@regression_testing//:org_apache_flink_flink_test_utils_2_12",
     ],
 )
+
+build_test(
+    name = "compat_repository_alias",
+    targets = [
+        "@org_pantsbuild_jarjar//jar",
+        "@nz_ac_waikato_cms_weka_weka_stable//jar",
+        "@com_digitalasset_damlc_osx//jar",
+        "@org_apache_flink_flink_test_utils_2_12//jar",
+    ],
+)


### PR DESCRIPTION
This PR adds a new attribute, `generate_compat_repositories`, to `maven_install`. The default is `False`. The motivation for this change is https://github.com/bazelbuild/rules_jvm_external/issues/85. (Fixes #85)

With this, we can refer to `@maven//:junit_junit` as `@junit_junit//jar`, where the latter is the most commonly used naming convention that is popularized by rules like `maven_jar` and `java_import_external`. This enables project maintainers to incrementall migrate from `maven_jar` to `rules_jvm_external` without a single change in their BUILD files. It also allows cross-external repository sharing of artifacts.

If enabled, `maven_install` generates an additional `compat.bzl` file in the `@maven` (or your custom) external repository. This file exposes one symbol, `compat_repositories`, to be loaded after `maven_install`, like this:

```python
maven_install(
    # ...
    generate_compat_repositories = True,
)

load("@maven//:compat.bzl", "compat_repositories")
compat_repositories()
```

`compat_repositories` expands into a list of `compat_repository` declarations, one for each `JAR` artifact in the transitive closure of the resolved dependency tree. For example:

```
$ cat compat.bzl 
load("@maven//:compat_repository.bzl", "compat_repository")
def compat_repositories():
    compat_repository(name = "android_arch_core_common")
    compat_repository(name = "android_arch_lifecycle_common")
    compat_repository(name = "androidx_annotation_annotation")
    compat_repository(name = "com_android_support_support_annotations")
    compat_repository(name = "com_google_code_findbugs_jsr305")
    compat_repository(name = "com_squareup_javawriter")
    compat_repository(name = "javax_inject_javax_inject")
    compat_repository(name = "junit_junit")
    compat_repository(name = "net_sf_kxml_kxml2")
    compat_repository(name = "org_ccil_cowan_tagsoup_tagsoup")
    compat_repository(name = "org_hamcrest_hamcrest_core")
    compat_repository(name = "org_hamcrest_hamcrest_integration")
    compat_repository(name = "org_hamcrest_hamcrest_library")
```

Each `compat_repository` creates a new external repository in `output_base/external`. In the case of junit, the directory is `output_base/external/junit_junit`, and the contents are as follows:

```
jingwen@jingwen:~/.cache/bazel/_bazel_jingwen/f1b46d82f4f66241b4c332b551d2226c/external/junit_junit
$ tree
.
├── jar
│   └── BUILD
└── WORKSPACE
```

The `WORKSPACE` is an empty file. The `BUILD` file contains an alias to the `@maven//:junit_junit` target:

```
$ cat jar/BUILD 
alias(name = "jar", actual = "@maven//:junit_junit")
```

Using this, we can refer to the target as `@junit_junit//jar:jar`, or `@junit_junit//jar` for short.


TODO 

- [x] Tests
- [x] Documentation