### PR TITLE
Remove build_tools_version and api_level

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,6 @@
 workspace(name = "rules_jvm_external")
 
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load(


### PR DESCRIPTION
Remove `build_tools_version` and `api_level` to let `android_sdk_repository` automatically select the latest installed version.

One of the fixes for https://github.com/bazelbuild/bazel/issues/13409#issuecomment-845265150