### PR TITLE
Update rules_kotlin and rules_scala versions.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,11 +194,11 @@ maven_install(
 load("@policy_pinned_testing//:defs.bzl", _policy_pinned_maven_install = "pinned_maven_install")
 _policy_pinned_maven_install()
 
-RULES_KOTLIN_VERSION = "da1232eda2ef90d4375e2d1677b32c7ddf09e8a1"
+RULES_KOTLIN_VERSION = "9051eb053f9c958440603d557316a6e9fda14687"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
-    sha256 = "0bbb0e5e536f0c775f37bded59d4f8cfb8556e6c3d926fcc0f58bf3489bff470",
+    sha256 = "c36e71eec84c0e17dd098143a9d93d5720e81b4db32bceaf2daf939252352727",
     strip_prefix = "rules_kotlin-%s" % RULES_KOTLIN_VERSION,
     url = "https://github.com/bazelbuild/rules_kotlin/archive/%s.tar.gz" % RULES_KOTLIN_VERSION,
 )

--- a/examples/scala_akka/WORKSPACE
+++ b/examples/scala_akka/WORKSPACE
@@ -5,11 +5,11 @@ local_repository(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-RULES_SCALA_VERSION = "8f006056990307cbd8320c97a59cd09c821011d8"
+RULES_SCALA_VERSION = "96176ae9e0be8582918a5212a7d4b44d885db8f6"
 
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "e85c1d64520554e0dcdfe828e16ff604de0774b0c68dbb0e90ffab1a6b045adf",
+    sha256 = "ccd4693c5f5a302b8c145ce87792c6fca1cb956b94c15b569ddd0809f5f617d1",
     strip_prefix = "rules_scala-%s" % RULES_SCALA_VERSION,
     url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % RULES_SCALA_VERSION,
 )


### PR DESCRIPTION
This is preparation for flipping [--incompatible_disallow_legacy_javainfo](https://github.com/bazelbuild/bazel/issues/5821).