### PR TITLE
Sort genquery outputs to be compatible with --incompatible_genquery_use_graphless_query

### DIFF
--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -28,13 +28,21 @@ genquery(
     ],
 )
 
+genrule(
+    name = "testonly-deps-sorted",
+    srcs = [":testonly-deps"],
+    outs = ["testonly-deps-sorted.txt"],
+    cmd = "cat $< | sort > $@",
+    testonly = 1,
+)
+
 diff_test(
     name = "testonly_artifacts_test",
     file1 = select({
         "@bazel_tools//src/conditions:windows": "testonly-deps.golden",
         "//conditions:default": "testonly-deps.golden.unix",
     }),
-    file2 = ":testonly-deps",
+    file2 = ":testonly-deps-sorted",
 )
 
 # https://github.com/coursier/coursier/issues/1792
@@ -50,13 +58,21 @@ genquery(
     scope = ["@version_interval_testing//:io_grpc_grpc_netty_shaded"],
 )
 
+genrule(
+    name = "version-interval-deps-sorted",
+    srcs = [":version_interval_deps"],
+    outs = ["version-interval-deps-sorted.txt"],
+    cmd = "cat $< | sort > $@",
+    testonly = 1,
+)
+
 diff_test(
     name = "version_interval_deps_test",
     file1 = select({
         "@bazel_tools//src/conditions:windows": "version-interval-deps.golden.dos",
         "//conditions:default": "version-interval-deps.golden.unix",
     }),
-    file2 = ":version_interval_deps",
+    file2 = ":version-interval-deps-sorted.txt",
 )
 
 java_import(

--- a/tests/integration/version-interval-deps.golden.dos
+++ b/tests/integration/version-interval-deps.golden.dos
@@ -1,9 +1,9 @@
-@version_interval_testing//:io_grpc_grpc_netty_shaded
-@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.29.0/grpc-netty-shaded-1.29.0.jar
-@version_interval_testing//:io_grpc_grpc_core
-@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.29.0/grpc-core-1.29.0.jar
-@version_interval_testing//:io_perfmark_perfmark_api
-@version_interval_testing//:io_grpc_grpc_api
-@version_interval_testing//:com_google_errorprone_error_prone_annotations
-@version_interval_testing//:com_google_code_gson_gson
 @version_interval_testing//:com_google_android_annotations
+@version_interval_testing//:com_google_code_gson_gson
+@version_interval_testing//:com_google_errorprone_error_prone_annotations
+@version_interval_testing//:io_grpc_grpc_api
+@version_interval_testing//:io_grpc_grpc_core
+@version_interval_testing//:io_grpc_grpc_netty_shaded
+@version_interval_testing//:io_perfmark_perfmark_api
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.29.0/grpc-core-1.29.0.jar
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.29.0/grpc-netty-shaded-1.29.0.jar

--- a/tests/integration/version-interval-deps.golden.unix
+++ b/tests/integration/version-interval-deps.golden.unix
@@ -1,9 +1,9 @@
-@version_interval_testing//:io_grpc_grpc_netty_shaded
-@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.29.0/grpc-netty-shaded-1.29.0.jar
-@version_interval_testing//:io_grpc_grpc_core
-@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.29.0/grpc-core-1.29.0.jar
-@version_interval_testing//:io_perfmark_perfmark_api
-@version_interval_testing//:io_grpc_grpc_api
-@version_interval_testing//:com_google_errorprone_error_prone_annotations
-@version_interval_testing//:com_google_code_gson_gson
 @version_interval_testing//:com_google_android_annotations
+@version_interval_testing//:com_google_code_gson_gson
+@version_interval_testing//:com_google_errorprone_error_prone_annotations
+@version_interval_testing//:io_grpc_grpc_api
+@version_interval_testing//:io_grpc_grpc_core
+@version_interval_testing//:io_grpc_grpc_netty_shaded
+@version_interval_testing//:io_perfmark_perfmark_api
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.29.0/grpc-core-1.29.0.jar
+@version_interval_testing//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.29.0/grpc-netty-shaded-1.29.0.jar


### PR DESCRIPTION
This presorts the outputs of genquery before testing them, making them independent of graphless query or the bazel version under test.

Fixes: #529