### PR TITLE
Generate pseudo-compile jars for bazel java compilation

### DIFF
--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -42,6 +42,8 @@ def _jvm_import_impl(ctx):
         arguments = [args],
         inputs = [outjar],
         outputs = [compilejar],
+        mnemonic = "CreateCompileJar",
+        progress_message = "Creating compile jar for %s" % ctx.label,
     )
 
     if not ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:

--- a/private/tools/java/rules/jvm/external/jar/BUILD
+++ b/private/tools/java/rules/jvm/external/jar/BUILD
@@ -11,6 +11,9 @@ java_binary(
     visibility = [
         "//visibility:public",
     ],
+    deps = [
+        "//private/tools/java/rules/jvm/external:byte-streams",
+    ],
 )
 
 java_binary(

--- a/tests/com/jvm/external/jar/BUILD
+++ b/tests/com/jvm/external/jar/BUILD
@@ -5,6 +5,7 @@ java_test(
     srcs = ["AddJarManifestEntryTest.java"],
     test_class = "com.jvm.external.jar.AddJarManifestEntryTest",
     deps = [
+        "//private/tools/java/rules/jvm/external:byte-streams",
         "//private/tools/java/rules/jvm/external/jar:AddJarManifestEntry",
         artifact("com.google.guava:guava"),
     ],


### PR DESCRIPTION
Normally, bazel uses `ijar` to prepare a jar containing just
ABI-entries for classfiles. These are stable when non-API breaking
changes are made, and so allow bazel to compile code faster, and are
known as "compile jars"

Because of https://github.com/bazelbuild/bazel/issues/4549
`rules_jvm_external` doesn't use `ijar`, and instead uses the
downloaded jar as the "compile jar". Normally, this is fine, but Bazel
4.0.0 now sets `-Xlint:path` for javac invocations, and this means
that if there's a `Class-Path` manifest entry in a compile jar, the
jars within _that_ will be checked. This can lead to noisy builds:
https://github.com/bazelbuild/bazel/issues/12968

This change generates a "pseudo-compile jar" for `jvm_import`
targets. All it does is repack the input jar, excluding the
`META-INF/MANIFEST.MF` file. This means that we should avoid
compilation problems whilst still working well with Kotlin projects.