### PR TITLE
Reenable Kotlin example on Windows CI

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -72,15 +72,12 @@ tasks:
     working_directory: examples/android_kotlin_app
     build_targets:
     - "//:app"
-  # rules_kotlin does not work on Windows.
-  # https://github.com/bazelbuild/rules_kotlin/issues/179
-  # https://github.com/bazelbuild/rules_kotlin/blob/master/.bazelci/presubmit.yml
-  # android-kotlin-windows:
-  #   name: "Android Kotlin example"
-  #   platform: windows
-  #   working_directory: examples/android_kotlin_app
-  #   build_targets:
-  #   - "//:app"
+  android-kotlin-windows:
+    name: "Android Kotlin example"
+    platform: windows
+    working_directory: examples/android_kotlin_app
+    build_targets:
+    - "//:app"
   spring-boot-linux:
     name: "Spring boot example"
     platform: ubuntu1804


### PR DESCRIPTION
Kotlin rules now work on Windows.

Fixed in https://github.com/bazelbuild/rules_kotlin/pull/193
