### PR TITLE
Declare COURSIER_OPTS to make it available

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -1055,6 +1055,7 @@ coursier_fetch = repository_rule(
         "no_proxy",
         "NO_PROXY",
         "COURSIER_CACHE",
+        "COURSIER_OPTS",
         "COURSIER_URL",
         "RJE_VERBOSE",
     ],


### PR DESCRIPTION
Option was added in https://github.com/bazelbuild/rules_jvm_external/pull/385
Not sure which bazel versions are strict about exposing env vars to repository rules, but
it seems that with bazel 3.3.1 COURSIER_OPTS isn't propagated by default.

One use-case is supporting proxy, for built-in repository rules it's possible for example to add following to .bazelrc
> startup --host_jvm_args=-Dhttps.proxyHost=... --host_jvm_args=-Dhttps.proxyPort=... --host_jvm_args=-Djavax.net.ssl.trustStore=... --host_jvm_args=-Djavax.net.ssl.trustStorePassword=...

Alternatively we could add TRUST_STORE and TRUST_STORE_PASSWORD env vars, but since COURSIER_OPTS is already here, let's stick with that one.