### PR TITLE
Extend jvm_import.bzl to stamp the jar's manifest with the Target-Label attribute for buildozer's add_dep feature

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,12 +18,11 @@ http_file(
 
 # Begin Skylib dependencies
 
-BAZEL_SKYLIB_TAG = "0.8.0"
+BAZEL_SKYLIB_TAG = "1.0.2"
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "2ea8a5ed2b448baf4a6855d3ce049c4c452a6470b1efd1504fdb7c1c134d220a",
-    strip_prefix = "bazel-skylib-%s" % BAZEL_SKYLIB_TAG,
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
     url = "https://github.com/bazelbuild/bazel-skylib/archive/%s.tar.gz" % BAZEL_SKYLIB_TAG,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,16 +18,15 @@ http_file(
 
 # Begin Skylib dependencies
 
-BAZEL_SKYLIB_TAG = "1.0.2"
-
 http_archive(
     name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+    ],
     sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/%s.tar.gz" % BAZEL_SKYLIB_TAG,
 )
-
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
 bazel_skylib_workspace()
 
 # End Skylib dependencies
@@ -36,9 +35,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_stardoc",
-    url = "https://github.com/bazelbuild/stardoc/archive/4378e9b6bb2831de7143580594782f538f461180.zip",
-    strip_prefix = "stardoc-4378e9b6bb2831de7143580594782f538f461180",
     sha256 = "4a355dccc713458071f441f3dafd7452b3111c53cde554d0847b9a82d657149e",
+    strip_prefix = "stardoc-4378e9b6bb2831de7143580594782f538f461180",
+    url = "https://github.com/bazelbuild/stardoc/archive/4378e9b6bb2831de7143580594782f538f461180.zip",
 )
 
 # Stardoc also depends on skydoc_repositories, rules_sass, rules_nodejs, but our
@@ -56,13 +55,14 @@ maven_install(
         "com.google.guava:guava:27.0-jre",
         "org.hamcrest:hamcrest-core:2.1",
     ],
+    maven_install_json = "@rules_jvm_external//:maven_install.json",
     repositories = [
         "https://jcenter.bintray.com/",
     ],
-    maven_install_json = "@rules_jvm_external//:maven_install.json",
 )
 
 load("@maven//:defs.bzl", "pinned_maven_install")
+
 pinned_maven_install()
 
 maven_install(
@@ -245,11 +245,12 @@ maven_install(
 maven_install(
     name = "maven_install_in_custom_location",
     artifacts = ["com.google.guava:guava:27.0-jre"],
-    repositories = ["https://repo1.maven.org/maven2"],
     maven_install_json = "@rules_jvm_external//tests/custom_maven_install:maven_install.json",
+    repositories = ["https://repo1.maven.org/maven2"],
 )
 
 load("@maven_install_in_custom_location//:defs.bzl", "pinned_maven_install")
+
 pinned_maven_install()
 
 RULES_KOTLIN_VERSION = "8ca948548159f288450516a09248dcfb9e957804"

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -32,6 +32,17 @@ java_test(
     ],
 )
 
+java_import(
+    name = "guava_import",
+    jars = [
+        # The default @maven//:com_google_guava_guava is a stamped jar created
+        # from the actual symlinked jar. Instead of referencing the stamped jar,
+        # which isn't part of the unsafe shared cache, import the symlink file label
+        # here directly, and bypass the stamping in jvm_import.bzl.
+        "@unsafe_shared_cache//:v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+    ]
+)
+
 java_test(
     name = "UnsafeSharedCacheTest",
     srcs = ["UnsafeSharedCacheTest.java"],
@@ -39,6 +50,6 @@ java_test(
     deps = [
         "@maven//:org_hamcrest_hamcrest",
         "@maven//:org_hamcrest_hamcrest_core",
-        "@unsafe_shared_cache//:com_google_guava_guava",
+        ":guava_import",
     ],
 )

--- a/tests/unit/manifest_contents/BUILD
+++ b/tests/unit/manifest_contents/BUILD
@@ -1,0 +1,18 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+genrule(
+    name = "extract_manifest",
+    srcs = [
+        "@maven//:com_google_guava_guava",
+    ],
+    outs = [
+        "MANIFEST.MF",
+    ],
+    cmd = "unzip -p $< META-INF/MANIFEST.MF > $@",
+)
+
+diff_test(
+    name = "diff_manifest_test",
+    file1 = "MANIFEST.MF.golden",
+    file2 = "MANIFEST.MF",
+)

--- a/tests/unit/manifest_contents/MANIFEST.MF.golden
+++ b/tests/unit/manifest_contents/MANIFEST.MF.golden
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Created-By: singlejar
+Target-Label: @maven//:com_google_guava_guava
+


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_jvm_external/issues/283

With the repro in #283:

```
$ bazel build //:B_no_dep
INFO: Writing tracer profile to '/private/var/tmp/_bazel_jingwen/ac10292842231f27a13ff5ac097aa7a7/command.profile.gz'
INFO: Analyzed target //:B_no_dep (1 packages loaded, 14 targets configured).
INFO: Found 1 target...
ERROR: /Users/jingwen/code/rules_jvm_demo/rules_jvm/BUILD:16:1: Building libB_no_dep.jar (1 source file) failed (Exit 1)
B.java:6: error: [strict] Using type com.google.common.collect.Lists from an indirect dependency (TOOL_INFO: "@maven//:com_google_guava_guava"). See command below **
        System.err.println(Lists.reverse(A.INTEGERS));
                           ^
 ** Please add the following dependencies:
  @maven//:com_google_guava_guava to //:B_no_dep
 ** You can use the following buildozer command:
buildozer 'add deps @maven//:com_google_guava_guava' //:B_no_dep

Target //:B_no_dep failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 6.599s, Critical Path: 0.17s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```

TODO

- [x] add tests