### PR TITLE
Set RBE machine type with KVM for instrumentation tests

### DIFF
--- a/examples/android_instrumentation_test/BUILD
+++ b/examples/android_instrumentation_test/BUILD
@@ -22,5 +22,9 @@ platform(
             name: "dockerPrivileged"
             value: "true"
         }
+        properties: {
+            name: "gceMachineType"
+            value: "n1-standard-2"
+        }
 """,
 )


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_jvm_external/issues/536

Same fix applied to android/testing-samples in https://github.com/android/testing-samples/pull/327