### PR TITLE
Update documentation to use the latest names

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,6 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
-load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
-
-rules_jvm_external_deps()
-
-load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
-
-rules_jvm_external_setup()
-
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(


### PR DESCRIPTION
Documentation was updated here: https://github.com/bazelbuild/rules_jvm_external/releases/tag/3.3
But it was not updated in this readme