### PR TITLE
Add a build setting `--//setting:stamp_manifest` to disable Target-Label stamping.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,11 +9,14 @@ tasks:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
+    test_flags:
+      - "--//settings:stamp_manifest=True"
     test_targets:
       - "//..."
       # manual tests
       # TODO: Re-enable after fixing https://github.com/bazelbuild/rules_jvm_external/issues/375
       # - "//tests/integration:UnsafeSharedCacheTest"
+      - "//tests/unit/manifest_stamp:diff_manifest_test" # https://github.com/bazelbuild/rules_jvm_external/issues/283
   rbe_ubuntu1604:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
@@ -72,10 +75,13 @@ tasks:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
+    test_flags:
+      - "--//settings:stamp_manifest=True"
     test_targets:
       - "//..."
       # manual tests
       - "//tests/integration:UnsafeSharedCacheTest"
+      - "//tests/unit/manifest_stamp:diff_manifest_test" # https://github.com/bazelbuild/rules_jvm_external/issues/283
   windows:
     environment:
       # This tests custom cache locations.

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,10 @@
 ---
 tasks:
   ubuntu1604:
+    environment:
+      # This tests custom cache locations.
+      # https://github.com/bazelbuild/rules_jvm_external/pull/316
+      COURSIER_CACHE: /tmp/custom_coursier_cache
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,10 +1,6 @@
 ---
 tasks:
   ubuntu1604:
-    environment:
-      # This tests custom cache locations.
-      # https://github.com/bazelbuild/rules_jvm_external/pull/316
-      COURSIER_CACHE: /tmp/custom_coursier_cache
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,0 @@
-build --repo_env=COURSIER_CACHE=/tmp/custom_coursier_cache

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --repo_env=COURSIER_CACHE=/tmp/custom_coursier_cache

--- a/settings/BUILD
+++ b/settings/BUILD
@@ -1,0 +1,10 @@
+load("//settings:stamp_manifest.bzl", "stamp_manifest")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+stamp_manifest(
+    name = "stamp_manifest",
+    build_setting_default = True,
+)

--- a/settings/BUILD
+++ b/settings/BUILD
@@ -6,5 +6,5 @@ package(
 
 stamp_manifest(
     name = "stamp_manifest",
-    build_setting_default = True,
+    build_setting_default = False,
 )

--- a/settings/stamp_manifest.bzl
+++ b/settings/stamp_manifest.bzl
@@ -1,0 +1,9 @@
+StampManifestProvider = provider(fields = ['stamp_enabled'])
+
+def _impl(ctx):
+    return StampManifestProvider(stamp_enabled = ctx.build_setting_value)
+
+stamp_manifest = rule(
+    implementation = _impl,
+    build_setting = config.bool(flag = True)
+)

--- a/settings/stamp_manifest.bzl
+++ b/settings/stamp_manifest.bzl
@@ -5,5 +5,5 @@ def _impl(ctx):
 
 stamp_manifest = rule(
     implementation = _impl,
-    build_setting = config.bool(flag = False)
+    build_setting = config.bool(flag = True)
 )

--- a/settings/stamp_manifest.bzl
+++ b/settings/stamp_manifest.bzl
@@ -5,5 +5,5 @@ def _impl(ctx):
 
 stamp_manifest = rule(
     implementation = _impl,
-    build_setting = config.bool(flag = True)
+    build_setting = config.bool(flag = False)
 )

--- a/tests/unit/manifest_stamp/BUILD
+++ b/tests/unit/manifest_stamp/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@rules_jvm_external//settings:stamp_manifest.bzl", "stamp_manifest")
 
 build_test(
     name = "artifacts",

--- a/tests/unit/manifest_stamp/BUILD
+++ b/tests/unit/manifest_stamp/BUILD
@@ -31,6 +31,9 @@ diff_test(
         "//conditions:default": "guava_MANIFEST.MF.golden.unix",
     }),
     file2 = "guava_MANIFEST.MF",
+    # TODO(https://github.com/bazelbuild/rules_jvm_external/issues/283): Fix reproducibility issues.
+    # This test requires --//settings:stamp_manifest.
+    tags = ["manual"],
 )
 
 genrule(


### PR DESCRIPTION
There are a few reports of jar stamping being non-deterministic. This PR adds an ability to enable or disable the `Target-Label` stamping by passing the flag `--@rules_jvm_external//setting:stamp_manifest`.