### PR TITLE
Add a `deploy_env` attribute to `java_export`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+# API Reference
+
+- [Basic functions](#basic-functions)
+  - [javadoc](#javadoc)
+  - [java_export](#java_export)
+  - [maven_install](#maven_install)
+- [Maven specification functions](#maven-specification-functions)
+  - [maven.repository](#mavenrepository)
+  - [maven.artifact](#mavenartifact)
+  - [maven.exclusion](#mavenexclusion)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Basic functions
 
 These are the basic functions to get started.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,18 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# API Reference
-
-- [Basic functions](#basic-functions)
-  - [javadoc](#javadoc)
-  - [java_export](#java_export)
-  - [maven_install](#maven_install)
-- [Maven specification functions](#maven-specification-functions)
-  - [maven.repository](#mavenrepository)
-  - [maven.artifact](#mavenartifact)
-  - [maven.exclusion](#mavenexclusion)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Basic functions
 
 These are the basic functions to get started.
@@ -48,7 +33,7 @@ Generate a javadoc from all the `deps`
 ## java_export
 
 <pre>
-java_export(<a href="#java_export-name">name</a>, <a href="#java_export-maven_coordinates">maven_coordinates</a>, <a href="#java_export-pom_template">pom_template</a>, <a href="#java_export-visibility">visibility</a>, <a href="#java_export-tags">tags</a>, <a href="#java_export-kwargs">kwargs</a>)
+java_export(<a href="#java_export-name">name</a>, <a href="#java_export-maven_coordinates">maven_coordinates</a>, <a href="#java_export-deploy_env">deploy_env</a>, <a href="#java_export-pom_template">pom_template</a>, <a href="#java_export-visibility">visibility</a>, <a href="#java_export-tags">tags</a>, <a href="#java_export-kwargs">kwargs</a>)
 </pre>
 
 Extends `java_library` to allow maven artifacts to be uploaded.
@@ -97,6 +82,7 @@ Generated rules:
 | :-------------: | :-------------: | :-------------: |
 | name |  A unique name for this target   |  none |
 | maven_coordinates |  The maven coordinates for this target.   |  none |
+| deploy_env |  A list of labels of java targets to exclude from the generated jar   |  <code>[]</code> |
 | pom_template |  The template to be used for the pom.xml file.   |  <code>None</code> |
 | visibility |  The visibility of the target   |  <code>None</code> |
 | tags |  <p align="center"> - </p>   |  <code>[]</code> |
@@ -112,7 +98,7 @@ maven_install(<a href="#maven_install-name">name</a>, <a href="#maven_install-re
               <a href="#maven_install-use_unsafe_shared_cache">use_unsafe_shared_cache</a>, <a href="#maven_install-excluded_artifacts">excluded_artifacts</a>, <a href="#maven_install-generate_compat_repositories">generate_compat_repositories</a>,
               <a href="#maven_install-version_conflict_policy">version_conflict_policy</a>, <a href="#maven_install-maven_install_json">maven_install_json</a>, <a href="#maven_install-override_targets">override_targets</a>, <a href="#maven_install-strict_visibility">strict_visibility</a>,
               <a href="#maven_install-resolve_timeout">resolve_timeout</a>, <a href="#maven_install-jetify">jetify</a>, <a href="#maven_install-jetify_include_list">jetify_include_list</a>, <a href="#maven_install-additional_netrc_lines">additional_netrc_lines</a>,
-              <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>)
+              <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>, <a href="#maven_install-use_starlark_android_rules">use_starlark_android_rules</a>, <a href="#maven_install-aar_import_bzl_label">aar_import_bzl_label</a>)
 </pre>
 
 Resolves and fetches artifacts transitively from Maven repositories.
@@ -144,6 +130,8 @@ and fetch Maven artifacts transitively.
 | jetify_include_list |  List of artifacts that need to be jetified in <code>groupId:artifactId</code> format. By default all artifacts are jetified if <code>jetify</code> is set to True.   |  <code>["*"]</code> |
 | additional_netrc_lines |  Additional lines prepended to the netrc file used by <code>http_file</code> (with <code>maven_install_json</code> only).   |  <code>[]</code> |
 | fail_if_repin_required |  Whether to fail the build if the required maven artifacts have been changed but not repinned. Requires the <code>maven_install_json</code> to have been set.   |  <code>False</code> |
+| use_starlark_android_rules |  Whether to use the native or Starlark version   of the Android rules. Default is False.   |  <code>False</code> |
+| aar_import_bzl_label |  The label (as a string) to use to import aar_import   from. This is usually needed only if the top-level workspace file does   not use the typical default repository name to import the Android   Starlark rules. Default is   "@build_bazel_rules_android//rules:rules.bzl".   |  <code>"@build_bazel_rules_android//android:rules.bzl"</code> |
 
 
 # Maven specification functions

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -6,6 +6,7 @@ load("//private/rules:pom_file.bzl", "pom_file")
 def java_export(
         name,
         maven_coordinates,
+        deploy_env = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -52,6 +53,7 @@ def java_export(
       name: A unique name for this target
       maven_coordinates: The maven coordinates for this target.
       pom_template: The template to be used for the pom.xml file.
+      deploy_env: A list of labels of java targets to exclude from the generated jar
       visibility: The visibility of the target
       kwargs: These are passed to [`java_library`](https://docs.bazel.build/versions/master/be/java.html#java_library),
         and so may contain any valid parameter for that rule.
@@ -71,6 +73,7 @@ def java_export(
     maven_project_jar(
         name = "%s-project" % name,
         target = ":%s" % lib_name,
+        deploy_env = deploy_env,
         tags = tags,
     )
 

--- a/private/rules/maven_project_jar.bzl
+++ b/private/rules/maven_project_jar.bzl
@@ -28,7 +28,9 @@ def _maven_project_jar_impl(ctx):
         ctx,
         ctx.executable._merge_jars,
         artifact_jars,
-        depset(transitive = [ji.transitive_runtime_jars for ji in info.dep_infos.to_list()]).to_list(),
+        depset(transitive =
+            [ji.transitive_runtime_jars for ji in info.dep_infos.to_list()] +
+            [jar[JavaInfo].transitive_runtime_jars for jar in ctx.attr.deploy_env]).to_list(),
         bin_jar,
     )
 
@@ -101,6 +103,13 @@ single artifact that other teams can download and use.
             aspects = [
                 has_maven_deps,
             ],
+        ),
+        "deploy_env": attr.label_list(
+            doc = "A list of targets to exclude from the generated jar",
+            providers = [
+                [JavaInfo],
+            ],
+            allow_empty = True,
         ),
         # Bazel's own singlejar doesn't respect java service files,
         # so use our own.

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -1,4 +1,4 @@
-load("//:defs.bzl", "artifact")
+load("//:defs.bzl", "artifact", "java_export")
 load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
 
 java_test(
@@ -54,5 +54,41 @@ java_library(
     srcs = ["Dependency.java"],
     deps = [
         artifact("com.google.guava:guava"),
+    ],
+)
+
+java_export(
+    name = "deploy-env",
+    srcs = [
+        "Main.java",
+    ],
+    deploy_env = [
+        ":dep",
+    ],
+    maven_coordinates = "com.example:lib:1.0.0",
+    deps = [
+        ":dep",
+    ],
+)
+
+genrule(
+    name = "list-deploy-env-classes",
+    srcs = [
+        ":deploy-env-project",
+    ],
+    outs = ["classes.txt"],
+    cmd = "for SRC in $(SRCS); do jar tf $$SRC >> $@; done",
+)
+
+sh_test(
+    name = "check-deploy-env",
+    srcs = [
+        "check-deploy-env.sh",
+    ],
+    data = [
+        ":classes.txt",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/tests/integration/java_export/check-deploy-env.sh
+++ b/tests/integration/java_export/check-deploy-env.sh
@@ -1,0 +1,22 @@
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euox pipefail
+
+classes_file=$(rlocation rules_jvm_external/tests/integration/java_export/classes.txt)
+
+if grep -q Dependency.class "$classes_file"; then
+  exit 1
+fi
+
+if ! grep -q Main.class "$classes_file"; then
+  exit 2
+fi  

--- a/tests/integration/java_export/check-deploy-env.sh
+++ b/tests/integration/java_export/check-deploy-env.sh
@@ -14,9 +14,11 @@ set -euox pipefail
 classes_file=$(rlocation rules_jvm_external/tests/integration/java_export/classes.txt)
 
 if grep -q Dependency.class "$classes_file"; then
+  echo "Unexpectedly found dependency class in jar"
   exit 1
 fi
 
 if ! grep -q Main.class "$classes_file"; then
-  exit 2
+  echo "Missing main class from jar"
+  exit 1
 fi  


### PR DESCRIPTION
This allows `java_export` to be used to generate things such as
plugins for Apache Spark or jar files for use in JEE servers by
excluding provided dependencies from the generated jars. This is
analagous to maven's `provided` scope, and maps to the `deploy_env`
attribute of `java_binary`.

The difference between `java_export` and `java_binary`'s `deploy_env`
is that `java_export` allows anything that provides a `JavaInfo` as an
input to `deploy_env`. This is because the expected use-cases are for
things that are normally provided as regular imports from a maven
dependency, rather than a custom binary.