### PR TITLE
Avoid calling out to Bazel

### DIFF
--- a/private/pin.sh
+++ b/private/pin.sh
@@ -3,8 +3,7 @@
 set -euo pipefail
 readonly maven_install_json_loc={maven_install_location}
 # This script is run as a `sh_binary`, so ensure we are in the calling workspace before running Bazel.
-readonly execution_root=$(cd "$(dirname "$maven_install_json_loc")" && bazel info execution_root)
-readonly workspace_name=$(basename "$execution_root")
+cd "$(dirname "$maven_install_json_loc")"
 # `jq` is a platform-specific dependency with an unpredictable path.
 readonly jq=$1
 cat <<"RULES_JVM_EXTERNAL_EOF" | "$jq" --sort-keys --indent 4 . - > $maven_install_json_loc
@@ -28,7 +27,7 @@ else
 maven_install(
     artifacts = # ...,
     repositories = # ...,
-    maven_install_json = "@$workspace_name//:{repository_name}_install.json",
+    maven_install_json = "@//:{repository_name}_install.json",
 )
 
 load("@{repository_name}//:defs.bzl", "pinned_maven_install")

--- a/private/pin.sh
+++ b/private/pin.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 readonly maven_install_json_loc={maven_install_location}
-# This script is run as a `sh_binary`, so ensure we are in the calling workspace before running Bazel.
-cd "$(dirname "$maven_install_json_loc")"
 # `jq` is a platform-specific dependency with an unpredictable path.
 readonly jq=$1
 cat <<"RULES_JVM_EXTERNAL_EOF" | "$jq" --sort-keys --indent 4 . - > $maven_install_json_loc


### PR DESCRIPTION
I was thinking about the case where user doesn't have bazel in their path but only bazelisk, or is using our vendored bazelisk Python script, etc. Are you open to this? It seemed like a lot of effort just to print the workspace name into the terminal output help text, and isn't it optional to begin with?

Let me know and if not I can try to rework this to get this info some other way.