### PR TITLE
feat(pin): allow only repinning the rules_jvm_external lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,11 @@ a build error, causing the build to fail. When this attribute is set,
 it is possible to update the `maven_install.json` file using:
 
 ```shell
-$ REPIN=1 bazel run @unpinned_maven//:pin
+# To repin everything:
+REPIN=1 bazel run @unpinned_maven//:pin
+
+# To only repin rules_jvm_external:
+RULES_JVM_EXTERNAL_REPIN=1 bazel run @unpinned_maven//:pin
 ```
 
 Alternatively, it is also possible to modify the

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -41,7 +41,6 @@ _AAR_IMPORT_STATEMENT = """\
 load("%s", "aar_import")
 """
 
-
 _BUILD_PIN = """
 genrule(
     name = "jq-binary",
@@ -128,12 +127,12 @@ def _relativize_and_symlink_file(repository_ctx, absolute_path):
     return artifact_relative_path
 
 def _get_aar_import_statement_or_empty_str(repository_ctx):
-  if repository_ctx.attr.use_starlark_android_rules:
-    # parse the label to validate it
-    _ = Label(repository_ctx.attr.aar_import_bzl_label)
-    return _AAR_IMPORT_STATEMENT % repository_ctx.attr.aar_import_bzl_label
-  else:
-    return ""
+    if repository_ctx.attr.use_starlark_android_rules:
+        # parse the label to validate it
+        _ = Label(repository_ctx.attr.aar_import_bzl_label)
+        return _AAR_IMPORT_STATEMENT % repository_ctx.attr.aar_import_bzl_label
+    else:
+        return ""
 
 # Generate the base `coursier` command depending on the OS, JAVA_HOME or the
 # location of `java`.

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -337,7 +337,8 @@ def _fail_if_repin_required(repository_ctx):
     if not repository_ctx.attr.fail_if_repin_required:
         return False
 
-    return "REPIN" not in repository_ctx.os.environ.keys()
+    env_var_names = repository_ctx.os.environ.keys()
+    return "RULES_JVM_EXTERNAL_REPIN" not in env_var_names and "REPIN" not in env_var_names
 
 def _pinned_coursier_fetch_impl(repository_ctx):
     if not repository_ctx.attr.maven_install_json:


### PR DESCRIPTION
---

#### Commits _(oldest to newest)_

d49ec1f feat(pin): allow only repinning the rules_jvm_external lockfile

Now that rules_rust and rules_jvm_external both support the same
repinning method, make it possible to choose to repin a single lockfile
or all lockfiles.

Refs: https://github.com/bazelbuild/rules_rust/pull/682

<br/>