### PR TITLE
Fix compatibility with --incompatible_disable_depset_items

### DIFF
--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -84,8 +84,9 @@ def _has_maven_deps_impl(target, ctx):
             first_order_java_infos.append(dep[JavaInfo])
 
     deps_java_infos = depset(
-        items = first_order_java_infos,
-        transitive = [dep.deps_java_infos for dep in all_infos])
+        first_order_java_infos,
+        transitive = [dep.deps_java_infos for dep in all_infos],
+    )
 
     all_jars = target[JavaInfo].transitive_runtime_jars
     jars_from_maven_deps = depset(transitive = [info.jars_from_maven_deps for info in all_infos])


### PR DESCRIPTION
The first depset argument will be named 'direct' instead of 'items'.
Most of the time, it is passed positionally though.

The flag will be enabled by default in Bazel 4.0.