### PR TITLE
Remove build_tools_version and api_level from example workspace files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,6 @@
 workspace(name = "rules_jvm_external")
 
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load(

--- a/examples/android_instrumentation_test/WORKSPACE
+++ b/examples/android_instrumentation_test/WORKSPACE
@@ -1,10 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 android_ndk_repository(
     name = "androidndk",

--- a/examples/android_kotlin_app/WORKSPACE
+++ b/examples/android_kotlin_app/WORKSPACE
@@ -1,10 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 # BEGIN io_bazel_rules_kotlin
 

--- a/examples/android_local_test/WORKSPACE
+++ b/examples/android_local_test/WORKSPACE
@@ -1,10 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 http_archive(
     name = "robolectric",

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -1,8 +1,4 @@
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 local_repository(
     name = "rules_jvm_external",


### PR DESCRIPTION
Remove `build_tools_version` and `api_level` from workspace file in examples to let `android_sdk_repository` automatically select the latest installed version. See https://github.com/bazelbuild/bazel/issues/13409