### PR TITLE
Add regression test for bug in artifacts that use version intervals for deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -383,6 +383,17 @@ maven_install(
     fetch_sources = True,
 )
 
+# https://github.com/bazelbuild/rules_jvm_external/issues/433
+maven_install(
+    name = "version_interval_testing",
+    artifacts = [
+        "io.grpc:grpc-netty-shaded:1.29.0",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+
 load(
     "@json_artifacts_testing//:defs.bzl",
     _json_artifacts_testing_install = "pinned_maven_install",

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -37,6 +37,25 @@ diff_test(
     file2 = ":testonly-deps",
 )
 
+# https://github.com/coursier/coursier/issues/1792
+# https://github.com/bazelbuild/rules_jvm_external/issues/433
+genquery(
+    name = "version_interval_deps",
+    expression = "deps(@version_interval_testing//:io_grpc_grpc_netty_shaded, 2)",
+    opts = ["--nohost_deps", "--noimplicit_deps"],
+    scope = ["@version_interval_testing//:io_grpc_grpc_netty_shaded"],
+    testonly = True,
+)
+
+diff_test(
+    name = "version_interval_deps_test",
+    file1 = select({
+        "@bazel_tools//src/conditions:windows": "version-interval-deps.golden.dos",
+        "//conditions:default": "version-interval-deps.golden.unix",
+    }),
+    file2 = ":version_interval_deps",
+)
+
 java_import(
     name = "guava_import",
     jars = [

--- a/tests/integration/version-interval-deps.golden.dos
+++ b/tests/integration/version-interval-deps.golden.dos
@@ -1,0 +1,9 @@
+@version_interval_testing//:io_grpc_grpc_netty_shaded
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.29.0/grpc-netty-shaded-1.29.0.jar
+@version_interval_testing//:io_grpc_grpc_core
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.29.0/grpc-core-1.29.0.jar
+@version_interval_testing//:io_perfmark_perfmark_api
+@version_interval_testing//:io_grpc_grpc_api
+@version_interval_testing//:com_google_errorprone_error_prone_annotations
+@version_interval_testing//:com_google_code_gson_gson
+@version_interval_testing//:com_google_android_annotations

--- a/tests/integration/version-interval-deps.golden.unix
+++ b/tests/integration/version-interval-deps.golden.unix
@@ -1,0 +1,9 @@
+@version_interval_testing//:io_grpc_grpc_netty_shaded
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.29.0/grpc-netty-shaded-1.29.0.jar
+@version_interval_testing//:io_grpc_grpc_core
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.29.0/grpc-core-1.29.0.jar
+@version_interval_testing//:io_perfmark_perfmark_api
+@version_interval_testing//:io_grpc_grpc_api
+@version_interval_testing//:com_google_errorprone_error_prone_annotations
+@version_interval_testing//:com_google_code_gson_gson
+@version_interval_testing//:com_google_android_annotations


### PR DESCRIPTION
2.0.0-RC6-24 (and now 2.0.7 on RJE HEAD) brings bugfixes to artifacts that use version intervals in their deps, and add regression tests to fix #433.

See https://github.com/coursier/coursier/issues/1792 and https://github.com/bazelbuild/rules_jvm_external/issues/433
