### PR TITLE
Allow in-source cache directory to store artifacts and check them in

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ This is **not safe** as Bazel is currently not able to detect changes in the
 shared cache. For example, if an artifact is deleted from the shared cache,
 Bazel will not re-run the repository rule automatically.
 
+To change the location to another directory, set the environment variable
+`COURSIER_CACHE=/absolute/path/to/directory`.
+
 The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
 will create independent caches for each `maven_install` repository, located at
 `$(bazel info output_base)/external/@repository_name/v1`.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,7 +84,6 @@ maven_install(
         "https://digitalassetsdk.bintray.com/DigitalAssetSDK",
         "https://maven.google.com",
     ],
-    use_unsafe_shared_cache = True,
 )
 
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,7 @@ maven_install(
         "https://digitalassetsdk.bintray.com/DigitalAssetSDK",
         "https://maven.google.com",
     ],
+    use_unsafe_shared_cache = True,
 )
 
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"

--- a/examples/simple/.bazelrc
+++ b/examples/simple/.bazelrc
@@ -1,0 +1,1 @@
+common --experimental_allow_incremental_repository_updates

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -1,3 +1,10 @@
+workspace(
+    name = "simple",
+    managed_directories = {
+        "@maven": [ "third_party" ]
+    },
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 android_sdk_repository(name = "androidsdk")
@@ -21,4 +28,5 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    use_unsafe_shared_cache = True,
 )


### PR DESCRIPTION
`COURSIER_CACHE=$(pwd)/third_party/v1 bazel build //...`