### PR TITLE
Extract methods for parsing proxy Urls and add ability to parse proxy Urls with username and password

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -13,6 +13,7 @@
 
 load("//third_party/bazel_json/lib:json_parser.bzl", "json_parse")
 load("//:specs.bzl", "utils")
+load("//:private/proxy.bzl" , "get_java_proxy_args")
 load(
     "//:private/versions.bzl",
     "COURSIER_CLI_GITHUB_ASSET_URL",
@@ -405,31 +406,7 @@ def _get_java_proxy_args(repository_ctx):
     http_proxy = repository_ctx.os.environ.get("http_proxy", repository_ctx.os.environ.get("HTTP_PROXY"))
     https_proxy = repository_ctx.os.environ.get("https_proxy", repository_ctx.os.environ.get("HTTPS_PROXY"))
     no_proxy = repository_ctx.os.environ.get("no_proxy", repository_ctx.os.environ.get("NO_PROXY"))
-
-    proxy_args = []
-
-    # Extract the host and port from a standard proxy URL:
-    # http://proxy.example.com:3128 -> ["proxy.example.com", "3128"]
-    if http_proxy:
-        proxy = http_proxy.split("://", 1)[1].split(":", 1)
-        proxy_args.extend([
-            "-Dhttp.proxyHost=%s" % proxy[0],
-            "-Dhttp.proxyPort=%s" % proxy[1],
-        ])
-
-    if https_proxy:
-        proxy = https_proxy.split("://", 1)[1].split(":", 1)
-        proxy_args.extend([
-            "-Dhttps.proxyHost=%s" % proxy[0],
-            "-Dhttps.proxyPort=%s" % proxy[1],
-        ])
-
-    # Convert no_proxy-style exclusions, including base domain matching, into java.net nonProxyHosts:
-    # localhost,example.com,foo.example.com,.otherexample.com -> "localhost|example.com|foo.example.com|*.otherexample.com"
-    if no_proxy != None:
-        proxy_args.append("-Dhttp.nonProxyHosts=%s" % no_proxy.replace(",", "|").replace("|.", "|*."))
-
-    return proxy_args
+    return get_java_proxy_args(http_proxy, https_proxy, no_proxy)
 
 def _windows_check(repository_ctx):
     # TODO(jin): Remove BAZEL_SH usage ASAP. Bazel is going bashless, so BAZEL_SH

--- a/private/proxy.bzl
+++ b/private/proxy.bzl
@@ -1,0 +1,71 @@
+def _get_proxy_user(url):
+    netloc = url.split("://", 1)[1]
+    if "@" in netloc:
+        userinfo = netloc.rsplit("@", 1)[0]
+        if ":" in userinfo:
+            userinfo = userinfo.split(":", 1)[0]
+        return userinfo
+    return None
+
+def _get_proxy_password(url):
+    netloc = url.split("://", 1)[1]
+    if "@" in netloc:
+        userinfo = netloc.rsplit("@", 1)[0]
+        if ":" in userinfo:
+            userinfo = userinfo.split(":", 1)[1]
+        return userinfo
+    return None
+
+def _get_proxy_hostname(url):
+    netloc = url.split("://", 1)[1].split("@")[-1]
+    if ":" in netloc:
+        return netloc.split(":")[0]
+    else:
+        return netloc
+
+def _get_proxy_port(url):
+    netloc = url.split("://", 1)[1].split("@")[-1]
+    if ":" in netloc:
+        return netloc.split(":")[1]
+    else:
+        return None
+
+# Extract the well-known environment variables http_proxy, https_proxy and
+# no_proxy and convert them to java.net-compatible property arguments.
+def get_java_proxy_args(http_proxy, https_proxy, no_proxy):
+    proxy_args = []
+
+    if http_proxy:
+        proxy_user = _get_proxy_user(http_proxy)
+        if proxy_user:
+            proxy_args.append("-Dhttp.proxyUser=%s" % proxy_user)
+        proxy_password = _get_proxy_password(http_proxy)
+        if proxy_password:
+            proxy_args.append("-Dhttp.proxyPassword=%s" % proxy_password)
+        proxy_host = _get_proxy_hostname(http_proxy)
+        if proxy_host:
+            proxy_args.append("-Dhttp.proxyHost=%s" % proxy_host)
+        proxy_port = _get_proxy_port(http_proxy)
+        if proxy_port:
+            proxy_args.append("-Dhttp.proxyPort=%s" % proxy_port)
+
+    if https_proxy:
+        proxy_user = _get_proxy_user(https_proxy)
+        if proxy_user:
+            proxy_args.append("-Dhttps.proxyUser=%s" % proxy_user)
+        proxy_password = _get_proxy_password(https_proxy)
+        if proxy_password:
+            proxy_args.append("-Dhttps.proxyPassword=%s" % proxy_password)
+        proxy_host = _get_proxy_hostname(https_proxy)
+        if proxy_host:
+            proxy_args.append("-Dhttps.proxyHost=%s" % proxy_host)
+        proxy_port = _get_proxy_port(https_proxy)
+        if proxy_port:
+            proxy_args.append("-Dhttps.proxyPort=%s" % proxy_port)
+
+    # Convert no_proxy-style exclusions, including base domain matching, into java.net nonProxyHosts:
+    # localhost,example.com,foo.example.com,.otherexample.com -> "localhost|example.com|foo.example.com|*.otherexample.com"
+    if no_proxy:
+        proxy_args.append("-Dhttp.nonProxyHosts=%s" % no_proxy.replace(",", "|").replace("|.", "|*."))
+
+    return proxy_args

--- a/tests/unit/BUILD
+++ b/tests/unit/BUILD
@@ -1,3 +1,5 @@
 load(":specs_test.bzl", "artifact_specs_test_suite")
+load(":proxy_test.bzl", "proxy_test_suite")
 
 artifact_specs_test_suite()
+proxy_test_suite()

--- a/tests/unit/proxy_test.bzl
+++ b/tests/unit/proxy_test.bzl
@@ -1,0 +1,66 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//:private/proxy.bzl", "get_java_proxy_args")
+
+def _java_proxy_parsing_empty_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, [], get_java_proxy_args("", "", ""))
+    asserts.equals(env, [], get_java_proxy_args(None, None, None))
+    return unittest.end(env)
+
+java_proxy_parsing_empty_test = unittest.make(_java_proxy_parsing_empty_test_impl)
+
+def _java_proxy_parsing_no_user_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ["-Dhttp.proxyHost=example.com",
+         "-Dhttp.proxyPort=80",
+         "-Dhttps.proxyHost=secureexample.com",
+         "-Dhttps.proxyPort=443",
+         "-Dhttp.nonProxyHosts=google.com"],
+        get_java_proxy_args("http://example.com:80", "https://secureexample.com:443", "google.com")
+    )
+    return unittest.end(env)
+
+java_proxy_parsing_no_user_test = unittest.make(_java_proxy_parsing_no_user_test_impl)
+
+def _java_proxy_parsing_no_port_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ["-Dhttp.proxyHost=example.com",
+         "-Dhttps.proxyHost=secureexample.com",
+         "-Dhttp.nonProxyHosts=google.com"],
+        get_java_proxy_args("http://example.com", "https://secureexample.com", "google.com")
+    )
+    return unittest.end(env)
+
+java_proxy_parsing_no_port_test = unittest.make(_java_proxy_parsing_no_port_test_impl)
+
+def _java_proxy_parsing_all_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ["-Dhttp.proxyUser=user1",
+         "-Dhttp.proxyPassword=pass1",
+         "-Dhttp.proxyHost=example.com",
+         "-Dhttp.proxyPort=80",
+         "-Dhttps.proxyUser=user2",
+         "-Dhttps.proxyPassword=pass2",
+         "-Dhttps.proxyHost=secureexample.com",
+         "-Dhttps.proxyPort=443",
+         "-Dhttp.nonProxyHosts=google.com|localhost"],
+        get_java_proxy_args("http://user1:pass1@example.com:80", "https://user2:pass2@secureexample.com:443", "google.com,localhost")
+    )
+    return unittest.end(env)
+
+java_proxy_parsing_all_test = unittest.make(_java_proxy_parsing_all_test_impl)
+
+def proxy_test_suite():
+    unittest.suite(
+        "proxy_tests",
+        java_proxy_parsing_empty_test,
+        java_proxy_parsing_no_user_test,
+        java_proxy_parsing_no_port_test,
+        java_proxy_parsing_all_test,
+    )

--- a/tests/unit/specs_test.bzl
+++ b/tests/unit/specs_test.bzl
@@ -234,6 +234,7 @@ def _repo_credentials_test_impl(ctx):
         utils.repo_credentials({ "repo_url": repo_url, "credentials": { "user": "bob", "password": "l0bl4w" } })
     )
     return unittest.end(env)
+
 repo_credentials_test = unittest.make(_repo_credentials_test_impl)
 
 def artifact_specs_test_suite():


### PR DESCRIPTION
Addressing https://github.com/bazelbuild/rules_jvm_external/issues/261 so proxy Urls with user and password get parsed correctly and the `http.proxyUser` and `http.proxyPassword` are set accordingly.  

The method was broken out into a new file for easier testing.