### PR TITLE
Add stamp_manifests option to maven_install so you can stamp manifests on a per maven_install basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,26 @@ maven_install(
 )
 ```
 
+### Stamping manifests for buildozer missing dependency support
+
+If you want more helpful messages when you are missing dependencies from this
+`maven_install` you can enable `stamp_manifests` to have Target-Label entries
+added to the manifests of the imported jar files.  The Target-Label entry provides
+Bazel with enough information to give you a `buildozer` command when a target is
+missing a dependency instead of just the path to the jar file.
+
+```python
+maven_install(
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    stamp_manifests = True
+)
+```
+
 ### Jetifier
 
 As part of the [Android
@@ -826,7 +846,7 @@ migration, convert legacy Android support library (`com.android.support`)
 libraries to rely on new AndroidX packages using the
 [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool.
 Enable jetification by specifying `jetify = True` in `maven_install.`
-Control which artifacts to jetify with `jetify_include_list` — list of artifacts that need to be jetified in `groupId:artifactId` format. 
+Control which artifacts to jetify with `jetify_include_list` — list of artifacts that need to be jetified in `groupId:artifactId` format.
 By default all artifacts are jetified if `jetify` is set to True.
 
 NOTE: There is a performance penalty to using jetifier due to modifying fetched binaries, fetching

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -891,6 +891,7 @@ pinned_coursier_fetch = repository_rule(
         "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
         "additional_netrc_lines": attr.string_list(doc = "Additional lines prepended to the netrc file used by `http_file` (with `maven_install_json` only).", default = []),
+        "stamp_manifests": attr.bool(doc = "Add Target-Label entry to manifests of jar files", default = False),
     },
     implementation = _pinned_coursier_fetch_impl,
 )
@@ -932,6 +933,7 @@ coursier_fetch = repository_rule(
         "resolve_timeout": attr.int(default = 600),
         "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
+        "stamp_manifests": attr.bool(doc = "Add Target-Label entry to manifests of jar files", default = False),
     },
     environ = [
         "JAVA_HOME",

--- a/defs.bzl
+++ b/defs.bzl
@@ -34,7 +34,8 @@ def maven_install(
         resolve_timeout = 600,
         jetify = False,
         jetify_include_list = JETIFY_INCLUDE_LIST_JETIFY_ALL,
-        additional_netrc_lines = []):
+        additional_netrc_lines = [],
+        stamp_manifests = False):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -69,6 +70,7 @@ def maven_install(
       jetify: Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.
       jetify_include_list: List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.
       additional_netrc_lines: Additional lines prepended to the netrc file used by `http_file` (with `maven_install_json` only).
+      stamp_manifests: Add Target-Label stamp information to manifests of jar files.
     """
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -116,6 +118,7 @@ def maven_install(
         resolve_timeout = resolve_timeout,
         jetify = jetify,
         jetify_include_list = jetify_include_list,
+        stamp_manifests = stamp_manifests,
     )
 
     if maven_install_json != None:
@@ -131,6 +134,7 @@ def maven_install(
             jetify = jetify,
             jetify_include_list = jetify_include_list,
             additional_netrc_lines = additional_netrc_lines,
+            stamp_manifests = stamp_manifests,
         )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -257,7 +257,24 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
                 target_import_string.append("\tvisibility = [\"//visibility:public\"],")
                 alias_visibility = "\tvisibility = [\"//visibility:public\"],\n"
 
-            # 9. Finish the java_import rule.
+            # 9. If `stamp_manifests` is True, add the stamp_manifest attribute
+            #
+            # java_import(
+            # 	name = "org_hamcrest_hamcrest_library",
+            # 	jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
+            # 	srcjar = "https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+            # 	deps = [
+            # 		":org_hamcrest_hamcrest_core",
+            # 	],
+            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #   neverlink = True,
+            #   testonly = True,
+            #   visibility = ["//visibility:public"],
+            #   stamp_manifest = True,
+            if repository_ctx.attr.stamp_manifests:
+                target_import_string.append("\tstamp_manifest = True,")
+
+            # 10. Finish the java_import rule.
             #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library",

--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -45,7 +45,7 @@ def _jvm_import_impl(ctx):
         progress_message = "Stamping the manifest of %s" % ctx.label,
     )
 
-    if not ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:
+    if (not ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled) and (not ctx.attr.stamp_manifest):
         outjar = injar
 
     return [
@@ -82,6 +82,9 @@ jvm_import = rule(
             providers = [JavaInfo],
         ),
         "neverlink": attr.bool(
+            default = False,
+        ),
+        "stamp_manifest": attr.bool(
             default = False,
         ),
         "_host_javabase": attr.label(


### PR DESCRIPTION
When trying to use the `--@rules_jvm_external//settings:stamp_manifest` option in a`.bazelrc` file the IJ plugin fails to sync with the message `ERROR: unknown key: '--@rules_jvm_external//settings:stamp_manifest'`.

Instead this PR adds a `stamp_manifests` option to `maven_install` so you can configure manifest stamping for each `maven_install` you setup and don't have to set the global option for all uses of the plugin.