### PR TITLE
Add Linux CI pipelines for 0.25.3 to 0.28.1 (latest) and update bazel-toolchains pin

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,7 +14,39 @@ tasks:
       # These tests are currently incompatible with RBE
       - "-//tests/integration:UnsafeSharedCacheTest"
       - "-//tests/integration/override_targets"
-  ubuntu1804:
+  ubuntu1804_0_25_3:
+    platform: ubuntu1804
+    bazel: 0.25.3 
+    shell_commands:
+      - bazel run @unpinned_regression_testing//:pin
+    test_targets:
+      - "--"
+      - "//..."
+      # These tests are currently incompatible with OpenJDK 11.
+      - "-//tests/integration:UnsafeSharedCacheTest"
+  ubuntu1804_0_26_1:
+    platform: ubuntu1804
+    bazel: 0.26.1 
+    shell_commands:
+      - bazel run @unpinned_regression_testing//:pin
+    test_targets:
+      - "--"
+      - "//..."
+      # These tests are currently incompatible with OpenJDK 11.
+      - "-//tests/integration:UnsafeSharedCacheTest"
+  ubuntu1804_0_27_2:
+    platform: ubuntu1804
+    bazel: 0.27.2 
+    shell_commands:
+      - bazel run @unpinned_regression_testing//:pin
+    test_targets:
+      - "--"
+      - "//..."
+      # These tests are currently incompatible with OpenJDK 11.
+      - "-//tests/integration:UnsafeSharedCacheTest"
+  ubuntu1804_latest:
+    platform: ubuntu1804
+    bazel: latest
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
     test_targets:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -209,11 +209,11 @@ kt_register_toolchains()
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "4598bf5a8b4f5ced82c782899438a7ba695165d47b3bf783ce774e89a8c6e617",
-    strip_prefix = "bazel-toolchains-0.27.0",
+    sha256 = "dcb58e7e5f0b4da54c6c5f8ebc65e63fcfb37414466010cf82ceff912162296e",
+    strip_prefix = "bazel-toolchains-0.28.2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.28.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.28.2.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This ensures that `rules_jvm_external` is backwards compatible for these versions.