### PR TITLE
Make read_coordinates public

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -15,10 +15,11 @@
 load(":coursier.bzl", "coursier_fetch", "pinned_coursier_fetch", "DEFAULT_AAR_IMPORT_LABEL")
 load(":specs.bzl", "json", "parse")
 load("//:private/dependency_tree_parser.bzl", "JETIFY_INCLUDE_LIST_JETIFY_ALL")
+load("//private/rules:has_maven_deps.bzl", _read_coordinates = "read_coordinates")
 load("//private/rules:java_export.bzl", _java_export = "java_export")
 load("//private/rules:javadoc.bzl", _javadoc = "javadoc")
-load("//private/rules:pom_file.bzl", _pom_file = "pom_file")
 load("//private/rules:maven_publish.bzl", _MavenPublishInfo = "MavenPublishInfo")
+load("//private/rules:pom_file.bzl", _pom_file = "pom_file")
 
 DEFAULT_REPOSITORY_NAME = "maven"
 
@@ -182,4 +183,5 @@ def _parse_artifact_str(artifact_str):
 java_export = _java_export
 javadoc = _javadoc
 pom_file = _pom_file
+read_coordinates = _read_coordinates
 MavenPublishInfo = _MavenPublishInfo

--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -36,7 +36,7 @@ _EMPTY_INFO = MavenInfo(
 _MAVEN_PREFIX = "maven_coordinates="
 _STOP_TAGS = ["maven:compile-only", "no-maven"]
 
-def _read_coordinates(tags):
+def read_coordinates(tags):
     coordinates = []
     for stop_tag in _STOP_TAGS:
         if stop_tag in tags:
@@ -120,7 +120,7 @@ def _has_maven_deps_impl(target, ctx):
         if tag in _STOP_TAGS:
             return _EMPTY_INFO
 
-    coordinates = _read_coordinates(ctx.rule.attr.tags)
+    coordinates = read_coordinates(ctx.rule.attr.tags)
     label_to_javainfo = {target.label: target[JavaInfo]}
 
     gathered = _gathered(


### PR DESCRIPTION
It's useful for other tools to be able to extract maven coordinates
from tags (for example, Selenium's Java Module generation) Making this
function public makes this possible.