### PR TITLE
Use @// instead of @${workspace_name}//

### DIFF
--- a/private/pin.sh
+++ b/private/pin.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 readonly maven_install_json_loc={maven_install_location}
-# This script is run as a `sh_binary`, so ensure we are in the calling workspace before running Bazel.
-readonly execution_root=$(cd "$(dirname "$maven_install_json_loc")" && bazel info execution_root)
-readonly workspace_name=$(basename "$execution_root")
 # `jq` is a platform-specific dependency with an unpredictable path.
 # Note that $(rootpath) will always give external/unpinned_maven/jq, however under --nolegacy_external_runfiles
 # there is only pin.runfiles/unpinned_maven/jq not also pin.runfiles/user_repo/external/unpinned_maven/jq
@@ -31,7 +28,7 @@ else
 maven_install(
     artifacts = # ...,
     repositories = # ...,
-    maven_install_json = "@$workspace_name//:{repository_name}_install.json",
+    maven_install_json = "@//:{repository_name}_install.json",
 )
 
 load("@{repository_name}//:defs.bzl", "pinned_maven_install")


### PR DESCRIPTION
@// refers to the root workspace of the bazel invocation, regardless of
which repository it's referred to in.

This avoids needing to run `bazel info` from inside the `bazel run`.