### PR TITLE
Added option to use safe shared cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,32 @@ The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
 will create independent caches for each `maven_install` repository, located at
 `$(bazel info output_base)/external/@repository_name/v1`.
 
+### Using a safe persistent artifact cache
+
+To download artifacts into a shared and persistent directory in your home
+directory (while keeping Bazel caching safe), set `use_safe_shared_cache = True` in `maven_install`.
+
+```python
+maven_install(
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    use_safe_shared_cache = True,
+)
+```
+
+
+This is considered safe as it copies the downloaded artifacts to Bazel's cache
+(and then stays disconnected). You'll need to re-execute artifact pinning to get
+an update from Coursier, but Coursier will run faster each time.
+
+The default value of `use_safe_shared_cache` is `False`. This means that Bazel
+will create independent caches for each `maven_install` repository, located at
+`$(bazel info output_base)/external/@repository_name/v1`.
+
 ### `artifact` helper macro
 
 The `artifact` macro translates the artifact's `group:artifact` coordinates to

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -69,6 +69,41 @@ def _relativize_and_symlink_file(repository_ctx, absolute_path):
         repository_ctx.symlink(absolute_path, repository_ctx.path(artifact_relative_path))
     return artifact_relative_path
 
+# Relativize an absolute path to an artifact in coursier's default cache location.
+# After relativizing, copy the file into the workspace's output base.
+# Then return the relative path for further processing
+def _relativize_and_copy_file(repository_ctx, absolute_path):
+    # The path manipulation from here on out assumes *nix paths, not Windows.
+    # for artifact_absolute_path in artifact_absolute_paths:
+    #
+    # Also replace '\' with '/` to normalize windows paths to *nix style paths
+    # BUILD files accept only *nix paths, so we normalize them here.
+    #
+    # We assume that coursier uses the default cache location
+    # TODO(jin): allow custom cache locations
+
+    absolute_path_parts = absolute_path.split("v1/")
+    if len(absolute_path_parts) != 2:
+        fail("Error while trying to parse the path of file in the coursier cache: " + absolute_path)
+    else:
+        # Copy the file from the absolute path of the artifact to the relative
+        # path within the output_base/external.
+        artifact_relative_path = "v1/" + absolute_path_parts[1]
+        bazel_cache_path = repository_ctx.path(artifact_relative_path)
+
+        parent_dir = bazel_cache_path.dirname
+
+        cmd = ["mkdir", "-p", parent_dir]
+        exec_result = repository_ctx.execute(cmd)
+        if exec_result.return_code != 0:
+            fail("Failed executing command %s: %s" % (cmd, exec_result.stderr))
+
+        cmd = ["cp", absolute_path, bazel_cache_path]
+        exec_result = repository_ctx.execute(cmd)
+        if exec_result.return_code != 0:
+            fail("Failed executing command %s: %s" % (cmd, exec_result.stderr))
+    return artifact_relative_path
+
 # Generate the base `coursier` command depending on the OS, JAVA_HOME or the
 # location of `java`.
 def _generate_java_jar_command(repository_ctx, jar_path):
@@ -471,7 +506,7 @@ def _coursier_fetch_impl(repository_ctx):
             cmd.extend(["--credentials", utils.repo_credentials(repository)])
     for a in excluded_artifacts:
         cmd.extend(["--exclude", ":".join([a["group"], a["artifact"]])])
-    if not repository_ctx.attr.use_unsafe_shared_cache:
+    if not (repository_ctx.attr.use_unsafe_shared_cache or repository_ctx.attr.use_safe_shared_cache):
         cmd.extend(["--cache", "v1"])  # Download into $output_base/external/$maven_repo_name/v1
     if repository_ctx.attr.fetch_sources:
         cmd.append("--sources")
@@ -512,6 +547,9 @@ def _coursier_fetch_impl(repository_ctx):
 
         if repository_ctx.attr.use_unsafe_shared_cache:
             artifact.update({"file": _relativize_and_symlink_file(repository_ctx, artifact["file"])})
+
+        if repository_ctx.attr.use_safe_shared_cache:
+            artifact.update({"file": _relativize_and_copy_file(repository_ctx, artifact["file"])})
 
         # Coursier saves the artifacts into a subdirectory structure
         # that mirrors the URL where the artifact's fetched from. Using
@@ -741,6 +779,7 @@ coursier_fetch = repository_rule(
         "fail_on_missing_checksum": attr.bool(default = True),
         "fetch_sources": attr.bool(default = False),
         "use_unsafe_shared_cache": attr.bool(default = False),
+        "use_safe_shared_cache": attr.bool(default = False),
         "excluded_artifacts": attr.string_list(default = []),  # list of artifacts to exclude
         "generate_compat_repositories": attr.bool(default = False),  # generate a compatible layer with repositories for each artifact
         "version_conflict_policy": attr.string(

--- a/defs.bzl
+++ b/defs.bzl
@@ -24,6 +24,7 @@ def maven_install(
         fail_on_missing_checksum = True,
         fetch_sources = False,
         use_unsafe_shared_cache = False,
+        use_safe_shared_cache = False,
         excluded_artifacts = [],
         generate_compat_repositories = False,
         version_conflict_policy = "default",
@@ -45,6 +46,8 @@ def maven_install(
       fetch_sources: Additionally fetch source JARs.
       use_unsafe_shared_cache: Download artifacts into a persistent shared cache on disk. Unsafe as Bazel is
         currently unable to detect modifications to the cache.
+      use_safe_shared_cache: Download artifacts into a persistent shared cache on disk. Considered safe as it copies
+        downloaded artifacts to Bazel's cache (and then stays disconnected).
       excluded_artifacts: A list of Maven artifact coordinates in the form of `group:artifact` to be
         excluded from the transitive dependencies.
       generate_compat_repositories: Additionally generate repository aliases in a .bzl file for all JAR
@@ -97,6 +100,7 @@ def maven_install(
         fail_on_missing_checksum = fail_on_missing_checksum,
         fetch_sources = fetch_sources,
         use_unsafe_shared_cache = use_unsafe_shared_cache,
+        use_safe_shared_cache = use_safe_shared_cache,
         excluded_artifacts = excluded_artifacts_json_strings,
         generate_compat_repositories = generate_compat_repositories,
         version_conflict_policy = version_conflict_policy,
@@ -117,7 +121,6 @@ def maven_install(
             override_targets = override_targets,
             strict_visibility = strict_visibility,
         )
-
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):
     artifact_obj = _parse_artifact_str(a) if type(a) == "string" else a

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,7 +28,9 @@ load("@rules_jvm_external//:defs.bzl", "maven_install", "artifact")
 
 <pre>
 maven_install(<a href="#maven_install-name">name</a>, <a href="#maven_install-repositories">repositories</a>, <a href="#maven_install-artifacts">artifacts</a>, <a href="#maven_install-fail_on_missing_checksum">fail_on_missing_checksum</a>, <a href="#maven_install-fetch_sources">fetch_sources</a>,
-              <a href="#maven_install-use_unsafe_shared_cache">use_unsafe_shared_cache</a>, <a href="#maven_install-excluded_artifacts">excluded_artifacts</a>, <a href="#maven_install-generate_compat_repositories">generate_compat_repositories</a>,
+              <a href="#maven_install-use_unsafe_shared_cache">use_unsafe_shared_cache</a>,
+              <a href="#maven_install-use_safe_shared_cache">use_safe_shared_cache</a>, 
+              <a href="#maven_install-excluded_artifacts">excluded_artifacts</a>, <a href="#maven_install-generate_compat_repositories">generate_compat_repositories</a>,
               <a href="#maven_install-version_conflict_policy">version_conflict_policy</a>, <a href="#maven_install-maven_install_json">maven_install_json</a>, <a href="#maven_install-override_targets">override_targets</a>, <a href="#maven_install-strict_visibility">strict_visibility</a>,
               <a href="#maven_install-resolve_timeout">resolve_timeout</a>)
 </pre>
@@ -50,6 +52,7 @@ and fetch Maven artifacts transitively.
 | fail_on_missing_checksum |  <p align="center"> - </p>   |  <code>True</code> |
 | fetch_sources |  Additionally fetch source JARs.   |  <code>False</code> |
 | use_unsafe_shared_cache |  Download artifacts into a persistent shared cache on disk. Unsafe as Bazel is   currently unable to detect modifications to the cache.   |  <code>False</code> |
+| use_safe_shared_cache |  Download artifacts into a persistent shared cache on disk. Considered safe as it copies   downloaded artifacts to Bazel's cache (and then stays disconnected).   |  <code>False</code> |
 | excluded_artifacts |  A list of Maven artifact coordinates in the form of <code>group:artifact</code> to be   excluded from the transitive dependencies.   |  <code>[]</code> |
 | generate_compat_repositories |  Additionally generate repository aliases in a .bzl file for all JAR   artifacts. For example, <code>@maven//:com_google_guava_guava</code> can also be referenced as   <code>@com_google_guava_guava//jar</code>.   |  <code>False</code> |
 | version_conflict_policy |  Policy for user-defined vs. transitive dependency version   conflicts.  If "pinned", choose the user's version unconditionally.  If "default", follow   Coursier's default policy.   |  <code>"default"</code> |


### PR DESCRIPTION
Comparing to unsafe shared cache we do not do symlinking to Bazel's cache
from Coursier's cache but copy, to avoid possible problems if coursier's
cache change.