### PR TITLE
Add missing case for primary_artifact_path

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -776,6 +776,9 @@ def _coursier_fetch_impl(repository_ctx):
                     # So, we use rfind to get the index of the final '@' in the
                     # repository url instead.
                     primary_artifact_path = primary_url[len(url):]
+                elif url.find("@") == -1 and primary_url.find("@") != -1:
+                    username_len = primary_url.find("//") + 2 + primary_url.find("@") + 1
+                    primary_artifact_path = primary_url[len(url) + username_len:]
 
             mirror_urls = [url + primary_artifact_path for url in repository_urls]
             artifact.update({"mirror_urls": mirror_urls})


### PR DESCRIPTION
I have an entry of:

```
maven_install(
    name = "zzz",
    artifacts = [
        "org.bouncycastle:bcpkix-jdk15on:1.61",
    ],
    repositories = [
        "https://xxx.yyy/repo",
    ),
)
```

And I have something in my `~/.config/coursier/credentials.properties` to give my creds. This confuses things currently because Coursier includes my name, but the repo doesn't know about it. I was previously getting an error because of `primary_artifact_path` being referenced before assigned.