### PR TITLE
Implement version_conflict_policy to pin user's artifact versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -167,7 +167,7 @@ maven_install(
     maven_install_json = "//:policy_pinned_testing_install.json",
 )
 
-load("@policy_pinned_testing//:defs.bzl", _policy_pinned_maven_install="pinned_maven_install")
+load("@policy_pinned_testing//:defs.bzl", _policy_pinned_maven_install = "pinned_maven_install")
 _policy_pinned_maven_install()
 
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,6 +152,24 @@ pinned_maven_install()
 load("@regression_testing//:compat.bzl", "compat_repositories")
 compat_repositories()
 
+maven_install(
+    name = "policy_pinned_testing",
+    artifacts = [
+        # https://github.com/bazelbuild/rules_jvm_external/issues/107
+        "com.google.cloud:google-cloud-storage:1.66.0",
+        "com.google.guava:guava:25.0-android",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+    version_conflict_policy = "pinned",
+    maven_install_json = "//:policy_pinned_testing_install.json",
+)
+
+load("@policy_pinned_testing//:defs.bzl", _policy_pinned_maven_install="pinned_maven_install")
+_policy_pinned_maven_install()
+
 RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"
 
 http_archive(

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -640,7 +640,7 @@ def _coursier_fetch_impl(repository_ctx):
     cmd.extend(artifact_coordinates)
     if repository_ctx.attr.version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
-            cmd.extend(["-V", coord])
+            cmd.extend(["--force-version", coord])
     cmd.extend(["--artifact-type", ",".join(_COURSIER_PACKAGING_TYPES + ["src"])])
     cmd.append("--quiet")
     cmd.append("--no-default")
@@ -819,7 +819,7 @@ coursier_fetch = repository_rule(
         "version_conflict_policy": attr.string(
             doc = """Policy for user-defined vs. transitive dependency version conflicts
 
-            If "pinned", choose the user's version unconditionally.
+            If "pinned", choose the user-specified version in maven_install unconditionally.
             If "default", follow Coursier's default policy.
             """,
             default = "default",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -638,6 +638,9 @@ def _coursier_fetch_impl(repository_ctx):
     cmd = _generate_coursier_command(repository_ctx)
     cmd.extend(["fetch"])
     cmd.extend(artifact_coordinates)
+    if repository_ctx.attr.version_conflict_policy == "pinned":
+        for coord in artifact_coordinates:
+            cmd.extend(["-V", coord])
     cmd.extend(["--artifact-type", ",".join(_COURSIER_PACKAGING_TYPES + ["src"])])
     cmd.append("--quiet")
     cmd.append("--no-default")
@@ -813,6 +816,15 @@ coursier_fetch = repository_rule(
         "use_unsafe_shared_cache": attr.bool(default = False),
         "excluded_artifacts": attr.string_list(default = []),  # list of artifacts to exclude
         "generate_compat_repositories": attr.bool(default = False),  # generate a compatible layer with repositories for each artifact
+        "version_conflict_policy": attr.string(
+            doc = """Policy for user-defined vs. transitive dependency version conflicts
+
+            If "pinned", choose the user's version unconditionally.
+            If "default", follow Coursier's default policy.
+            """,
+            default = "default",
+            values = ["default", "pinned"],
+        ),
         "maven_install_json": attr.label(allow_single_file = True),
     },
     environ = [

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -640,7 +640,8 @@ def _coursier_fetch_impl(repository_ctx):
     cmd.extend(artifact_coordinates)
     if repository_ctx.attr.version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
-            cmd.extend(["--force-version", coord])
+            # Undo any `,classifier=` suffix from `utils.artifact_coordinate`.
+            cmd.extend(["--force-version", coord.split(",classifier=")[0]])
     cmd.extend(["--artifact-type", ",".join(_COURSIER_PACKAGING_TYPES + ["src"])])
     cmd.append("--quiet")
     cmd.append("--no-default")

--- a/defs.bzl
+++ b/defs.bzl
@@ -26,6 +26,7 @@ def maven_install(
         use_unsafe_shared_cache = False,
         excluded_artifacts = [],
         generate_compat_repositories = False,
+        version_conflict_policy = "default",
         maven_install_json = None):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
@@ -46,6 +47,9 @@ def maven_install(
       generate_compat_repositories: Additionally generate repository aliases in a .bzl file for all JAR
         artifacts. For example, `@maven//:com_google_guava_guava` can also be referenced as
         `@com_google_guava_guava//jar`.
+      version_conflict_policy: Policy for user-defined vs. transitive dependency version
+        conflicts.  If "pinned", choose the user's version unconditionally.  If "default", follow
+        Coursier's default policy.
       maven_install_json: A label to a `maven_install.json` file to use pinned artifacts for generating
         build targets. e.g `//:maven_install.json`.
     """
@@ -85,6 +89,7 @@ def maven_install(
         use_unsafe_shared_cache = use_unsafe_shared_cache,
         excluded_artifacts = excluded_artifacts_json_strings,
         generate_compat_repositories = generate_compat_repositories,
+        version_conflict_policy = version_conflict_policy,
     )
 
     if maven_install_json != None:

--- a/policy_pinned_testing_install.json
+++ b/policy_pinned_testing_install.json
@@ -1,0 +1,536 @@
+{
+    "dependency_tree": {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar",
+                "sha256": "fab8746aedd6427788ee390ea04d438ec141bff7eb3476f8bdd5d9110fb2718a",
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar"
+            },
+            {
+                "coord": "com.google.api-client:google-api-client:1.27.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.oauth-client:google-oauth-client:1.27.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api-client/google-api-client/1.27.0/google-api-client-1.27.0.jar",
+                "sha256": "fd1f06bc8cea64cd6e85e7a29dd632ba05c4e4ec2daae9a7115b6dbc9004fcd9",
+                "url": "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/1.27.0/google-api-client-1.27.0.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                "dependencies": [
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
+                "sha256": "d94b529c39f94765fdb81f1835ee9c006de2707c0ef4a49445999d00cb99eec2",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-iam-v1:0.12.0",
+                "dependencies": [
+                    "com.google.api:api-common:1.7.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.protobuf:protobuf-java:3.6.1",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
+                "sha256": "ddabb48fe072ada50484c98f00893a3e1356b4f05d2d0bf0045bc830145d1e0c",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
+            },
+            {
+                "coord": "com.google.api:api-common:1.7.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/api-common/1.7.0/api-common-1.7.0.jar",
+                "sha256": "75e0a9c50391576fb3e9eede2218645c0e7f084ca18a8fa6e3e4196b94891a79",
+                "url": "https://repo1.maven.org/maven2/com/google/api/api-common/1.7.0/api-common-1.7.0.jar"
+            },
+            {
+                "coord": "com.google.api:gax-httpjson:0.59.0",
+                "dependencies": [
+                    "com.google.api:api-common:1.7.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.api:gax:1.42.0",
+                    "com.google.guava:guava:25.0-android",
+                    "com.google.code.gson:gson:2.7",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.auth:google-auth-library-oauth2-http:0.13.0",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "org.threeten:threetenbp:1.3.3",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.auth:google-auth-library-credentials:0.13.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/gax-httpjson/0.59.0/gax-httpjson-0.59.0.jar",
+                "sha256": "1dc3638c479cd9cd1ebedb18d8438763cda5ac8bb10981f308573bbbaf847705",
+                "url": "https://repo1.maven.org/maven2/com/google/api/gax-httpjson/0.59.0/gax-httpjson-0.59.0.jar"
+            },
+            {
+                "coord": "com.google.api:gax:1.42.0",
+                "dependencies": [
+                    "com.google.api:api-common:1.7.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.auth:google-auth-library-oauth2-http:0.13.0",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "org.threeten:threetenbp:1.3.3",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.auth:google-auth-library-credentials:0.13.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/gax/1.42.0/gax-1.42.0.jar",
+                "sha256": "9c8540678f209092191e19c59b6ca3092bd75b782f30823bdadf5567e2a1515a",
+                "url": "https://repo1.maven.org/maven2/com/google/api/gax/1.42.0/gax-1.42.0.jar"
+            },
+            {
+                "coord": "com.google.apis:google-api-services-storage:v1-rev20181109-1.27.0",
+                "dependencies": [
+                    "com.google.api-client:google-api-client:1.27.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.oauth-client:google-oauth-client:1.27.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/apis/google-api-services-storage/v1-rev20181109-1.27.0/google-api-services-storage-v1-rev20181109-1.27.0.jar",
+                "sha256": "1be252c53ce4247892296e43af9526975e6e8208a3a136d7e4d3809c1097bd63",
+                "url": "https://repo1.maven.org/maven2/com/google/apis/google-api-services-storage/v1-rev20181109-1.27.0/google-api-services-storage-v1-rev20181109-1.27.0.jar"
+            },
+            {
+                "coord": "com.google.auth:google-auth-library-credentials:0.13.0",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/0.13.0/google-auth-library-credentials-0.13.0.jar",
+                "sha256": "e117279c52c41b66937a5adae41dfeae0e40e48ae40230d2edeb4adc28ed996c",
+                "url": "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/0.13.0/google-auth-library-credentials-0.13.0.jar"
+            },
+            {
+                "coord": "com.google.auth:google-auth-library-oauth2-http:0.13.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.auth:google-auth-library-credentials:0.13.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/0.13.0/google-auth-library-oauth2-http-0.13.0.jar",
+                "sha256": "62551f27379f873962e410328fc10a11a2b8f5df7c232e3cbe96a1b5edadf1ba",
+                "url": "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/0.13.0/google-auth-library-oauth2-http-0.13.0.jar"
+            },
+            {
+                "coord": "com.google.cloud:google-cloud-core-http:1.66.0",
+                "dependencies": [
+                    "com.google.api-client:google-api-client:1.27.0",
+                    "com.google.api:api-common:1.7.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.api.grpc:proto-google-iam-v1:0.12.0",
+                    "com.google.http-client:google-http-client-appengine:1.28.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.api:gax:1.42.0",
+                    "com.google.guava:guava:25.0-android",
+                    "com.google.code.gson:gson:2.7",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.protobuf:protobuf-java-util:3.6.1",
+                    "com.google.auth:google-auth-library-oauth2-http:0.13.0",
+                    "com.google.protobuf:protobuf-java:3.6.1",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "org.threeten:threetenbp:1.3.3",
+                    "javax.annotation:javax.annotation-api:1.3.2",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.oauth-client:google-oauth-client:1.27.0",
+                    "com.google.api:gax-httpjson:0.59.0",
+                    "com.google.cloud:google-cloud-core:1.66.0",
+                    "com.google.auth:google-auth-library-credentials:0.13.0",
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/cloud/google-cloud-core-http/1.66.0/google-cloud-core-http-1.66.0.jar",
+                "sha256": "f1df370d7e352721c4caf5dbace4919be5a12fb701a969e652625e82458342fb",
+                "url": "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core-http/1.66.0/google-cloud-core-http-1.66.0.jar"
+            },
+            {
+                "coord": "com.google.cloud:google-cloud-core:1.66.0",
+                "dependencies": [
+                    "com.google.api:api-common:1.7.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.api.grpc:proto-google-iam-v1:0.12.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.api:gax:1.42.0",
+                    "com.google.guava:guava:25.0-android",
+                    "com.google.code.gson:gson:2.7",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.protobuf:protobuf-java-util:3.6.1",
+                    "com.google.auth:google-auth-library-oauth2-http:0.13.0",
+                    "com.google.protobuf:protobuf-java:3.6.1",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "org.threeten:threetenbp:1.3.3",
+                    "javax.annotation:javax.annotation-api:1.3.2",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.auth:google-auth-library-credentials:0.13.0",
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/cloud/google-cloud-core/1.66.0/google-cloud-core-1.66.0.jar",
+                "sha256": "e7a0f5f5e58352cdb0a095a3cddc40c4050d4e2076d98c8ffce4af538971ce67",
+                "url": "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core/1.66.0/google-cloud-core-1.66.0.jar"
+            },
+            {
+                "coord": "com.google.cloud:google-cloud-storage:1.66.0",
+                "dependencies": [
+                    "com.google.api-client:google-api-client:1.27.0",
+                    "com.google.api:api-common:1.7.0",
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.api.grpc:proto-google-iam-v1:0.12.0",
+                    "com.google.http-client:google-http-client-appengine:1.28.0",
+                    "commons-logging:commons-logging:1.2",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.http-client:google-http-client-jackson2:1.28.0",
+                    "com.google.api:gax:1.42.0",
+                    "com.google.guava:guava:25.0-android",
+                    "com.google.code.gson:gson:2.7",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "org.apache.httpcomponents:httpclient:4.5.5",
+                    "com.google.protobuf:protobuf-java-util:3.6.1",
+                    "com.google.auth:google-auth-library-oauth2-http:0.13.0",
+                    "com.google.protobuf:protobuf-java:3.6.1",
+                    "org.apache.httpcomponents:httpcore:4.4.9",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "org.threeten:threetenbp:1.3.3",
+                    "javax.annotation:javax.annotation-api:1.3.2",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "commons-codec:commons-codec:1.10",
+                    "com.google.http-client:google-http-client-apache:2.0.0",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0",
+                    "com.google.oauth-client:google-oauth-client:1.27.0",
+                    "com.google.api:gax-httpjson:0.59.0",
+                    "com.google.cloud:google-cloud-core:1.66.0",
+                    "com.google.auth:google-auth-library-credentials:0.13.0",
+                    "com.google.cloud:google-cloud-core-http:1.66.0",
+                    "com.google.apis:google-api-services-storage:v1-rev20181109-1.27.0",
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/1.66.0/google-cloud-storage-1.66.0.jar",
+                "sha256": "524b75b693d09cae7b7ef56bdeca68cdc4b2e40ce392beaa1ea8d2b436efdddb",
+                "url": "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/1.66.0/google-cloud-storage-1.66.0.jar"
+            },
+            {
+                "coord": "com.google.code.findbugs:jsr305:3.0.2",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+                "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+                "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+            },
+            {
+                "coord": "com.google.code.gson:gson:2.7",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.jar",
+                "sha256": "2d43eb5ea9e133d2ee2405cc14f5ee08951b8361302fdd93494a3a997b508d32",
+                "url": "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.jar"
+            },
+            {
+                "coord": "com.google.errorprone:error_prone_annotations:2.1.3",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
+                "sha256": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
+                "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
+            },
+            {
+                "coord": "com.google.guava:guava:25.0-android",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/25.0-android/guava-25.0-android.jar",
+                "sha256": "db8b7b8004199af95eb3d5ec7d41fa9f1a4f7e58a2be669a70a3a1426ffa7b5c",
+                "url": "https://repo1.maven.org/maven2/com/google/guava/guava/25.0-android/guava-25.0-android.jar"
+            },
+            {
+                "coord": "com.google.http-client:google-http-client-apache:2.0.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "commons-logging:commons-logging:1.2",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "org.apache.httpcomponents:httpclient:4.5.5",
+                    "org.apache.httpcomponents:httpcore:4.4.9",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "commons-codec:commons-codec:1.10",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client-apache/2.0.0/google-http-client-apache-2.0.0.jar",
+                "sha256": "bfec6352be55ca0426935107d397275c6e703ecbc291b91594c507ca2005aa21",
+                "url": "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-apache/2.0.0/google-http-client-apache-2.0.0.jar"
+            },
+            {
+                "coord": "com.google.http-client:google-http-client-appengine:1.28.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client-appengine/1.28.0/google-http-client-appengine-1.28.0.jar",
+                "sha256": "cb08acb4f5dbe6fda8140eacdbd0a51ffb3bb3ed72f80e759327e9ffded8443d",
+                "url": "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-appengine/1.28.0/google-http-client-appengine-1.28.0.jar"
+            },
+            {
+                "coord": "com.google.http-client:google-http-client-jackson2:1.28.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.6",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client-jackson2/1.28.0/google-http-client-jackson2-1.28.0.jar",
+                "sha256": "5d81963854cf1bd3f082063b20a04d872ca2b9cd0009463924e91deacd0cd6cf",
+                "url": "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-jackson2/1.28.0/google-http-client-jackson2-1.28.0.jar"
+            },
+            {
+                "coord": "com.google.http-client:google-http-client:1.28.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/http-client/google-http-client/1.28.0/google-http-client-1.28.0.jar",
+                "sha256": "43af1d45ca31d8ce20e805d73e9e3444472a0a9eaab608f9cbd8c45fc1f822b6",
+                "url": "https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.28.0/google-http-client-1.28.0.jar"
+            },
+            {
+                "coord": "com.google.j2objc:j2objc-annotations:1.1",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+                "sha256": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+                "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
+            },
+            {
+                "coord": "com.google.oauth-client:google-oauth-client:1.27.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3",
+                    "com.google.http-client:google-http-client:1.28.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/oauth-client/google-oauth-client/1.27.0/google-oauth-client-1.27.0.jar",
+                "sha256": "80e85cc5eae49d8bb8b2b2221c780a26a36a3b213f97504f0968016df9fad474",
+                "url": "https://repo1.maven.org/maven2/com/google/oauth-client/google-oauth-client/1.27.0/google-oauth-client-1.27.0.jar"
+            },
+            {
+                "coord": "com.google.protobuf:protobuf-java-util:3.6.1",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "com.google.code.gson:gson:2.7",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.protobuf:protobuf-java:3.6.1",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.6.1/protobuf-java-util-3.6.1.jar",
+                "sha256": "692618ae9409fb4c4d936ccbf1a0217641c720a4a0a0dce35a4fe2ca96c5a190",
+                "url": "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.6.1/protobuf-java-util-3.6.1.jar"
+            },
+            {
+                "coord": "com.google.protobuf:protobuf-java:3.6.1",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.6.1/protobuf-java-3.6.1.jar",
+                "sha256": "fb66d913ff0578553b2e28a3338cbbbe2657e6cfe0e98d939f23aea219daf508",
+                "url": "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.6.1/protobuf-java-3.6.1.jar"
+            },
+            {
+                "coord": "commons-codec:commons-codec:1.10",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.jar",
+                "sha256": "4241dfa94e711d435f29a4604a3e2de5c4aa3c165e23bd066be6fc1fc4309569",
+                "url": "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.jar"
+            },
+            {
+                "coord": "commons-logging:commons-logging:1.2",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+                "sha256": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
+                "url": "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+            },
+            {
+                "coord": "io.grpc:grpc-context:1.14.0",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-context/1.14.0/grpc-context-1.14.0.jar",
+                "sha256": "d70c10bdd12cd62ba4563d0b060c6db8d9d8e6593a87791a122633b0c4fd70cc",
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.14.0/grpc-context-1.14.0.jar"
+            },
+            {
+                "coord": "io.opencensus:opencensus-api:0.18.0",
+                "dependencies": [
+                    "io.grpc:grpc-context:1.14.0"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-api/0.18.0/opencensus-api-0.18.0.jar",
+                "sha256": "45421ffe95271aba94686ed8d4c5070fe77dc2ff0b922688097f0dd40f1931b1",
+                "url": "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.18.0/opencensus-api-0.18.0.jar"
+            },
+            {
+                "coord": "io.opencensus:opencensus-contrib-http-util:0.18.0",
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "io.opencensus:opencensus-api:0.18.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.guava:guava:25.0-android",
+                    "io.grpc:grpc-context:1.14.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.errorprone:error_prone_annotations:2.1.3"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.18.0/opencensus-contrib-http-util-0.18.0.jar",
+                "sha256": "ccd7b95ab4fc30a7f4875a06a2293320f454c3a8d3f7eb8c3f0907d6c1370128",
+                "url": "https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.18.0/opencensus-contrib-http-util-0.18.0.jar"
+            },
+            {
+                "coord": "javax.annotation:javax.annotation-api:1.3.2",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+                "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+                "url": "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
+            },
+            {
+                "coord": "org.apache.httpcomponents:httpclient:4.5.5",
+                "dependencies": [
+                    "commons-codec:commons-codec:1.10",
+                    "commons-logging:commons-logging:1.2",
+                    "org.apache.httpcomponents:httpcore:4.4.9"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar",
+                "sha256": "7e97724443ad2a25ad8c73183431d47cc7946271bcbbdfa91a8a17522a566573",
+                "url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar"
+            },
+            {
+                "coord": "org.apache.httpcomponents:httpcore:4.4.9",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar",
+                "sha256": "1b4a1c0b9b4222eda70108d3c6e2befd4a6be3d9f78ff53dd7a94966fdf51fc5",
+                "url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar"
+            },
+            {
+                "coord": "org.checkerframework:checker-compat-qual:2.0.0",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
+                "sha256": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
+                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
+            },
+            {
+                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+                "sha256": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+                "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
+            },
+            {
+                "coord": "org.threeten:threetenbp:1.3.3",
+                "dependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/threeten/threetenbp/1.3.3/threetenbp-1.3.3.jar",
+                "sha256": "7bbee842b0334f63627556d3c657aab82431f3a207c8dc4dcfc379d7d210a8c6",
+                "url": "https://repo1.maven.org/maven2/org/threeten/threetenbp/1.3.3/threetenbp-1.3.3.jar"
+            }
+        ],
+        "version": "0.1.0"
+    }
+}

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -27,3 +27,10 @@ build_test(
         "@org_apache_flink_flink_test_utils_2_12//jar",
     ],
 )
+
+build_test(
+    name = "version_conflict_policy_pinned",
+    targets = [
+        "@policy_pinned_testing//:com_google_guava_guava_25_0_android",
+    ],
+)


### PR DESCRIPTION
This commit implements `maven_install`'s `version_conflict_policy` attribute
as described by @jin's comments ([1] and [2]).

`version_conflict_policy = "pinned"` translates to Coursier's
`-V group:artifact:version` for all requested artifacts.  The default of
"default" is a no-op.

[1]: https://github.com/bazelbuild/rules_jvm_external/issues/107#issuecomment-481460441
[2]: https://github.com/bazelbuild/rules_jvm_external/issues/107#issuecomment-481884679

Resolves #107.

Testing Done:
- added new test case to //tests/unit/build_tests