### PR TITLE
Add jar-less alias target for generate_compat_repositories mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ maven_install(
     artifacts = [
         "junit:junit:4.12",
         "androidx.test.espresso:espresso-core:3.1.1",
+        "org.hamcrest:hamcrest-library:1.3",
     ],
     repositories = [
         # Private repositories are supported through HTTP Basic auth
@@ -58,11 +59,19 @@ maven_install(
 and use them directly in the BUILD file by specifying the versionless target alias label:
 
 ```python
-android_library(
-    name = "test_deps",
+java_library(
+    name = "java_test_deps",
     exports = [
+        "@maven//:junit_junit"
+        "@maven//:org_hamcrest_hamcrest_library",
+    ],
+)
+
+android_library(
+    name = "android_test_deps",
+    exports = [
+        "@maven//:junit_junit"
         "@maven//:androidx_test_espresso_espresso_core",
-        "@maven//:junit_junit",
     ],
 )
 ```
@@ -451,6 +460,10 @@ provide a `generate_compat_repositories` attribute in `maven_install`. If
 enabled, JAR artifacts can also be referenced using the `@group_artifact//jar`
 target label. For example, `@maven//:com_google_guava_guava` can also be
 referenced using `@com_google_guava_guava//jar`.
+
+The artifacts can also be referenced using the style used by
+`java_import_external` as `@group_artifact//:group_artifact` or
+`@group_artifact` for short.
 
 ```python
 maven_install(

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -737,13 +737,6 @@ def _coursier_fetch_impl(repository_ctx):
         executable = False,  # not executable
     )
 
-    repository_ctx.template(
-        "compat_repository.bzl",
-        repository_ctx.attr._compat_repository,
-        substitutions = {},
-        executable = False,  # not executable
-    )
-
     repository_ctx.file(
         "BUILD",
         _BUILD.format(
@@ -773,6 +766,13 @@ def _coursier_fetch_impl(repository_ctx):
 
     # Generate a compatibility layer of external repositories for all jar artifacts.
     if repository_ctx.attr.generate_compat_repositories:
+        repository_ctx.template(
+            "compat_repository.bzl",
+            repository_ctx.attr._compat_repository,
+            substitutions = {},
+            executable = False,  # not executable
+        )
+
         compat_repositories_bzl = ["load(\"@%s//:compat_repository.bzl\", \"compat_repository\")" % repository_ctx.name]
         compat_repositories_bzl.append("def compat_repositories():")
         for versionless_target_label in jar_versionless_target_labels:

--- a/private/compat_repository.bzl
+++ b/private/compat_repository.bzl
@@ -1,4 +1,4 @@
-_BUILD = """
+_JAR_BUILD = """
 alias(
     name = "jar",
     actual = "@{generating_repository}//:{target_name}",
@@ -6,10 +6,29 @@ alias(
 )
 """
 
+_ROOT_BUILD = """
+alias(
+    name = "{repository_name}",
+    actual = "@{generating_repository}//:{target_name}",
+    visibility = ["//visibility:public"]
+)
+"""
+
+
 def _compat_repository_impl(repository_ctx):
     repository_ctx.file(
         "jar/BUILD",
-        _BUILD.format(
+        _JAR_BUILD.format(
+            generating_repository = repository_ctx.attr.generating_repository,
+            target_name = repository_ctx.name,
+        ),
+        executable = False,
+    )
+
+    repository_ctx.file(
+        "BUILD",
+        _ROOT_BUILD.format(
+            repository_name = repository_ctx.name,
             generating_repository = repository_ctx.attr.generating_repository,
             target_name = repository_ctx.name,
         ),

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -27,3 +27,13 @@ build_test(
         "@org_apache_flink_flink_test_utils_2_12//jar",
     ],
 )
+
+build_test(
+    name = "compat_repository_alias_jarless",
+    targets = [
+        "@org_pantsbuild_jarjar",
+        "@nz_ac_waikato_cms_weka_weka_stable",
+        "@com_digitalasset_damlc_osx",
+        "@org_apache_flink_flink_test_utils_2_12",
+    ],
+)


### PR DESCRIPTION
Make the generated compat repositories also generate the `@group_artifact//:group_artifact` / `@group_artifact` target label on top of `@group_artifact//jar` label to be interoperable with [`java_import_external`](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/java.bzl#L25
). Some users refer to targets generated by `java_import_external` as `@group_artifact` instead of `@group_artifact//jar`. This was motivated by feedback in https://github.com/bazelbuild/rules_webtesting/pull/363#issuecomment-510121372.

Fixes https://github.com/bazelbuild/rules_jvm_external/pull/190