### PR TITLE
Add aliases with classifiers stripped

### DIFF
--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -27,23 +27,29 @@ SUPPORTED_PACKAGING_TYPES = [
     "scala-jar",
 ]
 
-def strip_packaging_and_classifier(coord):
-    # Strip some packaging and classifier values based on the following maven coordinate formats
-    # groupId:artifactId:version
-    # groupId:artifactId:packaging:version
-    # groupId:artifactId:packaging:classifier:version
+def strip_packaging(coord):
     coordinates = coord.split(":")
-    if len(coordinates) > 4:
-        if coordinates[3] in ["sources", "natives"]:
-            coordinates.pop(3)
 
     if len(coordinates) > 3:
         # We add "pom" into SUPPORTED_PACKAGING_TYPES here because "pom" is not a
         # packaging type that Coursier CLI accepts.
         if coordinates[2] in SUPPORTED_PACKAGING_TYPES + ["pom"]:
             coordinates.pop(2)
-
     return ":".join(coordinates)
+
+def strip_packaging_and_version(coord):
+    return ":".join(strip_packaging(coord).split(":")[:-1])
+
+def strip_packaging_and_classifier(coord):
+    # Strip classifier and some packaging values based on the following maven coordinate formats
+    # groupId:artifactId:version
+    # groupId:artifactId:packaging:version
+    # groupId:artifactId:packaging:classifier:version
+    coordinates = coord.split(":")
+    if len(coordinates) > 4:
+        coordinates.pop(3)
+
+    return strip_packaging(":".join(coordinates))
 
 def strip_packaging_and_classifier_and_version(coord):
     return ":".join(strip_packaging_and_classifier(coord).split(":")[:-1])

--- a/tests/unit/coursier_utilities_test.bzl
+++ b/tests/unit/coursier_utilities_test.bzl
@@ -33,11 +33,11 @@ def _strip_packaging_and_classifier_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(env, "groupId:artifactId:version",
         strip_packaging_and_classifier("groupId:artifactId:version"))
-    # Note: currently only some package and classifier values are stripped
+    # Note: currently only some package values are stripped
     asserts.equals(env, "groupId:artifactId:packaging:version",
         strip_packaging_and_classifier("groupId:artifactId:packaging:version"))
-    asserts.equals(env, "groupId:artifactId:packaging:classifier:version",
-        strip_packaging_and_classifier("groupId:artifactId:packaging:classifier:version"))
+    asserts.equals(env, "groupId:artifactId:packaging:version",
+        strip_packaging_and_classifier("groupId:artifactId:packaging:version"))
     asserts.equals(env, "groupId:artifactId:version",
         strip_packaging_and_classifier("groupId:artifactId:bundle:version"))
     asserts.equals(env, "groupId:artifactId:version",
@@ -50,7 +50,7 @@ def _strip_packaging_and_classifier_and_version_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(env, "groupId:artifactId",
         strip_packaging_and_classifier_and_version("groupId:artifactId:version"))
-    # Note: currently only some package and classifier values are stripped
+    # Note: currently only some package values are stripped
     asserts.equals(env, "groupId:artifactId",
         strip_packaging_and_classifier_and_version("groupId:artifactId:bundle:version"))
     asserts.equals(env, "groupId:artifactId",

--- a/tests/unit/coursier_utilities_test.bzl
+++ b/tests/unit/coursier_utilities_test.bzl
@@ -37,7 +37,7 @@ def _strip_packaging_and_classifier_test_impl(ctx):
     asserts.equals(env, "groupId:artifactId:packaging:version",
         strip_packaging_and_classifier("groupId:artifactId:packaging:version"))
     asserts.equals(env, "groupId:artifactId:packaging:version",
-        strip_packaging_and_classifier("groupId:artifactId:packaging:version"))
+        strip_packaging_and_classifier("groupId:artifactId:packaging:classifier:version"))
     asserts.equals(env, "groupId:artifactId:version",
         strip_packaging_and_classifier("groupId:artifactId:bundle:version"))
     asserts.equals(env, "groupId:artifactId:version",
@@ -53,6 +53,8 @@ def _strip_packaging_and_classifier_and_version_test_impl(ctx):
     # Note: currently only some package values are stripped
     asserts.equals(env, "groupId:artifactId",
         strip_packaging_and_classifier_and_version("groupId:artifactId:bundle:version"))
+    asserts.equals(env, "groupId:artifactId",
+        strip_packaging_and_classifier_and_version("groupId:artifactId:bundle:classifier:version"))
     asserts.equals(env, "groupId:artifactId",
         strip_packaging_and_classifier_and_version("groupId:artifactId:pom:sources:version"))
     return unittest.end(env)


### PR DESCRIPTION
If a resolved artifact includes a classifier, it won't have a `group_name`-style target created for it. This is an issue when a dependency does not specify a classifier, but the resolved artifact does. For example:

- Artifact `com.example:foo:classifier:1` is published. It is the only artifact matching `com.example:foo:1`.
- Artifact `com.example:bar` declares a dependency on `com.example:foo:1`
- Coursier resolves `com.example:foo:1`, to the artifact with coords `com.example:foo:classifier:1`
- A rule for the resolved `foo` is generated, named `@maven//:com_example_foo_classifier`
- The generated rule for `bar` depends on `@maven//:com_example_foo`, which does not exist
- Bazel explodes

This PR doesn't remove/change any targets that are currently created, but in the above example it will create an alias from `@maven//:com_example_foo` -> `@maven://com_example_foo_classifier` (and another alias with version numbers)