### PR TITLE
Add support for jetify_include_patterns

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -321,6 +321,9 @@ maven_install(
         "https://maven.google.com",
     ],
     jetify = True,
+    jetify_exclude_patterns = [
+        "startswith(com.google)",
+    ],
 )
 
 RULES_KOTLIN_VERSION = "8ca948548159f288450516a09248dcfb9e957804"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -321,8 +321,9 @@ maven_install(
         "https://maven.google.com",
     ],
     jetify = True,
-    jetify_exclude_patterns = [
-        "startswith(com.google)",
+    jetify_include_patterns = [
+        "startswith(com.google:)",
+        "startswith(com.android.support:)",
     ],
 )
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -775,7 +775,8 @@ pinned_coursier_fetch = repository_rule(
             """,
             default = False,
         ),
-        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False)
+        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
+        "jetify_exclude_patterns": attr.string_list(doc = "TODO", default = []),
     },
     implementation = _pinned_coursier_fetch_impl,
 )
@@ -815,7 +816,8 @@ coursier_fetch = repository_rule(
             default = False,
         ),
         "resolve_timeout": attr.int(default = 600),
-        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False)
+        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
+        "jetify_exclude_patterns": attr.string_list(doc = "TODO", default = []),
     },
     environ = [
         "JAVA_HOME",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -776,7 +776,7 @@ pinned_coursier_fetch = repository_rule(
             default = False,
         ),
         "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
-        "jetify_include_patterns": attr.string_list(doc = "TODO", default = []),
+        "jetify_include_patterns": attr.string_list(doc = "TODO", default = ["contains(:)"]),
     },
     implementation = _pinned_coursier_fetch_impl,
 )
@@ -817,7 +817,7 @@ coursier_fetch = repository_rule(
         ),
         "resolve_timeout": attr.int(default = 600),
         "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
-        "jetify_include_patterns": attr.string_list(doc = "TODO", default = []),
+        "jetify_include_patterns": attr.string_list(doc = "TODO", default = ["contains(:)"]),
     },
     environ = [
         "JAVA_HOME",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -776,7 +776,7 @@ pinned_coursier_fetch = repository_rule(
             default = False,
         ),
         "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
-        "jetify_exclude_patterns": attr.string_list(doc = "TODO", default = []),
+        "jetify_include_patterns": attr.string_list(doc = "TODO", default = []),
     },
     implementation = _pinned_coursier_fetch_impl,
 )
@@ -817,7 +817,7 @@ coursier_fetch = repository_rule(
         ),
         "resolve_timeout": attr.int(default = 600),
         "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
-        "jetify_exclude_patterns": attr.string_list(doc = "TODO", default = []),
+        "jetify_include_patterns": attr.string_list(doc = "TODO", default = []),
     },
     environ = [
         "JAVA_HOME",

--- a/defs.bzl
+++ b/defs.bzl
@@ -31,7 +31,8 @@ def maven_install(
         override_targets = {},
         strict_visibility = False,
         resolve_timeout = 600,
-        jetify = False):
+        jetify = False,
+        jetify_exclude_patterns = []):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -107,6 +108,7 @@ def maven_install(
         maven_install_json = maven_install_json,
         resolve_timeout = resolve_timeout,
         jetify = jetify,
+        jetify_exclude_patterns = jetify_exclude_patterns,
     )
 
     if maven_install_json != None:
@@ -120,6 +122,7 @@ def maven_install(
             override_targets = override_targets,
             strict_visibility = strict_visibility,
             jetify = jetify,
+            jetify_exclude_patterns = jetify_exclude_patterns,
         )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):

--- a/defs.bzl
+++ b/defs.bzl
@@ -32,7 +32,7 @@ def maven_install(
         strict_visibility = False,
         resolve_timeout = 600,
         jetify = False,
-        jetify_exclude_patterns = []):
+        jetify_include_patterns = []):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -108,7 +108,7 @@ def maven_install(
         maven_install_json = maven_install_json,
         resolve_timeout = resolve_timeout,
         jetify = jetify,
-        jetify_exclude_patterns = jetify_exclude_patterns,
+        jetify_include_patterns = jetify_include_patterns,
     )
 
     if maven_install_json != None:
@@ -122,7 +122,7 @@ def maven_install(
             override_targets = override_targets,
             strict_visibility = strict_visibility,
             jetify = jetify,
-            jetify_exclude_patterns = jetify_exclude_patterns,
+            jetify_include_patterns = jetify_include_patterns,
         )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):


### PR DESCRIPTION
Allows user to include only certain artifacts for jetification. 

Since Starlark doesn't support Regex, I decided to allow few Starlark supported string comparison patterns applied against simple coords `groupId:artifactId`:

- `equals(x)`
- `contains(x)`
- `startswith(x)`
- `endswith(x)`

This is not complete yet (but already works!), I'd like to get feedback on the approach first, hope you'll find it let's say "interesting" 😅 