### PR TITLE
Allow `bazel run @maven//:pin` to run successfully

### DIFF
--- a/private/pin.sh
+++ b/private/pin.sh
@@ -6,7 +6,7 @@ readonly maven_install_json_loc={maven_install_location}
 readonly execution_root=$(cd "$(dirname "$maven_install_json_loc")" && bazel info execution_root)
 readonly workspace_name=$(basename "$execution_root")
 # `jq` is a platform-specific dependency with an unpredictable path.
-readonly jq=$(find external/ -name jq -perm -o+x)
+readonly jq=$1
 cat <<"RULES_JVM_EXTERNAL_EOF" | "$jq" --sort-keys --indent 4 . - > $maven_install_json_loc
 {dependency_tree_json}
 RULES_JVM_EXTERNAL_EOF

--- a/private/versions.bzl
+++ b/private/versions.bzl
@@ -7,20 +7,17 @@ COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/d
 COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
 COURSIER_CLI_SHA256 = "6598d9277705ad8369a4f9c64217fbc31c19234f2cbcca9b1e5c4300a3abb317"
 
-JQ_VERSIONS = [
-    struct(
-        os = "linux",
+JQ_VERSIONS = {
+    "linux": struct(
         url = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64",
         sha256 = "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44",
     ),
-    struct(
-        os = "osx",
+    "macos": struct(
         url = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64",
         sha256 = "5c0a0a3ea600f302ee458b30317425dd9632d1ad8882259fcaf4e9b868b2b1ef",
     ),
-    struct(
-        os = "windows",
+    "windows": struct(
         url = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-win64.exe",
         sha256 = "a51d36968dcbdeabb3142c6f5cf9b401a65dc3a095f3144bd0c118d5bb192753",
     ),
-]
+}


### PR DESCRIPTION
To do this, we download each version of jq that might be used and
ensure it's available. Decide at run time which version we'll use.

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/409