### PR TITLE
Add support for custom java install for coursier

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -142,7 +142,10 @@ def _generate_java_jar_command(repository_ctx, jar_path):
     coursier_opts = repository_ctx.os.environ.get("COURSIER_OPTS", "")
     coursier_opts = coursier_opts.split(" ") if len(coursier_opts) > 0 else []
 
-    if java_home != None:
+    if repository_ctx.attr.java_binary != None:
+        java = repository_ctx.path(repository_ctx.attr.java_binary)
+        cmd = [java, "-noverify", "-jar"] + coursier_opts + _get_java_proxy_args(repository_ctx) + [jar_path]
+    elif java_home != None:
         # https://github.com/coursier/coursier/blob/master/doc/FORMER-README.md#how-can-the-launcher-be-run-on-windows-or-manually-with-the-java-program
         # The -noverify option seems to be required after the proguarding step
         # of the main JAR of coursier.
@@ -1120,6 +1123,7 @@ coursier_fetch = repository_rule(
         "resolve_timeout": attr.int(default = 600),
         "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
+        "java_binary": attr.label(doc = "Full path to a java executable", default = None),
         "use_starlark_android_rules": attr.bool(default = False, doc = "Whether to use the native or Starlark version of the Android rules."),
         "aar_import_bzl_label": attr.string(default = DEFAULT_AAR_IMPORT_LABEL, doc = "The label (as a string) to use to import aar_import from"),
     },

--- a/defs.bzl
+++ b/defs.bzl
@@ -39,6 +39,7 @@ def maven_install(
         resolve_timeout = 600,
         jetify = False,
         jetify_include_list = JETIFY_INCLUDE_LIST_JETIFY_ALL,
+        java_binary = None,
         additional_netrc_lines = [],
         fail_if_repin_required = False,
         use_starlark_android_rules = False,
@@ -77,6 +78,7 @@ def maven_install(
       resolve_timeout: The execution timeout of resolving and fetching artifacts.
       jetify: Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.
       jetify_include_list: List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.
+      java_binary: Label pointing to a java binary if you want to provide a custom installation (default: None)
       additional_netrc_lines: Additional lines prepended to the netrc file used by `http_file` (with `maven_install_json` only).
       fail_if_repin_required: Whether to fail the build if the required maven artifacts have been changed but not repinned. Requires the `maven_install_json` to have been set.
       use_starlark_android_rules: Whether to use the native or Starlark version
@@ -134,6 +136,7 @@ def maven_install(
         resolve_timeout = resolve_timeout,
         jetify = jetify,
         jetify_include_list = jetify_include_list,
+        java_binary = java_binary,
         use_starlark_android_rules = use_starlark_android_rules,
         aar_import_bzl_label = aar_import_bzl_label,
     )


### PR DESCRIPTION
We are using this to avoid java versions mismatch between environments (where some machines may have jdk1.8 or jdk14 instead of jdk11), which causes pinning to generate different results.

A rough example of how we use this with a `repository_rule`
```
JAVA_EXEC_TEMPLATE = """
#!/usr/bin/env bash
exec %s "$@"
"""

BUILD_FILE_CONTENTS = """
exports_files(["java"])
"""

def _jdkenv(repository_ctx):
    cwd = repository_ctx.execute(["pwd"]).stdout.strip()
    java_bin = download_jdk11()
    repository_ctx.file(
        "java",
        content = JAVA_EXEC_TEMPLATE % java_bin,
        executable = True,
    )

    repository_ctx.file("BUILD", content = BUILD_FILE_CONTENTS)
jdkenv = repository_rule(
    implementation = _jdkenv,
    environ = ["JAVA_HOME"],
    doc = """Repository rule for detecting jdk11:
@repo//:java -- Java binary
""",
```
And in `maven_install`:
```
load("@rules_jvm_external//:defs.bzl", "maven_install")
load("//tools/build:jdk.bzl", "jdkenv")

jdkenv(
    name = "jdk11",
)
maven_install(
        name = "jvm_es_deps",
        ....
        java_binary = "@jdk11//:java",
)   
```