### PR TITLE
Preserver jar filename when stamping

### DIFF
--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -21,7 +21,7 @@ def _jvm_import_impl(ctx):
         },
     )
 
-    outjar = ctx.actions.declare_file("stamped_" + injar.basename, sibling = injar)
+    outjar = ctx.actions.declare_file("stamped/" + injar.basename, sibling = injar)
     ctx.actions.run_shell(
         inputs = [injar, manifest_update_file] + ctx.files._host_javabase,
         outputs = [outjar],

--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -21,7 +21,8 @@ def _jvm_import_impl(ctx):
         },
     )
 
-    outjar = ctx.actions.declare_file("stamped/" + injar.basename, sibling = injar)
+    outjar_name = injar.basename[:-4] + '_stamped.jar'
+    outjar = ctx.actions.declare_file(outjar_name, sibling = injar)
     ctx.actions.run_shell(
         inputs = [injar, manifest_update_file] + ctx.files._host_javabase,
         outputs = [outjar],


### PR DESCRIPTION
After updating to version 3.1 (from 2.9) all external libraries in idea got a prefix `stamped_`

<img width="347" alt="screenshot 2020-01-24 в 0 51 15" src="https://user-images.githubusercontent.com/423802/73027027-b34b2a00-3e43-11ea-9395-6ad94ca9b2b1.png">

Its not a problem on its own.
But there is problem with idea plugin:
[It looks](https://github.com/bazelbuild/intellij/blob/c240371fbc3b3756b5faa2fa7f60130cb22327b2/scala/src/com/google/idea/blaze/scala/sync/BlazeScalaSyncPlugin.java#L78) for libraries which start with `scala-library` to configure scala sdk.

This fix will keep original jar names so they will be imported to idea with their original names