### PR TITLE
Use coursier's default cache directory when fetching jars to update the install.json file

### DIFF
--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -371,23 +371,39 @@ def _get_coursier_cache_or_default_disabled_test(ctx):
     asserts.equals(
         env,
         "v1",
-        get_coursier_cache_or_default(mock_environ, False)
+        get_coursier_cache_or_default(mock_environ, "linux", False)
     )
     return unittest.end(env)
 
 get_coursier_cache_or_default_disabled_test = add_test(_get_coursier_cache_or_default_disabled_test)
 
-def _get_coursier_cache_or_default_enabled_with_default_location_test(ctx):
+def _get_coursier_cache_or_default_enabled_with_default_location_linux_test(ctx):
     env = unittest.begin(ctx)
-    mock_environ = {}
+    mock_environ = {
+        "HOME": "/home/testuser"
+    }
     asserts.equals(
         env,
-        "v1",
-        get_coursier_cache_or_default(mock_environ, True)
+        "/home/testuser/.cache/coursier/v1",
+        get_coursier_cache_or_default(mock_environ, "linux", True)
     )
     return unittest.end(env)
 
-get_coursier_cache_or_default_enabled_with_default_location_test = add_test(_get_coursier_cache_or_default_enabled_with_default_location_test)
+get_coursier_cache_or_default_enabled_with_default_location_linux_test = add_test(_get_coursier_cache_or_default_enabled_with_default_location_linux_test)
+
+def _get_coursier_cache_or_default_enabled_with_default_location_mac_test(ctx):
+    env = unittest.begin(ctx)
+    mock_environ = {
+        "HOME": "/Users/testuser"
+    }
+    asserts.equals(
+        env,
+        "/Users/testuser/Library/Caches/Coursier/v1",
+        get_coursier_cache_or_default(mock_environ, "mac", True)
+    )
+    return unittest.end(env)
+
+get_coursier_cache_or_default_enabled_with_default_location_mac_test = add_test(_get_coursier_cache_or_default_enabled_with_default_location_mac_test)
 
 def _get_coursier_cache_or_default_enabled_with_custom_location_test(ctx):
     env = unittest.begin(ctx)
@@ -397,7 +413,7 @@ def _get_coursier_cache_or_default_enabled_with_custom_location_test(ctx):
     asserts.equals(
         env,
         "/custom/location",
-        get_coursier_cache_or_default(mock_environ, True)
+        get_coursier_cache_or_default(mock_environ, "linux", True)
     )
     return unittest.end(env)
 


### PR DESCRIPTION
Every time I run `bazel run @unpinned_maven//:pin` it downloads every jar defined in the `maven_install` target because the @unpinned_maven repository is deleted every time it is "fetched".  Basically the Coursier cache used for fetching at `external/unpinned_maven/v1` is never re-used when you are updating the `maven_install.json` file.  

This PR changes the unpinned fetch so it uses Coursier's default cache locations or the COURSIER_CACHE env var for the cache.

By re-using the cache a `bazel run @unpinned_maven//:pin` update now takes around 60 seconds instead of 10-15 minutes when the cache is empty.