### PR TITLE
Spell auth scheme as "Basic" for artifactory

### DIFF
--- a/private/tools/java/rules/jvm/external/maven/MavenPublisher.java
+++ b/private/tools/java/rules/jvm/external/maven/MavenPublisher.java
@@ -171,7 +171,7 @@ public class MavenPublisher {
       if (credentials.getUser() != null) {
         String basicAuth = Base64.getEncoder().encodeToString(
           String.format("%s:%s", credentials.getUser(), credentials.getPassword()).getBytes(US_ASCII));
-        connection.setRequestProperty("Authorization", "BASIC " + basicAuth);
+        connection.setRequestProperty("Authorization", "Basic " + basicAuth);
       }
       connection.setRequestProperty("Content-Length", "" + Files.size(toUpload));
 


### PR DESCRIPTION
JFrog Artifactory seems to accept only "Basic" casing.
Even though authorization scheme should be case-insensitive https://tools.ietf.org/html/rfc7617#section-2