### PR TITLE
Add verbose mode to surface coursier stdout with RJE_VERBOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,7 +922,24 @@ You can find demos in the [`examples/`](./examples/) directory.
 Find other GitHub projects using `rules_jvm_external`
 [with this search query](https://github.com/search?p=1&q=rules_jvm_external+filename%3A%2FWORKSPACE+filename%3A%5C.bzl&type=Code).
 
-## Generating documentation
+## Developing this project
+
+### Verbose / debug mode
+
+Set the `RJE_VERBOSE` environment variable to print `coursier`'s verbose
+output. For example:
+
+```
+$ RJE_VERBOSE bazel run @unpinned_maven//:pin
+```
+
+### Tests
+
+```
+$ bazel test //...
+```
+
+### Generating documentation
 
 Use [Stardoc](https://skydoc.bazel.build/docs/getting_started_stardoc.html) to
 generate API documentation in the [docs](docs/) directory using

--- a/README.md
+++ b/README.md
@@ -926,11 +926,11 @@ Find other GitHub projects using `rules_jvm_external`
 
 ### Verbose / debug mode
 
-Set the `RJE_VERBOSE` environment variable to print `coursier`'s verbose
+Set the `RJE_VERBOSE` environment variable to `true` to print `coursier`'s verbose
 output. For example:
 
 ```
-$ RJE_VERBOSE bazel run @unpinned_maven//:pin
+$ RJE_VERBOSE=true bazel run @unpinned_maven//:pin
 ```
 
 ### Tests


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_jvm_external/issues/383

```
$ RJE_VERBOSE=true bazel run @unpinned_maven//:pin
DEBUG: /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:9:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:9: buildkite_config not using checked in configs; Bazel version 3.1.0 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"]}
  Dependencies:
com.google.guava:guava:27.0-jre:
org.hamcrest:hamcrest-core:2.1:
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.pom
Downloading https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom
Downloaded https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.pom
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.pom.md5
Downloading https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom.md5
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.pom.md5
Downloaded https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom.md5
Downloading https://jcenter.bintray.com/com/google/guava/guava-parent/27.0-jre/guava-parent-27.0-jre.pom
Downloaded https://jcenter.bintray.com/com/google/guava/guava-parent/27.0-jre/guava-parent-27.0-jre.pom
Downloading https://jcenter.bintray.com/com/google/guava/guava-parent/27.0-jre/guava-parent-27.0-jre.pom.md5
Downloaded https://jcenter.bintray.com/com/google/guava/guava-parent/27.0-jre/guava-parent-27.0-jre.pom.md5
Downloading https://jcenter.bintray.com/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
Downloaded https://jcenter.bintray.com/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
Downloading https://jcenter.bintray.com/org/sonatype/oss/oss-parent/9/oss-parent-9.pom.md5
Downloaded https://jcenter.bintray.com/org/sonatype/oss/oss-parent/9/oss-parent-9.pom.md5
Downloading https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.pom
Downloading https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.pom
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.pom
Downloading https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
Downloading https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom
Downloading https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.pom
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.pom
Downloading https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
Downloaded https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.pom
Downloading https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.pom
Downloaded https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
Downloading https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.pom.md5
Downloaded https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.pom
Downloading https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.pom.md5
Downloaded https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
Downloading https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom.md5
Downloaded https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.pom
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.pom
Downloading https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.pom.md5
Downloading https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom.md5
Downloaded https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom
Downloading https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.pom.md5
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.pom.md5
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.pom.md5
Downloaded https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.pom.md5
Downloading https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom.md5
Downloaded https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom.md5
Downloaded https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.pom.md5
Downloaded https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom.md5
Downloaded https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.pom.md5
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.pom.md5
Downloaded https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom.md5
Downloading https://jcenter.bintray.com/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom
Downloading https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-parent/1.17/animal-sniffer-parent-1.17.pom
Downloading https://jcenter.bintray.com/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom
Downloading https://jcenter.bintray.com/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-parent/1.17/animal-sniffer-parent-1.17.pom
Downloading https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-parent/1.17/animal-sniffer-parent-1.17.pom.md5
Downloaded https://jcenter.bintray.com/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Downloading https://jcenter.bintray.com/org/sonatype/oss/oss-parent/7/oss-parent-7.pom.md5
Downloaded https://jcenter.bintray.com/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom
Downloading https://jcenter.bintray.com/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom.md5
Downloaded https://jcenter.bintray.com/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom
Downloading https://jcenter.bintray.com/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom.md5
Downloaded https://jcenter.bintray.com/org/sonatype/oss/oss-parent/7/oss-parent-7.pom.md5
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-parent/1.17/animal-sniffer-parent-1.17.pom.md5
Downloaded https://jcenter.bintray.com/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom.md5
Downloaded https://jcenter.bintray.com/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom.md5
Downloading https://jcenter.bintray.com/org/codehaus/mojo/mojo-parent/40/mojo-parent-40.pom
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/mojo-parent/40/mojo-parent-40.pom
Downloading https://jcenter.bintray.com/org/codehaus/mojo/mojo-parent/40/mojo-parent-40.pom.md5
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/mojo-parent/40/mojo-parent-40.pom.md5
Downloading https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar
Downloading https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar
Downloading https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar
Downloading https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar
Downloaded https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar
Downloading https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar
Downloading https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar
Downloading https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar
Downloaded https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar
Downloading https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
Downloaded https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar
Downloading https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar.md5
Downloaded https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar.md5
Downloaded https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
Downloading https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar.md5
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar
Downloading https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar.md5
Downloaded https://jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar.md5
Downloading https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar.md5
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar.md5
Downloading https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar.md5
Downloaded https://jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar.md5
Downloading https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar.md5
Downloaded https://jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar.md5
Downloading https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar.md5
Downloaded https://jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar.md5
Downloaded https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar.md5
Downloaded https://jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar.md5
Downloaded https://jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar.md5
Downloaded https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar
Downloading https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar.md5
Downloaded https://jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar.md5
Downloaded https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar
Downloading https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar.md5
Downloading https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar.sha1
Downloaded https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar.sha1
Downloaded https://jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar.md5
v1/https/jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar
v1/https/jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar
v1/https/jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar
v1/https/jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar
v1/https/jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar
v1/https/jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar
v1/https/jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
v1/https/jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar
v1/https/jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar
v1/https/jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar
766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar
6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar
d084bef9cd07a8537a1753e4850a69b7e8bab1d1e22e9f3a1e4826309a7a2336 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar
63b09db6861011e7fb2481be7790c7fd4b03f0bb884b3de2ecba8823ad19bf3f /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar
b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar
64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar
92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar
e09109e54a289d88506b9bfec987ddd199f4217c9464132668351b9a4f00bee9 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar
ba93b2e3a562322ba432f0a1b53addcc55cb188253319a020ed77f824e692050 /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/unpinned_maven/v1/https/jcenter.bintray.com/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar
INFO: Analyzed target @unpinned_maven//:pin (3 packages loaded, 10 targets configured).
INFO: Found 1 target...
Target @unpinned_maven//:pin up-to-date:
  bazel-bin/external/unpinned_maven/pin
INFO: Elapsed time: 24.341s, Critical Path: 0.02s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
DEBUG: /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:9:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/8484bc4fff18ee4a905b69a9ddb0e143/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:9: buildkite_config not using checked in configs; Bazel version 3.1.0 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"]}
Successfully pinned resolved artifacts for @maven, /usr/local/google/home/jingwen/code/rules_jvm_external/maven_install.json is now up-to-date.
```