### PR TITLE
Make behaviour when merging duplicates configurable

### DIFF
--- a/private/tools/java/rules/jvm/external/jar/DuplicateEntryStrategy.java
+++ b/private/tools/java/rules/jvm/external/jar/DuplicateEntryStrategy.java
@@ -1,0 +1,72 @@
+package rules.jvm.external.jar;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.joining;
+
+enum DuplicateEntryStrategy {
+
+  LAST_IN_WINS("last-wins") {
+    @Override
+    public void resolve(Path current, InputStream inputStreamForDuplicate) throws IOException {
+      try (OutputStream os = Files.newOutputStream(current, TRUNCATE_EXISTING)) {
+        ByteStreams.copy(inputStreamForDuplicate, os);
+      }
+    }
+  },
+  FIRST_IN_WINS("first-wins") {
+    @Override
+    public void resolve(Path current, InputStream inputStreamForDuplicate) {
+      // No need to do anything.
+    }
+  },
+  IS_ERROR("are-errors") {
+    @Override
+    public void resolve(Path current, InputStream inputStreamForDuplicate) throws IOException {
+      HashFunction hashFunction = Hashing.goodFastHash(64);
+
+      HashCode first = hashFunction.hashBytes(Files.readAllBytes(current));
+      HashCode second = hashFunction.hashBytes(ByteStreams.toByteArray(inputStreamForDuplicate));
+
+      if (first.equals(second)) {
+        return;
+      }
+      throw new IOException("Attempt to write different duplicate file for: " + current);
+    }
+  };
+
+  private final String shortName;
+
+  DuplicateEntryStrategy(String shortName) {
+    this.shortName = shortName;
+  }
+
+  public static DuplicateEntryStrategy fromShortName(String name) {
+    for (DuplicateEntryStrategy value : DuplicateEntryStrategy.values()) {
+      if (value.shortName.equals(name)) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException(String.format(
+        "Unable to find matching short name for %s. Valid options are: %s",
+        name,
+        Arrays.stream(values()).map(v -> v.shortName).collect(joining(", "))));
+  }
+
+  public String toString() {
+    return shortName;
+  }
+
+  public abstract void resolve(Path current, InputStream inputStreamForDuplicate) throws IOException;
+}

--- a/private/tools/java/rules/jvm/external/zip/BUILD.bazel
+++ b/private/tools/java/rules/jvm/external/zip/BUILD.bazel
@@ -3,5 +3,6 @@ java_library(
     srcs = glob(["*.java"]),
     visibility = [
         "//private/tools/java:__subpackages__",
+        "//tests:__subpackages__",
     ],
 )

--- a/tests/com/jvm/external/jar/BUILD
+++ b/tests/com/jvm/external/jar/BUILD
@@ -1,0 +1,12 @@
+load("//:defs.bzl", "artifact")
+
+java_test(
+    name = "MergeJarsTest",
+    test_class = "com.jvm.external.jar.MergeJarsTest",
+    srcs = ["MergeJarsTest.java"],
+    deps = [
+        "//private/tools/java/rules/jvm/external/jar:MergeJars",
+        "//private/tools/java/rules/jvm/external/zip",
+        artifact("com.google.guava:guava"),
+    ]
+)

--- a/tests/com/jvm/external/jar/MergeJarsTest.java
+++ b/tests/com/jvm/external/jar/MergeJarsTest.java
@@ -1,0 +1,195 @@
+package com.jvm.external.jar;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import rules.jvm.external.jar.MergeJars;
+import rules.jvm.external.zip.StableZipEntry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MergeJarsTest {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void shouldGenerateAnEmptyJarIfNoSourcesAreGiven() throws IOException {
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{"--output", outputJar.toAbsolutePath().toString()});
+
+    assertTrue(Files.exists(outputJar));
+    assertTrue(Files.size(outputJar) > 0);
+  }
+
+  @Test
+  public void shouldGenerateAJarContainingAllTheClassesFromASingleSource() throws IOException {
+    Path inputOne = temp.newFile("first.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--sources", inputOne.toAbsolutePath().toString()});
+
+    Map<String, String> contents = readJar(outputJar);
+    // We expect the manifest and one file
+    assertEquals(2, contents.size());
+    assertEquals("Hello, World!", contents.get("com/example/A.class"));
+  }
+
+  @Test
+  public void shouldMergeMultipleSourceJarsIntoASingleOutputJar() throws IOException {
+    Path inputOne = temp.newFile("first.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path inputTwo = temp.newFile("second.jar").toPath();
+    createJar(inputTwo, ImmutableMap.of("com/example/foo/B.class", "Also hello"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--sources", inputOne.toAbsolutePath().toString(),
+      "--sources", inputTwo.toAbsolutePath().toString()});
+
+    Map<String, String> contents = readJar(outputJar);
+    // We expect the manifest and one file
+    assertEquals(3, contents.size());
+    assertEquals("Hello, World!", contents.get("com/example/A.class"));
+    assertEquals("Also hello", contents.get("com/example/foo/B.class"));
+  }
+
+  @Test
+  public void shouldAllowDuplicateClassesByDefaultAndLastOneInWins() throws IOException {
+    // Create jars with names such that the first is sorted after the second
+    Path inputOne = temp.newFile("beta.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path inputTwo = temp.newFile("alpha.jar").toPath();
+    createJar(inputTwo, ImmutableMap.of("com/example/A.class", "Farewell!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--sources", inputOne.toAbsolutePath().toString(),
+      "--sources", inputTwo.toAbsolutePath().toString()});
+
+    Map<String, String> contents = readJar(outputJar);
+    // We expect the manifest and one file
+    assertEquals(2, contents.size());
+    assertEquals("Farewell!", contents.get("com/example/A.class"));
+  }
+
+  @Test
+  public void shouldBeAbleToSpecifyThatFirstSeenClassShouldBeIncludedInMergedJar() throws IOException {
+    // Create jars with names such that the first is sorted after the second
+    Path inputOne = temp.newFile("beta.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path inputTwo = temp.newFile("alpha.jar").toPath();
+    createJar(inputTwo, ImmutableMap.of("com/example/A.class", "Farewell!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--sources", inputOne.toAbsolutePath().toString(),
+      "--sources", inputTwo.toAbsolutePath().toString(),
+      "--duplicates", "first-wins"});
+
+    Map<String, String> contents = readJar(outputJar);
+    // We expect the manifest and one file
+    assertEquals(2, contents.size());
+    assertEquals("Hello, World!", contents.get("com/example/A.class"));
+  }
+
+  @Test(expected = IOException.class)
+  public void duplicateClassesCanBeDeclaredAsErrors() throws IOException {
+    // Create jars with names such that the first is sorted after the second
+    Path inputOne = temp.newFile("beta.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path inputTwo = temp.newFile("alpha.jar").toPath();
+    createJar(inputTwo, ImmutableMap.of("com/example/A.class", "Farewell!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--sources", inputOne.toAbsolutePath().toString(),
+      "--sources", inputTwo.toAbsolutePath().toString(),
+      "--duplicates", "are-errors"});
+  }
+
+  @Test
+  public void identicalDuplicateClassesAreFine() throws IOException {
+    // Create jars with names such that the first is sorted after the second
+    Path inputOne = temp.newFile("beta.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path inputTwo = temp.newFile("alpha.jar").toPath();
+    createJar(inputTwo, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--sources", inputOne.toAbsolutePath().toString(),
+      "--sources", inputTwo.toAbsolutePath().toString(),
+      "--duplicates", "are-errors"});
+
+    Map<String, String> contents = readJar(outputJar);
+    // We expect the manifest and one file
+    assertEquals(2, contents.size());
+    assertEquals("Hello, World!", contents.get("com/example/A.class"));
+  }
+
+  private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
+    try (OutputStream os = Files.newOutputStream(outputTo);
+         ZipOutputStream zos = new ZipOutputStream(os)) {
+
+      for (Map.Entry<String, String> entry : pathToContents.entrySet()) {
+        ZipEntry ze = new StableZipEntry(entry.getKey());
+        zos.putNextEntry(ze);
+        zos.write(entry.getValue().getBytes(UTF_8));
+        zos.closeEntry();
+      }
+    }
+  }
+
+  private Map<String, String> readJar(Path jar) throws IOException {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+    try (InputStream is = Files.newInputStream(jar);
+         ZipInputStream zis = new ZipInputStream(is)) {
+
+      for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
+        if (entry.isDirectory()) {
+          continue;
+        }
+
+        builder.put(entry.getName(), new String(ByteStreams.toByteArray(zis), UTF_8));
+      }
+    }
+
+    return builder.build();
+  }
+}


### PR DESCRIPTION
Although the behaviour before was stable, it wasn't obvious, so this
change makes the behaviour of MergeJars explicit and configurable via
the command line.

This change also adds some (much needed) unit tests for MergeJars to
ensure that it behaves as we expect it should.