### PR TITLE
add resolve_timeout attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,24 @@ maven_install(
 )
 ```
 
+### Fetch and resolve timeout
+
+The default timeout to fetch and resolve artifacts is 600 seconds.  If you need
+to change this to resolve a large number of artifacts you can set the
+`resolve_timeout` attribute in `maven_install`:
+
+```python
+maven_install(
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    resolve_timeout = 900
+)
+```
+
 ## Exporting and consuming artifacts from external repositories
 
 If you're writing a library that has dependencies, you should define a constant that

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -689,7 +689,7 @@ def _coursier_fetch_impl(repository_ctx):
         cmd.extend(["--parallel", "1"])
 
     repository_ctx.report_progress("Resolving and fetching the transitive closure of %s artifact(s).." % len(artifact_coordinates))
-    exec_result = repository_ctx.execute(cmd)
+    exec_result = repository_ctx.execute(cmd, timeout=repository_ctx.attr.resolve_timeout)
     if (exec_result.return_code != 0):
         fail("Error while fetching artifact with coursier: " + exec_result.stderr)
 
@@ -722,7 +722,7 @@ def _coursier_fetch_impl(repository_ctx):
                 if part == "http" or part == "https":
                      protocol = part
             if protocol == None:
-                fail("Only artifacts downloaded over http(s) are supported: %s" % artifact["coord"]) 
+                fail("Only artifacts downloaded over http(s) are supported: %s" % artifact["coord"])
             primary_url_parts.extend([protocol, "://"])
             for part in filepath_parts[filepath_parts.index(protocol) + 1:]:
                 primary_url_parts.extend([part, "/"])
@@ -956,6 +956,7 @@ coursier_fetch = repository_rule(
             """,
             default = False,
         ),
+        "resolve_timeout": attr.int(default = 600),
     },
     environ = [
         "JAVA_HOME",

--- a/defs.bzl
+++ b/defs.bzl
@@ -29,7 +29,8 @@ def maven_install(
         version_conflict_policy = "default",
         maven_install_json = None,
         override_targets = {},
-        strict_visibility = False):
+        strict_visibility = False,
+        resolve_timeout = 600):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -60,6 +61,7 @@ def maven_install(
       strict_visibility: Controls visibility of transitive dependencies. If `True`, transitive dependencies
         are private and invisible to user's rules. If `False`, transitive dependencies are public and
         visible to user's rules.
+      resolve_timeout: The execution timeout of resolving and fetching artifacts.
     """
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -101,6 +103,7 @@ def maven_install(
         override_targets = override_targets,
         strict_visibility = strict_visibility,
         maven_install_json = maven_install_json,
+        resolve_timeout = resolve_timeout,
     )
 
     if maven_install_json != None:


### PR DESCRIPTION
Some of our resolves are starting to take longer than the default 600 second timeout for `repository_ctx.execute`.  

This PR adds a `resolve_timeout` attribute to `maven_install` so the timeout can be changed if needed.