### PR TITLE
Replace uses of JavaInfo.transitive_export with custom label collection.

### DIFF
--- a/private/rules/maven_project_jar.bzl
+++ b/private/rules/maven_project_jar.bzl
@@ -53,9 +53,7 @@ def _maven_project_jar_impl(ctx):
 
     # Grab the exported javainfos
     exported_infos = []
-    targets = [] + target[JavaInfo].transitive_exports.to_list()
-    for i in info.artifact_infos.to_list():
-        targets.extend(i.transitive_exports.to_list())
+    targets = target[MavenInfo].transitive_exports.to_list()
 
     for label in targets:
         export_info = info.label_to_javainfo.get(label)


### PR DESCRIPTION
In order to simplify `JavaInfo` provider, we're removing `transitive_exports` from it (and the native `TransitiveExportsProvider`). 

`rules_jvm_external` is the only downstream project, that this change breaks.

This PR works with both older and newer versions of Bazel.

Collecting exported labels in an aspect is a better option, because it work also over other Java-like targets (Kotlin, Android) which have JavaInfo provider. `transitive_exports` also creates problems when defining `JavaInfo()` and `java_common.compile` API (because Labels would need to be passed in).

Issue: https://github.com/bazelbuild/bazel/issues/13457

Design document: https://docs.google.com/document/d/10isTEK5W9iCPp4BIyGBrLY5iti3Waaam6EeGVSjq3r8/edit#bookmark=id.34gjanvu5611