### PR TITLE
Make documentation `bzl_library` publicly visible

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -53,6 +53,9 @@ bzl_library(
         "//third_party/bazel_json/lib:json_parser.bzl",
     ],
     visibility = [
+        # This library is only visible to allow others who depend on
+        # `rules_jvm_external` to be able to document their code using
+        # stardoc.
         "//visibility:public",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -52,6 +52,9 @@ bzl_library(
         "//settings:stamp_manifest.bzl",
         "//third_party/bazel_json/lib:json_parser.bzl",
     ],
+    visibility = [
+        "//visibility:public",
+    ],
 )
 
 genrule(


### PR DESCRIPTION
This allows anyone who depends on `rules_jvm_external` and imports
"something" from these rules into their own rules to be able to
generate stardoc of their own functions.

I've filed https://github.com/bazelbuild/stardoc/issues/93 to track
this issue. Once it's fixed, we can close this.