### PR TITLE
Add jetify_include_list to jetify only specific artifacts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -321,6 +321,9 @@ maven_install(
         "https://maven.google.com",
     ],
     jetify = True,
+    jetify_include_list = [
+        "com.android.support:appcompat-v7",
+    ]
 )
 
 RULES_KOTLIN_VERSION = "8ca948548159f288450516a09248dcfb9e957804"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -311,7 +311,7 @@ maven_install(
 )
 
 maven_install(
-    name = "jetify_test",
+    name = "jetify_all_test",
     artifacts = [
         "com.google.guava:guava:27.0-jre",
         "com.android.support:appcompat-v7:28.0.0"
@@ -321,9 +321,23 @@ maven_install(
         "https://maven.google.com",
     ],
     jetify = True,
+)
+
+maven_install(
+    name = "jetify_include_list_test",
+    artifacts = [
+        "com.google.guava:guava:27.0-jre",
+        "com.android.support:appcompat-v7:28.0.0",
+        "com.android.support:swiperefreshlayout:28.0.0",
+    ],
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+    ],
+    jetify = True,
     jetify_include_list = [
         "com.android.support:appcompat-v7",
-    ]
+    ],
 )
 
 RULES_KOTLIN_VERSION = "8ca948548159f288450516a09248dcfb9e957804"

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -781,7 +781,7 @@ pinned_coursier_fetch = repository_rule(
             """,
             default = False,
         ),
-        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
+        "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
     },
     implementation = _pinned_coursier_fetch_impl,
@@ -822,7 +822,7 @@ coursier_fetch = repository_rule(
             default = False,
         ),
         "resolve_timeout": attr.int(default = 600),
-        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
+        "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
     },
     environ = [

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -14,7 +14,7 @@
 load("//third_party/bazel_json/lib:json_parser.bzl", "json_parse")
 load("//:specs.bzl", "utils")
 load("//:private/proxy.bzl", "get_java_proxy_args")
-load("//:private/dependency_tree_parser.bzl", "parser")
+load("//:private/dependency_tree_parser.bzl", "parser", "JETIFY_INCLUDE_LIST_JETIFY_ALL")
 load("//:private/coursier_utilities.bzl", "SUPPORTED_PACKAGING_TYPES", "escape")
 load(
     "//:private/versions.bzl",
@@ -775,7 +775,8 @@ pinned_coursier_fetch = repository_rule(
             """,
             default = False,
         ),
-        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False)
+        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
+        "jetify_include_list": attr.string_list(doc="List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
     },
     implementation = _pinned_coursier_fetch_impl,
 )
@@ -815,7 +816,8 @@ coursier_fetch = repository_rule(
             default = False,
         ),
         "resolve_timeout": attr.int(default = 600),
-        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False)
+        "jetify": attr.bool(doc = "Runs the AndroidX Jetifier tool on all artifacts.", default = False),
+        "jetify_include_list": attr.string_list(doc="List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
     },
     environ = [
         "JAVA_HOME",

--- a/defs.bzl
+++ b/defs.bzl
@@ -14,6 +14,7 @@
 
 load(":coursier.bzl", "coursier_fetch", "pinned_coursier_fetch")
 load(":specs.bzl", "json", "parse")
+load("//:private/dependency_tree_parser.bzl", "JETIFY_INCLUDE_LIST_JETIFY_ALL")
 
 DEFAULT_REPOSITORY_NAME = "maven"
 
@@ -31,7 +32,8 @@ def maven_install(
         override_targets = {},
         strict_visibility = False,
         resolve_timeout = 600,
-        jetify = False):
+        jetify = False,
+        jetify_include_list = JETIFY_INCLUDE_LIST_JETIFY_ALL):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -64,6 +66,7 @@ def maven_install(
         visible to user's rules.
       resolve_timeout: The execution timeout of resolving and fetching artifacts.
       jetify: Runs the AndroidX jetifier tool on all artifacts.
+      jetify_include_list: List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.
     """
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -107,6 +110,7 @@ def maven_install(
         maven_install_json = maven_install_json,
         resolve_timeout = resolve_timeout,
         jetify = jetify,
+        jetify_include_list = jetify_include_list,
     )
 
     if maven_install_json != None:
@@ -120,6 +124,7 @@ def maven_install(
             override_targets = override_targets,
             strict_visibility = strict_visibility,
             jetify = jetify,
+            jetify_include_list = jetify_include_list,
         )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):

--- a/defs.bzl
+++ b/defs.bzl
@@ -65,7 +65,7 @@ def maven_install(
         are private and invisible to user's rules. If `False`, transitive dependencies are public and
         visible to user's rules.
       resolve_timeout: The execution timeout of resolving and fetching artifacts.
-      jetify: Runs the AndroidX jetifier tool on all artifacts.
+      jetify: Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.
       jetify_include_list: List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.
     """
     repositories_json_strings = []

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -19,7 +19,7 @@ into target declarations (jvm_import) for the final @maven//:BUILD file.
 
 load("//:private/coursier_utilities.bzl", "SUPPORTED_PACKAGING_TYPES", "escape", "strip_packaging_and_classifier", "strip_packaging_and_classifier_and_version")
 
-JETIFY_INCLUDE_LIST_JETIFY_ALL = ["_PRIVATE_RULES_JVM_EXTERNAL_JETIFY_ALL_"]
+JETIFY_INCLUDE_LIST_JETIFY_ALL = ["*"]
 
 def _genrule_copy_artifact_from_http_file(artifact):
     http_file_repository = escape(artifact["coord"])

--- a/tests/unit/jetifier/BUILD
+++ b/tests/unit/jetifier/BUILD
@@ -1,24 +1,64 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 build_test(
-    name = "jetified_artifacts",
+    name = "jetify_all_artifacts",
     targets = [
-        "@jetify_test//:com_google_guava_guava",
-        "@jetify_test//:com_android_support_appcompat_v7",
+        "@jetify_all_test//:com_google_guava_guava",
+        "@jetify_all_test//:com_android_support_appcompat_v7",
     ],
 )
 
 genrule(
-    name = "jetified_support_library_classes",
-    srcs = ["@jetify_test//:jetified_com_android_support_appcompat_v7"],
-    outs = ["jetified_classes.jar"],
+    name = "jetify_all_support_library_classes",
+    srcs = ["@jetify_all_test//:jetified_com_android_support_appcompat_v7"],
+    outs = ["jetify_all_jetified_classes.jar"],
     cmd = "unzip -p $< classes.jar > $@",
 )
 
 sh_test(
-    name = "test_jetified_classes_jar",
+    name = "test_jetify_all_classes_jar",
     size = "small",
-    srcs = ["jetifier_test.sh"],
-    data = [":jetified_classes.jar"],
+    srcs = ["jetify_all_test.sh"],
+    data = [":jetify_all_jetified_classes.jar"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+build_test(
+    name = "jetify_include_list_artifacts",
+    targets = [
+        "@jetify_include_list_test//:com_google_guava_guava",
+        "@jetify_include_list_test//:com_android_support_appcompat_v7",
+    ],
+)
+
+genrule(
+    name = "jetify_include_list_classes",
+    srcs = [
+        "@jetify_include_list_test//:jetified_com_android_support_appcompat_v7",
+        "@jetify_include_list_test//:com_android_support_swiperefreshlayout",
+    ],
+    outs = ["jetify_include_list_classes.txt"],
+    cmd = """
+    for SRC in $(SRCS)
+    do
+        if [[ $$SRC == *.aar ]]; then
+            mkdir aar
+            unzip -q -d aar $$SRC
+            if [[ -f aar/classes.jar ]]; then
+                jar tf aar/classes.jar >> $@;
+            fi
+            rm -rf aar
+        elif [[ $$SRC == *.jar ]]; then
+            jar tf $$SRC >> $@
+        fi
+    done
+    """,
+)
+
+sh_test(
+    name = "test_jetify_include_list_classes_jar",
+    size = "small",
+    srcs = ["jetify_include_list_test.sh"],
+    data = [":jetify_include_list_classes.txt"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/tests/unit/jetifier/jetify_all_test.sh
+++ b/tests/unit/jetifier/jetify_all_test.sh
@@ -9,11 +9,9 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-set -euxo pipefail
+set -euox pipefail
 
-readonly classes_jar=$(rlocation rules_jvm_external/tests/unit/jetifier/jetify_all_jetified_classes.jar)
-
-jar tf $classes_jar
+classes_jar=$(rlocation rules_jvm_external/tests/unit/jetifier/jetify_all_jetified_classes.jar)
 
 jar tf $classes_jar | grep "androidx/appcompat"
 jar tf $classes_jar | grep -v "android/support/v7"

--- a/tests/unit/jetifier/jetify_all_test.sh
+++ b/tests/unit/jetifier/jetify_all_test.sh
@@ -1,0 +1,19 @@
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euxo pipefail
+
+readonly classes_jar=$(rlocation rules_jvm_external/tests/unit/jetifier/jetify_all_jetified_classes.jar)
+
+jar tf $classes_jar
+
+jar tf $classes_jar | grep "androidx/appcompat"
+jar tf $classes_jar | grep -v "android/support/v7"

--- a/tests/unit/jetifier/jetify_include_list_test.sh
+++ b/tests/unit/jetifier/jetify_include_list_test.sh
@@ -9,9 +9,14 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-set -euox pipefail
+set -euxo pipefail
 
-classes_jar=$(rlocation rules_jvm_external/tests/unit/jetifier/jetified_classes.jar)
+readonly classes_txt=$(rlocation rules_jvm_external/tests/unit/jetifier/jetify_include_list_classes.txt)
 
-jar tf $classes_jar | grep "androidx/appcompat"
-jar tf $classes_jar | grep -v "android/support/v7"
+# support-appcompat is in the jetify_include_list, we expect it to be jetified
+grep "androidx/appcompat" "$classes_txt"
+! grep "android/support/v7" "$classes_txt"
+
+# swiperefreshlayout is not in the jetify_include_list, we do NOT expect it to be jetified
+grep "android/support/v4/widget/SwipeRefreshLayout" "$classes_txt"
+! grep "androidx/swiperefreshlayout/widget/SwipeRefreshLayout" "$classes_txt"


### PR DESCRIPTION
Allows user to include only certain artifacts for jetification.

This is not a breaking change as it keeps the default behavior intact, if user only sets `jetify = True` — all artifacts are jetified.

If user sets `jetify = True` **and** `jetify_include_list = [ … ]` then only included artifacts are jetified.

This allows to improve build times by avoiding jetification of artifacts that don't need it and avoid Jetifier bugs when it corrupts an artifact (haven't seen that in a while, but it was the case in past with some libraries).

This is a replacement for #348 as discussed in that PR.