### PR TITLE
Replace bazel_json with json.decode for #472

### DIFF
--- a/private/rules/json.bzl
+++ b/private/rules/json.bzl
@@ -2,7 +2,7 @@ load("//third_party/bazel_skylib/lib:versions.bzl", "versions")
 load("//third_party/bazel_json/lib:json_parser.bzl", "json_parse")
 
 def json_decode(s):
-    if  versions.is_at_least("4.0.0", native.bazel_version):
+    if "bazel_version" in dir(native) and versions.is_at_least("4.0.0", native.bazel_version):
         return json.decode(s)
     else:
         return json_parse(s)

--- a/private/rules/json.bzl
+++ b/private/rules/json.bzl
@@ -1,0 +1,8 @@
+load("//third_party/bazel_skylib/lib:versions.bzl", "versions")
+load("//third_party/bazel_json/lib:json_parser.bzl", "json_parse")
+
+def json_decode(s):
+    if  versions.is_at_least("4.0.0", native.bazel_version):
+        return json.decode(s)
+    else:
+        return json_parse(s)

--- a/third_party/bazel_skylib/LICENSE
+++ b/third_party/bazel_skylib/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/bazel_skylib/README.md
+++ b/third_party/bazel_skylib/README.md
@@ -1,0 +1,5 @@
+# bazel-skylib
+
+- Source: https://github.com/bazelbuild/bazel-skylib
+- Commit: df3c9e2735f02a7fe8cd80db4db00fec8e13d25f
+- License: Apache-2.0

--- a/third_party/bazel_skylib/lib/versions.bzl
+++ b/third_party/bazel_skylib/lib/versions.bzl
@@ -1,0 +1,128 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing functions for checking Bazel versions."""
+
+def _get_bazel_version():
+    """Returns the current Bazel version"""
+
+    return native.bazel_version
+
+def _extract_version_number(bazel_version):
+    """Extracts the semantic version number from a version string
+
+    Args:
+      bazel_version: the version string that begins with the semantic version
+        e.g. "1.2.3rc1 abc1234" where "abc1234" is a commit hash.
+
+    Returns:
+      The semantic version string, like "1.2.3".
+    """
+    for i in range(len(bazel_version)):
+        c = bazel_version[i]
+        if not (c.isdigit() or c == "."):
+            return bazel_version[:i]
+    return bazel_version
+
+# Parse the bazel version string from `native.bazel_version`.
+# e.g.
+# "0.10.0rc1 abc123d" => (0, 10, 0)
+# "0.3.0" => (0, 3, 0)
+def _parse_bazel_version(bazel_version):
+    """Parses a version string into a 3-tuple of ints
+
+    int tuples can be compared directly using binary operators (<, >).
+
+    Args:
+      bazel_version: the Bazel version string
+
+    Returns:
+      An int 3-tuple of a (major, minor, patch) version.
+    """
+
+    version = _extract_version_number(bazel_version)
+    return tuple([int(n) for n in version.split(".")])
+
+def _is_at_most(threshold, version):
+    """Check that a version is lower or equals to a threshold.
+
+    Args:
+      threshold: the maximum version string
+      version: the version string to be compared to the threshold
+
+    Returns:
+      True if version <= threshold.
+    """
+    return _parse_bazel_version(version) <= _parse_bazel_version(threshold)
+
+def _is_at_least(threshold, version):
+    """Check that a version is higher or equals to a threshold.
+
+    Args:
+      threshold: the minimum version string
+      version: the version string to be compared to the threshold
+
+    Returns:
+      True if version >= threshold.
+    """
+
+    return _parse_bazel_version(version) >= _parse_bazel_version(threshold)
+
+def _check_bazel_version(minimum_bazel_version, maximum_bazel_version = None, bazel_version = None):
+    """Check that the version of Bazel is valid within the specified range.
+
+    Args:
+      minimum_bazel_version: minimum version of Bazel expected
+      maximum_bazel_version: maximum version of Bazel expected
+      bazel_version: the version of Bazel to check. Used for testing, defaults to native.bazel_version
+    """
+    if not bazel_version:
+        if "bazel_version" not in dir(native):
+            fail("Current Bazel version is lower than 0.2.1; expected at least {}".format(
+                minimum_bazel_version,
+            ))
+        elif not native.bazel_version:
+            # Using a non-release version, assume it is good.
+            return
+        else:
+            bazel_version = native.bazel_version
+
+    if not _is_at_least(
+        threshold = minimum_bazel_version,
+        version = bazel_version,
+    ):
+        fail("Current Bazel version is {}; expected at least {}".format(
+            bazel_version,
+            minimum_bazel_version,
+        ))
+
+    if maximum_bazel_version:
+        if not _is_at_most(
+            threshold = maximum_bazel_version,
+            version = bazel_version,
+        ):
+            fail("Current Bazel version is {}; expected at most {}".format(
+                bazel_version,
+                maximum_bazel_version,
+            ))
+
+    pass
+
+versions = struct(
+    get = _get_bazel_version,
+    parse = _parse_bazel_version,
+    check = _check_bazel_version,
+    is_at_most = _is_at_most,
+    is_at_least = _is_at_least,
+)


### PR DESCRIPTION
For our 32k line JSON lock file evaluation of `_pinned_coursier_fetch_impl` went from 14000ms to 250ms.
There are some downsides to this change:

- Requires Bazel >= 4.0.0
- Loses the nice error message if the lock file is malformed

If we don't want to require 4.0.0, we could keep the old parser around and only use this if it's available. I couldn't figure out how to check if the `json` module is available or a simple way to check the bazel version (the one I know about seemed quite [complicated](https://github.com/bazelbuild/rules_nodejs/blob/stable/internal/common/check_bazel_version.bzl)).