### PR TITLE
Make @unpinned_maven//:pin always visible

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -55,6 +55,7 @@ sh_binary(
     data = [
         ":jq-binary",
     ],
+    visibility = ["//visibility:public"],
 )
 """
 


### PR DESCRIPTION
Allows to run :pin via multirun target regardless of strict visibility setting

Use-case is still to run it a a part of manual command, like 
```
# TODO: fix multirun handling of *_binary.args, it just exec-s files_to_execute at the moment
load("@com_github_atlassian_bazel_tools//multirun:def.bzl", "command", "multirun")
command(
    name = "pin-update",
    arguments = ["$(rootpath //:jq)"],
    command = "@unpinned_maven//:pin",
    data = ["//:jq"], # may also try using jq from rules_jvm_external
)
multirun(
    name = "maven-update",
    commands = [
        ":pin-update",
        ":some-other-update-task", # for example update checked-in generated pom.xml that can trigger dependabot PRs/alerts
        ":maybe a task that reports something",
    ]
)
```
Making pin public may also allow using it at build or test time, bur probably not that useful unless it starts accepting arguments like target maven_install.json location