### PR TITLE
Drop support for Bazel beta versions

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,9 +15,9 @@ tasks:
       # These tests are currently incompatible with RBE
       - "-//tests/integration:UnsafeSharedCacheTest"
       - "-//tests/integration/override_targets"
-  ubuntu1804_0_25_3:
+  ubuntu1804_1_0_1:
     platform: ubuntu1804
-    bazel: 0.25.3
+    bazel: 1.0.1
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
@@ -26,31 +26,9 @@ tasks:
       - "//..."
       # These tests are currently incompatible with OpenJDK 11.
       - "-//tests/integration:UnsafeSharedCacheTest"
-  ubuntu1804_0_26_1:
+  ubuntu1804_1_1_0:
     platform: ubuntu1804
-    bazel: 0.26.1
-    shell_commands:
-      - bazel run @unpinned_regression_testing//:pin
-      - bazel run @unpinned_maven_install_in_custom_location//:pin
-    test_targets:
-      - "--"
-      - "//..."
-      # These tests are currently incompatible with OpenJDK 11.
-      - "-//tests/integration:UnsafeSharedCacheTest"
-  ubuntu1804_0_27_2:
-    platform: ubuntu1804
-    bazel: 0.27.2
-    shell_commands:
-      - bazel run @unpinned_regression_testing//:pin
-      - bazel run @unpinned_maven_install_in_custom_location//:pin
-    test_targets:
-      - "--"
-      - "//..."
-      # These tests are currently incompatible with OpenJDK 11.
-      - "-//tests/integration:UnsafeSharedCacheTest"
-  ubuntu1804_0_29_1:
-    platform: ubuntu1804
-    bazel: 0.29.1
+    bazel: 1.1.0
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin


### PR DESCRIPTION
We'll be adding netrc support in #306, which exists in later Bazel
versions. Let's stop supporting pre-1.0.0 versions.

The next rules_jvm_external will be a major version bump.