### PR TITLE
Support custom cache locations with use_unsafe_shared_cache and COURSIER_CACHE

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,10 @@
 ---
 tasks:
   ubuntu1604:
+    environment:
+      # This tests custom cache locations.
+      # https://github.com/bazelbuild/rules_jvm_external/pull/316
+      COURSIER_CACHE: /tmp/custom_coursier_cache
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
@@ -52,6 +56,10 @@ tasks:
   ubuntu1804_latest:
     platform: ubuntu1804
     bazel: latest
+    environment:
+      # This tests custom cache locations.
+      # https://github.com/bazelbuild/rules_jvm_external/pull/316
+      COURSIER_CACHE: /tmp/custom_coursier_cache
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
@@ -62,6 +70,10 @@ tasks:
       # These tests are currently incompatible with OpenJDK 11.
       - "-//tests/integration:UnsafeSharedCacheTest"
   macos:
+    environment:
+      # This tests custom cache locations.
+      # https://github.com/bazelbuild/rules_jvm_external/pull/316
+      COURSIER_CACHE: /tmp/custom_coursier_cache
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
@@ -69,6 +81,10 @@ tasks:
     test_targets:
       - "//..."
   windows:
+    environment:
+      # This tests custom cache locations.
+      # https://github.com/bazelbuild/rules_jvm_external/pull/316
+      COURSIER_CACHE: /tmp/custom_coursier_cache
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ To change the location of the cache from the home directory, set the
 set the variable on the command line and in `.bazelrc` files:
 
 ```
-$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=/tmp/custom_cache
+$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=COURSIER_CACHE=/tmp/custom_cache
 ```
 
 This feature also enables checking the downloaded artifacts into your source
@@ -354,7 +354,7 @@ tree by declaring `COURSIER_CACHE` to be `<project root>/some/directory`. For
 example:
 
 ```
-$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=$(pwd)/third_party
+$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=COURSIER_CACHE=$(pwd)/third_party
 ```
 
 The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ maven_install(
 > is a caching mechanism that was implemented before artifact pinning,
 > which uses Coursier's own persistent cache. With artifact pinning and
 > maven_install.json, the persistent cache is integrated directly into
-> Bazel's own cache.
+> Bazel's internal cache.
 
 To download artifacts into a shared and persistent directory in your home
 directory, set `use_unsafe_shared_cache = True` in `maven_install`.
@@ -341,9 +341,25 @@ This is **not safe** as Bazel is currently not able to detect changes in the
 shared cache. For example, if an artifact is deleted from the shared cache,
 Bazel will not re-run the repository rule automatically.
 
+To change the location of the cache from the home directory, set the
+`COURSIER_CACHE` environment variable. You can also use the `--repo_env` flag to
+set the variable on the command line and in `.bazelrc` files:
+
+```
+$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=/tmp/custom_cache
+```
+
+This feature also enables checking the downloaded artifacts into your source
+tree by declaring `COURSIER_CACHE` to be `<project root>/some/directory`. For
+example:
+
+```
+$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=$(pwd)/third_party
+```
+
 The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
 will create independent caches for each `maven_install` repository, located at
-`$(bazel info output_base)/external/@repository_name/v1`.
+`$(bazel info output_base)/external/@<repository_name>/v1`.
 
 ### `artifact` helper macro
 

--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -4,6 +4,7 @@ load(
     "add_netrc_entries_from_mirror_urls",
     "extract_netrc_from_auth_url",
     "get_netrc_lines_from_entries",
+    "get_coursier_cache_or_default",
     "remove_auth_from_url",
     "split_url",
     infer = "infer_artifact_path_from_primary_and_repos",
@@ -355,6 +356,52 @@ def _get_netrc_lines_from_entries_multi_test_impl(ctx):
     return unittest.end(env)
 
 get_netrc_lines_from_entries_multi_test = add_test(_get_netrc_lines_from_entries_multi_test_impl)
+
+def _mock_repo_path(path):
+    if path.startswith("/"):
+        return path
+    else:
+        return "/mockroot/" + path
+
+def _get_coursier_cache_or_default_disabled_test(ctx):
+    env = unittest.begin(ctx)
+    mock_environ = {
+        "COURSIER_CACHE": _mock_repo_path("/does/not/matter")
+    }
+    asserts.equals(
+        env,
+        "v1",
+        get_coursier_cache_or_default(mock_environ, False)
+    )
+    return unittest.end(env)
+
+get_coursier_cache_or_default_disabled_test = add_test(_get_coursier_cache_or_default_disabled_test)
+
+def _get_coursier_cache_or_default_enabled_with_default_location_test(ctx):
+    env = unittest.begin(ctx)
+    mock_environ = {}
+    asserts.equals(
+        env,
+        "v1",
+        get_coursier_cache_or_default(mock_environ, True)
+    )
+    return unittest.end(env)
+
+get_coursier_cache_or_default_enabled_with_default_location_test = add_test(_get_coursier_cache_or_default_enabled_with_default_location_test)
+
+def _get_coursier_cache_or_default_enabled_with_custom_location_test(ctx):
+    env = unittest.begin(ctx)
+    mock_environ = {
+        "COURSIER_CACHE": _mock_repo_path("/custom/location")
+    }
+    asserts.equals(
+        env,
+        "/custom/location",
+        get_coursier_cache_or_default(mock_environ, True)
+    )
+    return unittest.end(env)
+
+get_coursier_cache_or_default_enabled_with_custom_location_test = add_test(_get_coursier_cache_or_default_enabled_with_custom_location_test)
 
 def coursier_test_suite():
     unittest.suite(


### PR DESCRIPTION
`use_unsafe_shared_cache` is an optimization when not using artifact pinning. It bypasses Bazel's downloader, since it uses Coursier's internal downloader. The location of the cache can be specified with the environment variable `COURSIER_CACHE`. 

This PR adds support for reading `COURSIER_CACHE` when `use_unsafe_shared_cache = True`. If `use_unsafe_shared_cache = False`, `COURSIER_CACHE` is explicitly set to the output_base-internal location to ensure that Coursier doesn't write to the home directory. This fixes https://github.com/bazelbuild/rules_jvm_external/issues/301 (cc @arjantop)

This also adds vendoring support -- that is, using `use_unsafe_shared_cache` and `--repo_env=COURSIER_CACHE=$(pwd)/third_party` lets you download the jars directly into your source directory. Previously attempted in https://github.com/bazelbuild/rules_jvm_external/pull/168. Also see https://github.com/bazelbuild/bazel/issues/8658, which allows rules_jvm_external to be used to manage Bazel's own Java dependencies since it's a requirement to vendor jars. (cc @shs96c) 