### PR TITLE
Allow strict visibility to work for artifacts with classifiers

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -225,6 +225,13 @@ maven_install(
     artifacts = [
         # https://github.com/bazelbuild/rules_jvm_external/issues/94
         "org.apache.tomcat:tomcat-catalina:9.0.24",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/255
+        maven.artifact(
+            group = "org.eclipse.jetty",
+            artifact = "jetty-http",
+            version = "9.4.20.v20190813",
+            classifier = "tests",
+        ),
     ],
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -552,10 +552,10 @@ def _pinned_coursier_fetch_impl(repository_ctx):
         repository_ctx = repository_ctx,
         dep_tree = dep_tree,
         explicit_artifacts = {
-            a["group"] + ":" + a["artifact"]: True for a in artifacts
+            a["group"] + ":" + a["artifact"] + (":" + a["classifier"] if "classifier" in a else ""): True for a in artifacts
         },
         neverlink_artifacts = {
-            a["group"] + ":" + a["artifact"]: True
+            a["group"] + ":" + a["artifact"] + (":" + a["classifier"] if "classifier" in a else ""): True
             for a in artifacts
             if a.get("neverlink", False)
         },
@@ -804,11 +804,11 @@ def _coursier_fetch_impl(repository_ctx):
         repository_ctx = repository_ctx,
         dep_tree = dep_tree,
         explicit_artifacts = {
-            a["group"] + ":" + a["artifact"]: True
+            a["group"] + ":" + a["artifact"] + (":" + a["classifier"] if "classifier" in a else ""): True
             for a in artifacts
         },
         neverlink_artifacts = {
-            a["group"] + ":" + a["artifact"]: True
+            a["group"] + ":" + a["artifact"] + (":" + a["classifier"] if "classifier" in a else ""): True
             for a in artifacts
             if a.get("neverlink", False)
         },

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -67,3 +67,10 @@ build_test(
     ],
     tags = ["manual"],  # negative test case
 )
+
+build_test(
+    name = "strict_version_classifier",
+    targets = [
+        "@strict_visibility_testing//:org_eclipse_jetty_jetty_http_tests",
+    ],
+)


### PR DESCRIPTION
strict_visibility does not work for artifacts with classifiers.  e.g.

```
maven_install(
    name = "strict_visibility_testing",
    artifacts = [
        maven.artifact(
            group = "org.eclipse.jetty",
            artifact = "jetty-http",
            version = "9.4.20.v20190813",
            classifier = "tests",
        ),
    ],
    repositories = [
        "https://repo1.maven.org/maven2",
    ],
    strict_visibility = True,
)
```
will fail with
```
ERROR: rules_jvm_external/tests/unit/build_tests/BUILD:71:1: in genrule rule //tests/unit/build_tests:strict_version_classifier_0__deps: target '@strict_visibility_testing//:org_eclipse_jetty_jetty_http_tests' is not visible from target '//tests/unit/build_tests:strict_version_classifier_0__deps'. Check the visibility declaration of the former target if you think the dependency is legitimate
```
this PR adds classifier to the `explicit_artifacts` dictionary used to lookup the strict visibility targets.