### PR TITLE
Include classifier in label if present

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -139,7 +139,10 @@ def maven_install(
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):
     artifact_obj = _parse_artifact_str(a) if type(a) == "string" else a
-    return "@%s//:%s" % (repository_name, _escape(artifact_obj["group"] + ":" + artifact_obj["artifact"]))
+    parts = [artifact_obj["group"], artifact_obj["artifact"]]
+    if "classifier" in artifact_obj:
+        parts.append(artifact_obj["classifier"])
+    return "@%s//:%s" % (repository_name, _escape(":".join(parts)))
 
 def maven_artifact(a):
     return artifact(a, repository_name = DEFAULT_REPOSITORY_NAME)


### PR DESCRIPTION
My use case is, I have a bzl file with a function that returns a list of all our artifacts. The function is called for both the artifacts attr of maven_install in the WORKSPACE and in another rule where I pass `[artifact(a) for a in get_rje_artifacts()]` as inputs to a custom rule we have. I also use strict_visibility

What happened was that for the artifact that has a classifier, the label returned wasn't valid and so my custom rule failed to build.

I was able to fix it like this.