### PR TITLE
Fix jq path in :pin runnable

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -50,7 +50,7 @@ sh_binary(
     name = "pin",
     srcs = ["pin.sh"],
     args = [
-      "$(location :jq-binary)",
+      "$(rootpath :jq-binary)",
     ],
     data = [
         ":jq-binary",

--- a/private/pin.sh
+++ b/private/pin.sh
@@ -6,7 +6,10 @@ readonly maven_install_json_loc={maven_install_location}
 readonly execution_root=$(cd "$(dirname "$maven_install_json_loc")" && bazel info execution_root)
 readonly workspace_name=$(basename "$execution_root")
 # `jq` is a platform-specific dependency with an unpredictable path.
-readonly jq=$1
+# Note that $(rootpath) will always give external/unpinned_maven/jq, however under --nolegacy_external_runfiles
+# there is only pin.runfiles/unpinned_maven/jq not also pin.runfiles/user_repo/external/unpinned_maven/jq
+# So replace leading external/ with ../
+readonly jq=${1/#external\//..\/}
 cat <<"RULES_JVM_EXTERNAL_EOF" | "$jq" --sort-keys --indent 4 . - > $maven_install_json_loc
 {dependency_tree_json}
 RULES_JVM_EXTERNAL_EOF


### PR DESCRIPTION
Problem reported on #426

The build typically takes place in the user's workspace, so using
`$(location)` (or more correctly, `$(rootpath)`) gives an undesirable
"external/" leading segment. This would be useful if the binary being
run is in the users workspace, but we know our binary is in the same
workspace defining the BUILD file.

This change also uses the runfiles helper since I think that's required
to make this work on Windows, though I only tested on Mac.