### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 tasks:
-  ubuntu1604:
+  ubuntu1804:
     environment:
       # This tests custom cache locations.
       # https://github.com/bazelbuild/rules_jvm_external/pull/316


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.