### PR TITLE
Don't export via deps, only via exports

### DIFF
--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -108,7 +108,6 @@ def _extract_from(gathered, maven_info, dep):
             gathered.dep_infos.append(dep[JavaInfo])
         else:
             gathered.artifact_infos.append(dep[JavaInfo])
-            gathered.transitive_exports.append(maven_info.transitive_exports)
 
 def _has_maven_deps_impl(target, ctx):
     if not JavaInfo in target:
@@ -129,7 +128,6 @@ def _has_maven_deps_impl(target, ctx):
     gathered = _gathered(
         all_infos = [],
         artifact_infos = [target[JavaInfo]],
-        transitive_exports = [],
         dep_infos = [],
         label_to_javainfo = {target.label: target[JavaInfo]},
     )
@@ -146,7 +144,6 @@ def _has_maven_deps_impl(target, ctx):
 
     all_infos = gathered.all_infos
     artifact_infos = gathered.artifact_infos
-    transitive_exports_from_deps = gathered.transitive_exports
     dep_infos = gathered.dep_infos
     label_to_javainfo = gathered.label_to_javainfo
     maven_deps = depset(transitive = [i.as_maven_dep for i in all_infos])
@@ -166,7 +163,7 @@ def _has_maven_deps_impl(target, ctx):
         artifact_infos = depset(direct = artifact_infos),
         dep_infos = depset(direct = dep_infos, transitive = [i.dep_infos for i in all_infos]),
         label_to_javainfo = label_to_javainfo,
-        transitive_exports = depset(transitive = [transitive_exports_from_exports] + transitive_exports_from_deps)
+        transitive_exports = depset(transitive = [transitive_exports_from_exports])
     )
 
     return [

--- a/tests/unit/exports/BUILD
+++ b/tests/unit/exports/BUILD
@@ -1,0 +1,3 @@
+load("//tests/unit/exports:exports_test.bzl", "exports_tests")
+
+exports_tests(name = "exports_tests")

--- a/tests/unit/exports/exports_test.bzl
+++ b/tests/unit/exports/exports_test.bzl
@@ -16,6 +16,7 @@ exports_test = analysistest.make(
     _exports_test_impl,
     attrs = {
         # We can't just use target_under_test because we need to add our own aspect to the attribute.
+        # See https://github.com/bazelbuild/bazel-skylib/pull/299
         "target_under_test_with_aspect": attr.label(aspects = [has_maven_deps], mandatory = True),
     },
 )

--- a/tests/unit/exports/exports_test.bzl
+++ b/tests/unit/exports/exports_test.bzl
@@ -1,0 +1,61 @@
+"""Unit tests for exports."""
+
+load("//private/rules:has_maven_deps.bzl", "MavenInfo", "has_maven_deps")
+load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _exports_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = env.ctx.attr.target_under_test_with_aspect
+    asserts.true(env, MavenInfo in tut, "java_library should provide MavenInfo")
+    maven_info = tut[MavenInfo]
+    asserts.equals(env, [Label("//tests/unit/exports:exported_leaf"), Label("//tests/unit/exports:is_export_has_exports")], maven_info.transitive_exports.to_list())
+    return analysistest.end(env)
+
+exports_test = analysistest.make(
+    _exports_test_impl,
+    attrs = {
+        # We can't just use target_under_test because we need to add our own aspect to the attribute.
+        "target_under_test_with_aspect": attr.label(aspects = [has_maven_deps], mandatory = True),
+    },
+)
+
+def exports_tests(name):
+    native.java_library(
+        name = "library_to_test",
+        deps = [":is_dep_has_exports", ":is_export_has_exports"],
+        exports = [":is_export_has_exports"],
+        srcs = ["Foo.java"],
+    )
+
+    native.java_library(
+        name = "is_dep_has_exports",
+        deps = [":leaf"],
+        exports = [":leaf"],
+        srcs = ["Foo.java"],
+    )
+
+    native.java_library(
+        name = "is_export_has_exports",
+        deps = [":exported_leaf"],
+        exports = [":exported_leaf"],
+        srcs = ["Foo.java"],
+    )
+
+    native.java_library(
+        name = "leaf",
+        srcs = ["Foo.java"],
+    )
+
+    native.java_library(
+        name = "exported_leaf",
+        srcs = ["Foo.java"],
+    )
+
+    native.filegroup(name = "ignored")
+
+    exports_test(
+        name = "exports_test",
+        target_under_test = ":ignored",
+        target_under_test_with_aspect = ":library_to_test",
+    )


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/pull/557 replaced using
`JavaInfo.transitive_exports` by instead using
`HasMavenDeps.transitive_exports` but it changed how this was computed.

The JavaInfo traversal code:
https://github.com/bazelbuild/bazel/blob/5a647bb234ba9817f51fdb2b4b5973a0602f51a4/src/main/java/com/google/devtools/build/lib/rules/java/JavaCommon.java#L341-L357
only follows the `exports` attribute, and merges together each of the
transitive exports it finds that way.

The replacement starlark code was traversing each of `deps`, `exports`,
and `runtime_deps`, looking for anything which may have been exported
_to_ those targets, which exports significantly more targets.

This adds a unit test to prevent future regressions.