### PR TITLE
Use AddJarManifestEntry to add Target-Label to jars manifest

### DIFF
--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -14,35 +14,28 @@ def _jvm_import_impl(ctx):
         fail("Please only specify one jar to import in the jars attribute.")
 
     injar = ctx.files.jars[0]
-    manifest_update_file = ctx.actions.declare_file(injar.basename + ".target_label_manifest", sibling = injar)
-    ctx.actions.expand_template(
-        template = ctx.file._manifest_template,
-        output = manifest_update_file,
-        substitutions = {
-            "{TARGETLABEL}": "%s" % ctx.label,
-        },
-    )
-
     outjar = ctx.actions.declare_file("processed_" + injar.basename, sibling = injar)
     ctx.actions.run_shell(
-        inputs = [injar, manifest_update_file] + ctx.files._host_javabase,
+        inputs = [injar] + ctx.files._add_jar_manifest_entry,
         outputs = [outjar],
-        command = " && ".join([
-            # Make a copy of the original jar, since `jar(1)` modifies the jar in place.
-            "cp {input_jar} {output_jar}".format(input_jar = injar.path, output_jar = outjar.path),
-            # Set the write bit on the copied jar.
-            "chmod +w {output_jar}".format(output_jar = outjar.path),
+        command = "\n".join([
             # If the jar is signed do not modify the manifest because it will
-            # make the signature invalid. Otherwise append the Target-Label
-            # manifest attribute using `jar umf`
-            "(unzip -l {output_jar} | grep -qE 'META-INF/.*\\.SF') || ({jar} umf {manifest_update_file} {output_jar} > /dev/null 2>&1 || true)".format(
-                jar = "%s/bin/jar" % ctx.attr._host_javabase[java_common.JavaRuntimeInfo].java_home,
-                manifest_update_file = manifest_update_file.path,
-                output_jar = outjar.path,
+            # make the signature invalid.
+            "if unzip -l {injar} | grep -qE 'META-INF/.*\\.SF'; then".format(injar = injar.path),
+            "  cp {injar} {outjar}".format(injar = injar.path, outjar = outjar.path),
+            "else",
+            "  set -e",
+            "  {add_jar_manifest_entry} --source {injar} --manifest-entry 'Target-Label:{target_label}' --output {outjar}".format(
+                add_jar_manifest_entry = ctx.attr._add_jar_manifest_entry.files_to_run.executable.path,
+                injar = injar.path,
+                target_label = ctx.label,
+                outjar = outjar.path,
             ),
+            "fi",
         ]),
         mnemonic = "StampJarManifest",
         progress_message = "Stamping the manifest of %s" % ctx.label,
+        tools = [ctx.attr._add_jar_manifest_entry.files_to_run],
     )
 
     if not ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:
@@ -84,14 +77,10 @@ jvm_import = rule(
         "neverlink": attr.bool(
             default = False,
         ),
-        "_host_javabase": attr.label(
+        "_add_jar_manifest_entry": attr.label(
+            executable = True,
             cfg = "host",
-            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
-            providers = [java_common.JavaRuntimeInfo],
-        ),
-        "_manifest_template": attr.label(
-            default = Label("@rules_jvm_external//private/templates:manifest_target_label.tpl"),
-            allow_single_file = True,
+            default = "//private/tools/java/rules/jvm/external/jar:AddJarManifestEntry",
         ),
         "_stamp_manifest": attr.label(
             default = Label("@rules_jvm_external//settings:stamp_manifest"),

--- a/private/templates/BUILD
+++ b/private/templates/BUILD
@@ -1,4 +1,3 @@
 exports_files([
-    "manifest_target_label.tpl",
     "pom.tpl",
 ])

--- a/private/templates/manifest_target_label.tpl
+++ b/private/templates/manifest_target_label.tpl
@@ -1,1 +1,0 @@
-Target-Label: {TARGETLABEL}

--- a/private/tools/java/rules/jvm/external/jar/AddJarManifestEntry.java
+++ b/private/tools/java/rules/jvm/external/jar/AddJarManifestEntry.java
@@ -1,0 +1,181 @@
+package rules.jvm.external.jar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/*
+ * A class that will add an entry to the manifest and keep the same modification
+ # times of the jar entries.
+ */
+public class AddJarManifestEntry {
+
+  public static final long DEFAULT_TIMESTAMP =
+      LocalDateTime.of(2010, 1, 1, 0, 0, 0)
+          .atZone(ZoneId.systemDefault())
+          .toInstant()
+          .toEpochMilli();
+
+  public static void verboseLog(String logline) {
+    // To make this work you need to add 'use_default_shell_env = True' to the
+    // rule and specify '--action_env=RJE_VERBOSE=true' to the bazel build command.
+    if (System.getenv("RJE_VERBOSE") != null) {
+      System.out.println(logline);
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    Path out = null;
+    Path source = null;
+    String manifestEntry = null;
+
+    for (int i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case "--output":
+          out = Paths.get(args[++i]);
+          break;
+
+        case "--manifest-entry":
+          manifestEntry = args[++i];
+          break;
+
+        case "--source":
+          source = Paths.get(args[++i]);
+          break;
+
+        default:
+          throw new IllegalArgumentException("Unable to parse command line: " + Arrays.toString(args));
+      }
+    }
+
+    Objects.requireNonNull(source, "Source jar must be set.");
+    Objects.requireNonNull(out, "Output path must be set.");
+
+    addEntryToManifest(out, source, manifestEntry, false);
+  }
+
+  public static void addEntryToManifest(Path out, Path source, String manifestEntry, boolean addManifest) throws IOException {
+    byte[] buffer = new byte[2048];
+    int bytesRead;
+    boolean manifestUpdated = false;
+
+    try (InputStream fis = Files.newInputStream(source);
+         ZipInputStream zis = new ZipInputStream(fis)) {
+
+      try (OutputStream fos = Files.newOutputStream(out);
+           ZipOutputStream zos = new JarOutputStream(fos)) {
+
+        if (addManifest) {
+          verboseLog("INFO: No jar manifest found in " + source + " Adding new jar manifest.");
+          Manifest manifest = new Manifest();
+          manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+          manifest.getMainAttributes().put(new Attributes.Name("Created-By"), "AddJarManifestEntry");
+          String[] manifestEntryParts = manifestEntry.split(":", 2);
+          manifest.getMainAttributes().put(new Attributes.Name(manifestEntryParts[0]), manifestEntryParts[1]);
+
+          ZipEntry newManifestEntry = new ZipEntry(JarFile.MANIFEST_NAME);
+          newManifestEntry.setTime(DEFAULT_TIMESTAMP);
+          zos.putNextEntry(newManifestEntry);
+          manifest.write(zos);
+          manifestUpdated = true;
+        }
+
+        ZipEntry sourceEntry;
+        while ((sourceEntry = zis.getNextEntry()) != null) {
+          String name = sourceEntry.getName();
+
+          ZipEntry outEntry = new ZipEntry(name);
+          outEntry.setMethod(sourceEntry.getMethod());
+          outEntry.setTime(sourceEntry.getTime());
+          outEntry.setComment(sourceEntry.getComment());
+          outEntry.setExtra(sourceEntry.getExtra());
+
+          if (manifestEntry != null && JarFile.MANIFEST_NAME.equals(name)) {
+            Manifest manifest = new Manifest(zis);
+            String[] manifestEntryParts = manifestEntry.split(":", 2);
+            manifest.getMainAttributes().put(new Attributes.Name(manifestEntryParts[0]), manifestEntryParts[1]);
+
+            if (sourceEntry.getMethod() == ZipEntry.STORED) {
+              CRC32OutputStream crc32OutputStream = new CRC32OutputStream();
+              manifest.write(crc32OutputStream);
+              outEntry.setSize(crc32OutputStream.getSize());
+              outEntry.setCrc(crc32OutputStream.getCRC());
+            }
+            zos.putNextEntry(outEntry);
+            manifest.write(zos);
+            manifestUpdated = true;
+
+          } else {
+
+            if (sourceEntry.getMethod() == ZipEntry.STORED) {
+              outEntry.setSize(sourceEntry.getSize());
+              outEntry.setCrc(sourceEntry.getCrc());
+            }
+
+            try {
+              zos.putNextEntry(outEntry);
+            } catch (ZipException e) {
+              if (e.getMessage().contains("duplicate entry:")) {
+                // If there is a duplicate entry we keep the first one we saw.
+                verboseLog("WARN: Skipping duplicate jar entry " + outEntry.getName() + " in " + source);
+                continue;
+              } else {
+                throw e;
+              }
+            }
+            while ((bytesRead = zis.read(buffer)) != -1) {
+              zos.write(buffer, 0, bytesRead);
+            }
+          }
+        }
+      }
+    }
+
+    if (manifestEntry != null && !manifestUpdated) {
+      // If no manifest was found then re-run and add the MANIFEST.MF as the first entry in the output jar
+      addEntryToManifest(out, source, manifestEntry, true);
+    }
+  }
+
+  // OutputStream to find the CRC32 of an updated STORED zip entry
+  private static class CRC32OutputStream extends java.io.OutputStream {
+    private final CRC32 crc = new CRC32();
+    private long size = 0;
+
+    CRC32OutputStream() {}
+
+    public void write(int b) throws IOException {
+      crc.update(b);
+      size++;
+    }
+
+    public void write(byte[] b, int off, int len) throws IOException {
+      crc.update(b, off, len);
+      size += len;
+    }
+
+    public long getSize() {
+      return size;
+    }
+
+    public long getCRC() {
+      return crc.getValue();
+    }
+  }
+}

--- a/private/tools/java/rules/jvm/external/jar/BUILD
+++ b/private/tools/java/rules/jvm/external/jar/BUILD
@@ -1,6 +1,24 @@
 java_binary(
+    name = "AddJarManifestEntry",
+    srcs = ["AddJarManifestEntry.java"],
+    javacopts = [
+        "-source",
+        "8",
+        "-target",
+        "8",
+    ],
+    main_class = "rules.jvm.external.jar.AddJarManifestEntry",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+java_binary(
     name = "MergeJars",
-    srcs = glob(["*.java"]),
+    srcs = [
+        "DuplicateEntryStrategy.java",
+        "MergeJars.java",
+    ],
     javacopts = [
         "-source",
         "8",
@@ -13,6 +31,5 @@ java_binary(
     ],
     deps = [
         "//private/tools/java/rules/jvm/external:byte-streams",
-        "//private/tools/java/rules/jvm/external/zip",
     ],
 )

--- a/tests/com/jvm/external/jar/AddJarManifestEntryTest.java
+++ b/tests/com/jvm/external/jar/AddJarManifestEntryTest.java
@@ -1,0 +1,169 @@
+package com.jvm.external.jar;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import rules.jvm.external.jar.AddJarManifestEntry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AddJarManifestEntryTest {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void shouldAddEntryToManifest() throws IOException {
+    Path inputOne = temp.newFile("first.jar").toPath();
+
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(new Attributes.Name("Hello-World"), "hello");
+
+    createJar(inputOne, manifest, new ImmutableMap.Builder<String, String>()
+           .put("com/example/A.class", "Hello, World!")
+           .put("com/example/B.class", "Hello, World Again!")
+           .build());
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    AddJarManifestEntry.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--source", inputOne.toAbsolutePath().toString(),
+      "--manifest-entry", "Target-Label:@maven//:com_google_guava_guava"});
+
+    Map<String, String> contents = readJar(outputJar);
+    assertEquals(3, contents.size());
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Manifest-Version: 1.0"));
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Hello-World: hello"));
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Target-Label: @maven//:com_google_guava_guava"));
+  }
+
+  @Test
+  public void shouldCreateManifestIfManifestIsMissing() throws IOException {
+    Path inputOne = temp.newFile("first.jar").toPath();
+    createJar(inputOne, null, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    AddJarManifestEntry.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--source", inputOne.toAbsolutePath().toString(),
+      "--manifest-entry", "Target-Label:@maven//:com_google_guava_guava"});
+
+    Map<String, String> contents = readJar(outputJar);
+    assertEquals(2, contents.size());
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Manifest-Version: 1.0"));
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Target-Label: @maven//:com_google_guava_guava"));
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Created-By: AddJarManifestEntry"));
+  }
+
+  @Test
+  public void shouldCreateManifestAsFirstEntryInJarIfManifestIsMissing() throws IOException {
+    Path inputOne = temp.newFile("first.jar").toPath();
+    createJar(inputOne, null, ImmutableMap.of("com/example/A.class", "Hello, World!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    AddJarManifestEntry.main(new String[]{
+            "--output", outputJar.toAbsolutePath().toString(),
+            "--source", inputOne.toAbsolutePath().toString(),
+            "--manifest-entry", "Target-Label:@maven//:com_google_guava_guava"});
+
+    List<String> entries = readJarEntries(outputJar);
+    assertEquals(2, entries.size());
+    assertEquals("META-INF/MANIFEST.MF", entries.get(0));
+    assertEquals("com/example/A.class", entries.get(1));
+  }
+
+  @Test
+  public void shouldOverwriteManifestEntryIfItAlreadyExistsInJar() throws IOException {
+    Path inputOne = temp.newFile("first.jar").toPath();
+
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(new Attributes.Name("Target-Label"), "@maven//:org_hamcrest_hamcrest");
+
+    createJar(inputOne, manifest, new ImmutableMap.Builder<String, String>()
+           .put("com/example/A.class", "Hello, World!")
+           .build());
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    AddJarManifestEntry.main(new String[]{
+      "--output", outputJar.toAbsolutePath().toString(),
+      "--source", inputOne.toAbsolutePath().toString(),
+      "--manifest-entry", "Target-Label:@maven//:com_google_guava_guava"});
+
+    Map<String, String> contents = readJar(outputJar);
+    assertEquals(2, contents.size());
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Manifest-Version: 1.0"));
+    assertTrue(contents.get("META-INF/MANIFEST.MF").contains("Target-Label: @maven//:com_google_guava_guava"));
+  }
+
+  private void createJar(Path outputTo, Manifest manifest, Map<String, String> pathToContents) throws IOException {
+    try (OutputStream os = Files.newOutputStream(outputTo);
+         ZipOutputStream zos = new JarOutputStream(os)) {
+
+      if (manifest != null) {
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        ZipEntry manifestEntry = new ZipEntry(JarFile.MANIFEST_NAME);
+        zos.putNextEntry(manifestEntry);
+        manifest.write(zos);
+      }
+
+      for (Map.Entry<String, String> entry : pathToContents.entrySet()) {
+        ZipEntry ze = new ZipEntry(entry.getKey());
+        zos.putNextEntry(ze);
+        zos.write(entry.getValue().getBytes(UTF_8));
+        zos.closeEntry();
+      }
+    }
+  }
+
+  private Map<String, String> readJar(Path jar) throws IOException {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    try (InputStream is = Files.newInputStream(jar);
+         ZipInputStream zis = new ZipInputStream(is)) {
+      for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
+        if (entry.isDirectory()) {
+          continue;
+        }
+        builder.put(entry.getName(), new String(ByteStreams.toByteArray(zis), UTF_8));
+      }
+    }
+    return builder.build();
+  }
+
+  private List<String> readJarEntries(Path jar) throws IOException {
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    try (InputStream is = Files.newInputStream(jar);
+         ZipInputStream zis = new ZipInputStream(is)) {
+      for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
+        if (entry.isDirectory()) {
+          continue;
+        }
+        builder.add(entry.getName());
+      }
+    }
+    return builder.build();
+  }
+}

--- a/tests/com/jvm/external/jar/BUILD
+++ b/tests/com/jvm/external/jar/BUILD
@@ -1,13 +1,23 @@
 load("//:defs.bzl", "artifact")
 
 java_test(
+    name = "AddJarManifestEntryTest",
+    srcs = ["AddJarManifestEntryTest.java"],
+    test_class = "com.jvm.external.jar.AddJarManifestEntryTest",
+    deps = [
+        "//private/tools/java/rules/jvm/external/jar:AddJarManifestEntry",
+        artifact("com.google.guava:guava"),
+    ],
+)
+
+java_test(
     name = "MergeJarsTest",
-    test_class = "com.jvm.external.jar.MergeJarsTest",
     srcs = ["MergeJarsTest.java"],
+    test_class = "com.jvm.external.jar.MergeJarsTest",
     deps = [
         "//private/tools/java/rules/jvm/external:byte-streams",
         "//private/tools/java/rules/jvm/external/jar:MergeJars",
         "//private/tools/java/rules/jvm/external/zip",
         artifact("com.google.guava:guava"),
-    ]
+    ],
 )


### PR DESCRIPTION
Use custom java class to add Target-Label to the jar manifest so we maintain consistent modification time of the jar Manifest.