### PR TITLE
Bump Coursier to 2.0.0-RC3-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ maven_install(
 )
 ```
 
-and use them directly in the BUILD file by specifying the versionless label:
+Credentials for private repositories can also be specified using a property file
+or environment variables. See the [Coursier
+documentation](https://get-coursier.io/docs/other-credentials.html#property-file)
+for more information.
+
+Next, reference the artifacts in the BUILD file with their versionless label:
 
 ```python
 java_library(

--- a/private/versions.bzl
+++ b/private/versions.bzl
@@ -1,7 +1,8 @@
-_COURSIER_CLI_VERSION = "v2.0.0-RC3"
+_COURSIER_CLI_VERSION = "v2.0.0-RC3-4"
 
 COURSIER_CLI_HTTP_FILE_NAME = ("coursier_cli_" + _COURSIER_CLI_VERSION).replace(".", "_").replace("-", "_")
 COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/download/{COURSIER_CLI_VERSION}/coursier.jar".format(COURSIER_CLI_VERSION = _COURSIER_CLI_VERSION)
+
 # Run 'bazel run //:mirror_coursier' to upload a copy of the jar to the Bazel mirror.
 COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
 COURSIER_CLI_SHA256 = "17f4ff053d0d1dca588afdcc94ca952f7ed85bb03675cd77ec05b7352a832b86"

--- a/private/versions.bzl
+++ b/private/versions.bzl
@@ -5,4 +5,4 @@ COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/d
 
 # Run 'bazel run //:mirror_coursier' to upload a copy of the jar to the Bazel mirror.
 COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
-COURSIER_CLI_SHA256 = "17f4ff053d0d1dca588afdcc94ca952f7ed85bb03675cd77ec05b7352a832b86"
+COURSIER_CLI_SHA256 = "8f35f92fb8e021f96b3aa8145c66c3b2e29295baabb28ff50569e613438afcbd"


### PR DESCRIPTION
Resolves authentication issue in https://github.com/bazelbuild/rules_jvm_external/issues/80#issuecomment-531317963.

Fixes #80