### PR TITLE
Support more packaging types to mirror Coursier's default set

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -40,6 +40,9 @@ _COURSIER_PACKAGING_TYPES = [
     "eclipse-plugin",
     "orbit",
     "test-jar",
+    "hk2-jar",
+    "maven-plugin",
+    "scala-jar",
 ]
 
 def _strip_packaging_and_classifier(coord):


### PR DESCRIPTION
Coursier recently added support for these packaging types to the default set to match SBT. We don't use the default set (`--no-default`), so we add them manually here.

https://github.com/coursier/coursier/pull/1207/files#diff-c1bcd89f837d1b694251360c98aa1d78
https://github.com/sbt/librarymanagement/blob/bb2c73e183fa52e2fb4b9ae7aca55799f3ff6624/ivy/src/main/scala/sbt/internal/librarymanagement/CustomPomParser.scala#L79

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/166