### PR TITLE
Fix proxy parsing when HTTP_PROXY doesn't have a scheme (#541)

### DIFF
--- a/private/proxy.bzl
+++ b/private/proxy.bzl
@@ -1,30 +1,35 @@
+def _strip_url_scheme(url):
+    return url.split("://", 1)[1] if "://" in url else url
+
 def _get_proxy_user(url):
-    netloc = url.split("://", 1)[1]
-    if "@" in netloc:
-        userinfo = netloc.rsplit("@", 1)[0]
+    no_scheme_url = _strip_url_scheme(url)
+    if "@" in no_scheme_url:
+        userinfo = no_scheme_url.rsplit("@", 1)[0]
         if ":" in userinfo:
             userinfo = userinfo.split(":", 1)[0]
         return userinfo
     return None
 
 def _get_proxy_password(url):
-    netloc = url.split("://", 1)[1]
-    if "@" in netloc:
-        userinfo = netloc.rsplit("@", 1)[0]
+    no_scheme_url = _strip_url_scheme(url)
+    if "@" in no_scheme_url:
+        userinfo = no_scheme_url.rsplit("@", 1)[0]
         if ":" in userinfo:
             userinfo = userinfo.split(":", 1)[1]
         return userinfo
     return None
 
 def _get_proxy_hostname(url):
-    netloc = url.split("://", 1)[1].split("@")[-1]
+    no_scheme_url = _strip_url_scheme(url)
+    netloc = no_scheme_url.split("@")[-1]
     if ":" in netloc:
         return netloc.split(":")[0]
     else:
         return netloc
 
 def _get_proxy_port(url):
-    netloc = url.split("://", 1)[1].split("/")[0].split("@")[-1]
+    no_scheme_url = _strip_url_scheme(url)
+    netloc = no_scheme_url.split("/")[0].split("@")[-1]
     if ":" in netloc:
         return netloc.split(":")[1]
     else:

--- a/tests/unit/proxy_test.bzl
+++ b/tests/unit/proxy_test.bzl
@@ -9,6 +9,23 @@ def _java_proxy_parsing_empty_test_impl(ctx):
 
 java_proxy_parsing_empty_test = unittest.make(_java_proxy_parsing_empty_test_impl)
 
+def _java_proxy_parsing_no_scheme_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        [
+            "-Dhttp.proxyHost=localhost",
+            "-Dhttp.proxyPort=8888",
+            "-Dhttps.proxyHost=localhost",
+            "-Dhttps.proxyPort=8843",
+            "-Dhttp.nonProxyHosts=google.com",
+        ],
+        get_java_proxy_args("localhost:8888", "localhost:8843", "google.com"),
+    )
+    return unittest.end(env)
+
+java_proxy_parsing_no_scheme_test = unittest.make(_java_proxy_parsing_no_scheme_test_impl)
+
 def _java_proxy_parsing_no_user_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(
@@ -83,6 +100,7 @@ def proxy_test_suite():
     unittest.suite(
         "proxy_tests",
         java_proxy_parsing_empty_test,
+        java_proxy_parsing_no_scheme_test,
         java_proxy_parsing_no_user_test,
         java_proxy_parsing_no_port_test,
         java_proxy_parsing_trailing_slash_test,


### PR DESCRIPTION
Fix for HTTP_PROXY parsing when url doesn't have a scheme https://github.com/bazelbuild/rules_jvm_external/issues/541