### PR TITLE
Generate Coursier credentials from a netrc file

### DIFF
--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -7,6 +7,7 @@ load(
     "get_coursier_cache_or_default",
     "remove_auth_from_url",
     "split_url",
+    "generate_coursier_credentials_from_netrc",
     infer = "infer_artifact_path_from_primary_and_repos",
 )
 
@@ -475,6 +476,42 @@ def _get_coursier_cache_or_default_enabled_with_home_dot_coursier_directory_test
     return unittest.end(env)
 
 get_coursier_cache_or_default_enabled_with_home_dot_coursier_directory_test = add_test(_get_coursier_cache_or_default_enabled_with_home_dot_coursier_directory_test)
+
+def _coursier_credentials_test(ctx):
+    env = unittest.begin(ctx)
+    netrc_content = """
+        machine example.com login foo password bar
+        default login is-ignored
+        machine ignored login missing-password
+        machine missing-password login login
+        machine with-newline
+          login foo
+          password bar
+        machine machine login foo password bar account ignored
+    """
+
+    asserts.equals(
+        env,
+        ["example.com foo:bar",
+         "with-newline foo:bar",
+         "machine foo:bar",
+         ],
+        generate_coursier_credentials_from_netrc(netrc_content)
+    )
+    return unittest.end(env)
+
+def _coursier_credentials_empty_test(ctx):
+    env = unittest.begin(ctx)
+    netrc_content = ""
+    asserts.equals(
+        env,
+        [],
+        generate_coursier_credentials_from_netrc(netrc_content)
+    )
+    return unittest.end(env)
+
+
+coursier_credentials_test  = add_test(_coursier_credentials_test)
 
 def coursier_test_suite():
     unittest.suite(

--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -479,39 +479,52 @@ get_coursier_cache_or_default_enabled_with_home_dot_coursier_directory_test = ad
 
 def _coursier_credentials_test(ctx):
     env = unittest.begin(ctx)
-    netrc_content = """
-        machine example.com login foo password bar
-        default login is-ignored
-        machine ignored login missing-password
-        machine missing-password login login
-        machine with-newline
-          login foo
-          password bar
-        machine machine login foo password bar account ignored
-    """
-
+    parsed_netrc = {
+        "example.com": {
+            "login": "foo",
+            "password": "bar",
+        },
+        "": {
+            "login": "is-ignored"
+        },
+        "ignored": {
+            "login": "missing-password",
+        },
+        "missing-password": {
+            "login": "login"
+        },
+        "with-newline": {
+            "login": "foo",
+            "password": "bar",
+        }, "machine": {
+            "login": "foo",
+            "password": "bar",
+            "account": "ignored"
+        }
+    }
     asserts.equals(
         env,
         ["example.com foo:bar",
          "with-newline foo:bar",
          "machine foo:bar",
          ],
-        generate_coursier_credentials_from_netrc(netrc_content)
+        generate_coursier_credentials_from_netrc(parsed_netrc)
     )
     return unittest.end(env)
+
+coursier_credentials_test  = add_test(_coursier_credentials_test)
 
 def _coursier_credentials_empty_test(ctx):
     env = unittest.begin(ctx)
-    netrc_content = ""
+    parsed_netrc = {}
     asserts.equals(
         env,
         [],
-        generate_coursier_credentials_from_netrc(netrc_content)
+        generate_coursier_credentials_from_netrc(parsed_netrc)
     )
     return unittest.end(env)
 
-
-coursier_credentials_test  = add_test(_coursier_credentials_test)
+coursier_credentials_empty_test = add_test(_coursier_credentials_empty_test)
 
 def coursier_test_suite():
     unittest.suite(


### PR DESCRIPTION
A simple parser parse the user netrc file and generate a list of
credentials that can be used by Coursier.

Fixes #483