### PR TITLE
use jq instead of python to format the pinned JSON (fixes #395)

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -22,15 +22,24 @@ load(
     "COURSIER_CLI_BAZEL_MIRROR_URL",
     "COURSIER_CLI_GITHUB_ASSET_URL",
     "COURSIER_CLI_SHA256",
+    "JQ_VERSIONS",
 )
 
 _BUILD = """
 package(default_visibility = ["//visibility:{visibility}"])
 
-exports_files(["pin"])
-
 load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
 load("@rules_jvm_external//private/rules:jetifier.bzl", "jetify_aar_import", "jetify_jvm_import")
+
+sh_binary(
+    name = "pin",
+    srcs = ["pin.sh"],
+    data = select({{
+        "@bazel_tools//src/conditions:linux_x86_64": ["@rules_jvm_external_jq_linux//file"],
+        "@bazel_tools//src/conditions:darwin": ["@rules_jvm_external_jq_osx//file"],
+        "@bazel_tools//src/conditions:windows": ["@rules_jvm_external_jq_windows//file"],
+    }}),
+)
 
 {imports}
 """
@@ -217,6 +226,22 @@ def get_home_netrc_contents(repository_ctx):
                 return repository_ctx.read(netrcfile)
     return ""
 
+def get_jq_http_files():
+    '''Returns repository targets for the `jq` dependency that `pin.sh` needs.'''
+    lines = []
+    for jq in JQ_VERSIONS:
+        lines.extend([
+            "    maybe(",
+            "        http_file,",
+            "        name = \"rules_jvm_external_jq_%s\"," % jq.os,
+            "        urls = %s," % repr([jq.url]),
+            "        sha256 = %s," % repr(jq.sha256),
+            "        downloaded_file_path = \"jq\",",
+            "        executable = True,",
+            "    )",
+        ])
+    return lines
+
 def _pinned_coursier_fetch_impl(repository_ctx):
     if not repository_ctx.attr.maven_install_json:
         fail("Please specify the file label to maven_install.json (e.g." +
@@ -281,6 +306,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
     # pinned_maven_install()
     http_files = [
         "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_file\")",
+        "load(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")",
         "def pinned_maven_install():",
     ]
     netrc_entries = {}
@@ -308,6 +334,9 @@ def _pinned_coursier_fetch_impl(repository_ctx):
                 # contains the mirror_urls field.
                 http_files.append("        urls = [\"%s\"]," % artifact["url"])
             http_files.append("    )")
+
+    http_files.extend(get_jq_http_files())
+
     repository_ctx.file("defs.bzl", "\n".join(http_files), executable = False)
     repository_ctx.file(
         "netrc",
@@ -745,22 +774,22 @@ def _coursier_fetch_impl(repository_ctx):
         override_targets = repository_ctx.attr.override_targets,
     )
 
-    repository_ctx.file(
-        "BUILD",
-        _BUILD.format(
-            visibility = "private" if repository_ctx.attr.strict_visibility else "public",
-            repository_name = repository_ctx.name,
-            imports = generated_imports,
-        ),
-        False,  # not executable
-    )
-
     # This repository rule can be either in the pinned or unpinned state, depending on when
     # the user invokes artifact pinning. Normalize the repository name here.
     if repository_ctx.name.startswith("unpinned_"):
         repository_name = repository_ctx.name[len("unpinned_"):]
     else:
         repository_name = repository_ctx.name
+
+    repository_ctx.file(
+        "BUILD",
+        _BUILD.format(
+            visibility = "private" if repository_ctx.attr.strict_visibility else "public",
+            repository_name = repository_name,
+            imports = generated_imports,
+        ),
+        False,  # not executable
+    )
 
     # If maven_install.json has already been used in maven_install,
     # we don't need to instruct user to update WORKSPACE and load pinned_maven_install.
@@ -788,7 +817,7 @@ def _coursier_fetch_impl(repository_ctx):
     # Create the maven_install.json export script for unpinned repositories.
     dependency_tree_json = "{ \"dependency_tree\": " + repr(dep_tree).replace("None", "null") + "}"
     repository_ctx.template(
-        "pin",
+        "pin.sh",
         repository_ctx.attr._pin,
         {
             "{maven_install_location}": "$BUILD_WORKSPACE_DIRECTORY/" + maven_install_location,
@@ -799,24 +828,15 @@ def _coursier_fetch_impl(repository_ctx):
         executable = True,
     )
 
-    # Generate a dummy 'defs.bzl' in the case where users have this
-    # in their WORKSPACE:
-    #
-    # maven_install(
-    #     name = "maven",
-    #     # maven_install_json = "//:maven_install.json",
-    # )
-    # load("@maven//:defs.bzl", "pinned_maven_install")
-    # pinned_maven_install()
-    #
-    # This scenario happens when users have a modified/corrupted
-    # 'maven_install.json' and wishes to re-generate one. Instead
-    # of asking users to also remove the load statement for
-    # pinned_maven_install(), we generate a dummy defs.bzl
-    # here so that builds will not fail due to a missing load.
+    # Generate 'defs.bzl' with just the dependencies for ':pin'.
+    http_files = [
+        "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_file\")",
+        "load(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")",
+        "def pinned_maven_install():",
+    ] + get_jq_http_files()
     repository_ctx.file(
         "defs.bzl",
-        "def pinned_maven_install():\n    pass",
+        "\n".join(http_files),
         executable = False,
     )
 

--- a/private/versions.bzl
+++ b/private/versions.bzl
@@ -6,3 +6,21 @@ COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/d
 # Run 'bazel run //:mirror_coursier' to upload a copy of the jar to the Bazel mirror.
 COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
 COURSIER_CLI_SHA256 = "6598d9277705ad8369a4f9c64217fbc31c19234f2cbcca9b1e5c4300a3abb317"
+
+JQ_VERSIONS = [
+    struct(
+        os = "linux",
+        url = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64",
+        sha256 = "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44",
+    ),
+    struct(
+        os = "osx",
+        url = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64",
+        sha256 = "5c0a0a3ea600f302ee458b30317425dd9632d1ad8882259fcaf4e9b868b2b1ef",
+    ),
+    struct(
+        os = "windows",
+        url = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-win64.exe",
+        sha256 = "a51d36968dcbdeabb3142c6f5cf9b401a65dc3a095f3144bd0c118d5bb192753",
+    ),
+]

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -22,6 +22,7 @@ genquery(
         "@testonly_testing//:com_google_code_findbugs_jsr305",
         "@testonly_testing//:com_google_auto_value_auto_value_annotations_1_6_3",
         "@testonly_testing//:com_google_auto_value_auto_value_annotations",
+        "@testonly_testing//:pin",
     ],
     testonly = True,
 )


### PR DESCRIPTION
The formatted output is consistent with python2's `json.tool`.  No changes are required to how rules_jvm_external is added in the workspace nor how :pin is run.  I've tested on linux (centos) and OS X.

I didn't add jq for windows because I wasn't sure if pinning worked for windows at all, and I can't test it.  Should I add that as well?