### PR TITLE
Automatically generate a netrc file according to basic http auth in url

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -277,7 +277,8 @@ def _pinned_coursier_fetch_impl(repository_ctx):
                 "        netrc = \"../%s/netrc\"," % (repository_ctx.name),
             ])
             if artifact.get("mirror_urls") != None:
-                http_files.append("        urls = %s," % repr(artifact["mirror_urls"]))
+                http_files.append("        urls = %s," % repr(
+                    [remove_auth_from_url(url) for url in artifact["mirror_urls"]]))
                 netrc_entries = add_netrc_entries_from_mirror_urls(netrc_entries, artifact["mirror_urls"])
             else:
                 # For backwards compatibility. mirror_urls is a field added in a

--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -1,7 +1,11 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//:coursier.bzl",
+    "add_netrc_entries_from_mirror_urls",
+    "extract_netrc_from_auth_url",
+    "get_netrc_lines_from_entries",
     infer = "infer_artifact_path_from_primary_and_repos",
     "remove_auth_from_url",
+    "split_url",
 )
 
 ALL_TESTS = []
@@ -119,6 +123,190 @@ def _remove_auth_noauth_noop_test_impl(ctx):
     return unittest.end(env)
 
 remove_auth_noauth_noop_test = add_test(_remove_auth_noauth_noop_test_impl)
+
+def _split_url_basic_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ("https", ["c1"]),
+        split_url("https://c1"))
+    return unittest.end(env)
+
+split_url_basic_test = add_test(_split_url_basic_test_impl)
+
+def _split_url_basic_auth_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ("https", ["a:b@c1"]),
+        split_url("https://a:b@c1"))
+    asserts.equals(
+        env,
+        ("https", ["a@c1"]),
+        split_url("https://a@c1"))
+    return unittest.end(env)
+
+split_url_basic_auth_test = add_test(_split_url_basic_auth_test_impl)
+
+def _split_url_with_path_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ("https", ["c1", "some", "path"]),
+        split_url("https://c1/some/path"))
+    return unittest.end(env)
+
+split_url_with_path_test = add_test(_split_url_with_path_test_impl)
+
+def _extract_netrc_from_auth_url_noop_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {},
+        extract_netrc_from_auth_url("https://c1"))
+    asserts.equals(
+        env,
+        {},
+        extract_netrc_from_auth_url("https://c2/useless@inurl"))
+    return unittest.end(env)
+
+extract_netrc_from_auth_url_noop_test = add_test(_extract_netrc_from_auth_url_noop_test_impl)
+
+def _extract_netrc_from_auth_url_with_auth_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {"machine": "c", "login": "a", "password": "b"},
+        extract_netrc_from_auth_url("https://a:b@c"))
+    asserts.equals(
+        env,
+        {"machine": "c", "login": "a", "password": "b"},
+        extract_netrc_from_auth_url("https://a:b@c/some/other/stuff@thisplace/for/testing"))
+    asserts.equals(
+        env,
+        {"machine": "c", "login": "a", "password": None},
+        extract_netrc_from_auth_url("https://a@c"))
+    asserts.equals(
+        env,
+        {"machine": "c", "login": "a", "password": None},
+        extract_netrc_from_auth_url("https://a@c/some/other/stuff@thisplace/for/testing"))
+    return unittest.end(env)
+
+extract_netrc_from_auth_url_with_auth_test = add_test(_extract_netrc_from_auth_url_with_auth_test_impl)
+
+def _extract_netrc_from_auth_url_at_in_password_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {"machine": "c", "login": "a", "password": "p@ssword"},
+        extract_netrc_from_auth_url("https://a:p@ssword@c"))
+    return unittest.end(env)
+
+extract_netrc_from_auth_url_at_in_password_test = add_test(_extract_netrc_from_auth_url_at_in_password_test_impl)
+
+def _add_netrc_entries_from_mirror_urls_noop_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {},
+        add_netrc_entries_from_mirror_urls({}, ["https://c1", "https://c1/something@there"]))
+    return unittest.end(env)
+
+add_netrc_entries_from_mirror_urls_noop_test = add_test(_add_netrc_entries_from_mirror_urls_noop_test_impl)
+
+def _add_netrc_entries_from_mirror_urls_basic_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {"c1": {"a": "b"}},
+        add_netrc_entries_from_mirror_urls({}, ["https://a:b@c1"]))
+    asserts.equals(
+        env,
+        {"c1": {"a": "b"}},
+        add_netrc_entries_from_mirror_urls(
+            {"c1": {"a": "b"}},
+            ["https://a:b@c1"]))
+    return unittest.end(env)
+
+add_netrc_entries_from_mirror_urls_basic_test = add_test(_add_netrc_entries_from_mirror_urls_basic_test_impl)
+
+def _add_netrc_entries_from_mirror_urls_multi_login_ignored_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {"c1": {"a": "b"}},
+        add_netrc_entries_from_mirror_urls({}, ["https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"]))
+    asserts.equals(
+        env,
+        {"c1": {"a": "b"}},
+        add_netrc_entries_from_mirror_urls(
+            {"c1": {"a": "b"}},
+            ["https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"]))
+    return unittest.end(env)
+
+add_netrc_entries_from_mirror_urls_multi_login_ignored_test = add_test(_add_netrc_entries_from_mirror_urls_multi_login_ignored_test_impl)
+
+def _add_netrc_entries_from_mirror_urls_multi_case_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        {"foo": {"bar": "baz"},
+         "c1": {"a1": "b1"},
+         "c2": {"a2": "b2"}},
+        add_netrc_entries_from_mirror_urls(
+            {"foo": {"bar": "baz"}},
+            ["https://a1:b1@c1", "https://a2:b2@c2", "https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"]))
+    return unittest.end(env)
+
+add_netrc_entries_from_mirror_urls_multi_case_test = add_test(_add_netrc_entries_from_mirror_urls_multi_case_test_impl)
+
+def _get_netrc_lines_from_entries_noop_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        [],
+        get_netrc_lines_from_entries({}))
+    return unittest.end(env)
+
+get_netrc_lines_from_entries_noop_test = add_test(_get_netrc_lines_from_entries_noop_test_impl)
+
+def _get_netrc_lines_from_entries_basic_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ["machine c", "login a", "password b"],
+        get_netrc_lines_from_entries({
+            "c": {"a": "b"}
+        }))
+    return unittest.end(env)
+
+get_netrc_lines_from_entries_basic_test = add_test(_get_netrc_lines_from_entries_basic_test_impl)
+
+def _get_netrc_lines_from_entries_no_pass_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ["machine c", "login a"],
+        get_netrc_lines_from_entries({
+            "c": {"a": ""}
+        }))
+    return unittest.end(env)
+
+get_netrc_lines_from_entries_no_pass_test = add_test(_get_netrc_lines_from_entries_no_pass_test_impl)
+
+def _get_netrc_lines_from_entries_multi_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        ["machine c", "login a", "password b",
+         "machine c2", "login a2", "password p@ssword"],
+        get_netrc_lines_from_entries({
+            "c": {"a": "b"},
+            "c2": {"a2": "p@ssword"}
+        }))
+    return unittest.end(env)
+
+get_netrc_lines_from_entries_multi_test = add_test(_get_netrc_lines_from_entries_multi_test_impl)
 
 def coursier_test_suite():
     unittest.suite(


### PR DESCRIPTION
For every mirror url in a pinned json, try to extract netrc credentials. Then, write those credentials into a file that every generated http_file for the various maven artifacts will use.

Alternative way of implementing would be by allowing you to pass a pre-made netrc and that can be added in later if we should choose to do so, although it may be somewhat difficult to do so due to there being at least three different repositories in play making it difficult to use raw paths.

With this change, basic http auth will appear to be supported even though it technically isn't since we are translating basic http auth into netrc auth with all of netrc's shortcomings.

In the majority of cases I expect for this to be enough, but for complex auth schemes we may need something in addition.

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/186