### PR TITLE
Add a provider to export the information being published

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -109,6 +109,7 @@ def java_export(
         javadocs = "%s-docs" % name,
         artifact_jar = ":%s-maven-artifact" % name,
         source_jar = ":%s-maven-source" % name,
+        visibility = visibility,
     )
 
     # Finally, alias the primary output

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -1,3 +1,13 @@
+MavenPublishInfo = provider (
+    fields = {
+        "coordinates": "Maven coordinates for the project, which may be None",
+        "pom": "Pom.xml file for metdata",
+        "javadocs": "Javadoc jar file for documentation files",
+        "artifact_jar": "Jar with the code and metadata for execution",
+        "source_jar": "Jar with the source code for review",
+    }
+)
+
 _TEMPLATE = """#!/usr/bin/env bash
 
 echo "Uploading {coordinates} to {maven_repo}"
@@ -38,6 +48,13 @@ def _maven_publish_impl(ctx):
                 },
                 collect_data = True,
             ).merge(ctx.attr._uploader[DefaultInfo].data_runfiles),
+        ),
+        MavenPublishInfo(
+            coordinates = ctx.attr.coordinates,
+            artifact_jar = ctx.file.artifact_jar,
+            javadocs = ctx.file.javadocs,
+            source_jar = ctx.file.source_jar,
+            pom = ctx.file.pom
         )
     ]
 


### PR DESCRIPTION
Makes it easier to integrate with other Bazel tools that use the published artifacts.

---
#### Commits _(oldest to newest)_

b8499cd Add a provider to export the information being published

Make the provider available to external users.

<br/>

e8e110d Make maven_publish rule and "<name>.publish" target visible externally

For an external publishing tool, make the maven_publish rule (and the
"<name>.publish" target) visible to external targets.

This allows capturing the list of files (artifact, source, doc, pom) for
an external publishing tool to known about, reason about, and correctly
process these artifacts as needed.

<br/>
