### PR TITLE
Fix error in maven_install.json filename generation

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -763,7 +763,10 @@ def _coursier_fetch_impl(repository_ctx):
     repository_ctx.template("pin", repository_ctx.attr._pin,
         {
             "{dependency_tree_json}": dependency_tree_json,
-            "{repository_name}": repository_ctx.name.lstrip("unpinned_"),
+            "{repository_name}": \
+                repository_ctx.name[len("unpinned_"):] \
+                if repository_ctx.name.startswith("unpinned_") \
+                else repository_ctx.name,
         },
         executable = True,
     )


### PR DESCRIPTION
This was caused by an incorrect use of `lstrip("unpinned_")`. 

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/182