### PR TITLE
Allow for custom coursier download url via COURSIER_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,18 @@ The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
 will create independent caches for each `maven_install` repository, located at
 `$(bazel info output_base)/external/@<repository_name>/v1`.
 
+### Using a custom Coursier download url
+
+By default bazel bootstraps Coursier via [the urls specificed in versions.bzl](private/versions.bzl).
+However in case they are not directly accessible in your environment, you can also specify a custom
+url to download Coursier. For example:
+
+```
+$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=COURSIER_URL='https://my_secret_host.com/vXYZ/coursier.jar'
+```
+
+Please note it still requires the SHA to match.
+
 ### `artifact` helper macro
 
 The `artifact` macro translates the artifact's `group:artifact` coordinates to

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -568,10 +568,16 @@ def _coursier_fetch_impl(repository_ctx):
     # caches and uses Coursier's own download mechanisms.
 
     # Download Coursier's standalone (deploy) jar from Maven repositories.
-    repository_ctx.download([
+    coursier_download_urls = [
         COURSIER_CLI_GITHUB_ASSET_URL,
         COURSIER_CLI_BAZEL_MIRROR_URL,
-    ], "coursier", sha256 = COURSIER_CLI_SHA256, executable = True)
+    ]
+
+    coursier_url_from_env = repository_ctx.os.environ.get("COURSIER_URL")
+    if coursier_url_from_env != None:
+        coursier_download_urls.append(coursier_url_from_env)
+
+    repository_ctx.download(coursier_download_urls, "coursier", sha256 = COURSIER_CLI_SHA256, executable = True)
 
     # Try running coursier once
     exec_result = repository_ctx.execute(
@@ -936,6 +942,7 @@ coursier_fetch = repository_rule(
         "no_proxy",
         "NO_PROXY",
         "COURSIER_CACHE",
+        "COURSIER_URL",
     ],
     implementation = _coursier_fetch_impl,
 )


### PR DESCRIPTION
### Problem

Coursier download urls are hardcoded, hurdling firewalled environments without additional proxy support.

### Solution

Use `COURSIER_URL` specify a custom download url.

Addresses #389