### PR TITLE
Print a warning when there is a duplicate artifact in the artifact list

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,7 +9,7 @@ tasks:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_flags:
       - "--//settings:stamp_manifest=True"
     test_targets:
@@ -33,7 +33,7 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_targets:
       - "--"
       - "//..."
@@ -43,7 +43,7 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_targets:
       - "--"
       - "//..."
@@ -53,7 +53,7 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_targets:
       - "--"
       - "//..."
@@ -68,7 +68,7 @@ tasks:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_targets:
       - "--"
       - "//..."
@@ -81,7 +81,7 @@ tasks:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_flags:
       - "--//settings:stamp_manifest=True"
     test_targets:
@@ -98,7 +98,7 @@ tasks:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
-      - bazel run @regression_testing//:outdated
+      - tests/bazel_run_tests.sh
     test_targets:
       - "--"
       - "//..."

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Table of Contents
          * [Hiding transitive dependencies](#hiding-transitive-dependencies)
          * [Fetch and resolve timeout](#fetch-and-resolve-timeout)
          * [Jetifier](#jetifier)
+         * [Duplicate artifact warning](#duplicate-artifact-warning)
       * [Exporting and consuming artifacts from external repositories](#exporting-and-consuming-artifacts-from-external-repositories)
       * [Publishing to external repositories](#publishing-to-external-repositories)
       * [Demo](#demo)
@@ -890,6 +891,22 @@ maven_install(
     jetify_include_list = [
         "exampleGroupId:exampleArtifactId",
     ],
+)
+```
+
+### Duplicate artifact warning
+
+By default you will be warned if there are duplicate artifacts in your artifact list. The `duplicate_version_warning` setting can be used to change this behavior. Use "none" to disable the warning and "error" to fail the build instead of warn.
+
+```python
+maven_install(
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    duplicate_version_warning = "error"
 )
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -364,6 +364,33 @@ maven_install(
 )
 
 maven_install(
+    name = "duplicate_version_warning",
+    artifacts = [
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.12.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.11.2",
+        "com.github.jnr:jffi:1.3.4",
+        maven.artifact(
+            group = "com.github.jnr",
+            artifact = "jffi",
+            version = "1.3.3",
+            classifier = "native",
+        ),
+        maven.artifact(
+            group = "com.github.jnr",
+            artifact = "jffi",
+            version = "1.3.2",
+            classifier = "native",
+        ),
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+)
+
+maven_install(
     name = "starlark_aar_import_test",
     artifacts = [
         "com.android.support:appcompat-v7:28.0.0",

--- a/defs.bzl
+++ b/defs.bzl
@@ -42,7 +42,8 @@ def maven_install(
         additional_netrc_lines = [],
         fail_if_repin_required = False,
         use_starlark_android_rules = False,
-        aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL):
+        aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
+        duplicate_version_warning = "warn"):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -86,6 +87,9 @@ def maven_install(
         not use the typical default repository name to import the Android
         Starlark rules. Default is
         "@build_bazel_rules_android//rules:rules.bzl".
+      duplicate_version_warning: What to do if an artifact is specified multiple times. If "error" then
+        fail the build, if "warn" then print a message and continue, if "none" then do nothing. The default
+        is "warn".
     """
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -136,6 +140,7 @@ def maven_install(
         jetify_include_list = jetify_include_list,
         use_starlark_android_rules = use_starlark_android_rules,
         aar_import_bzl_label = aar_import_bzl_label,
+        duplicate_version_warning = duplicate_version_warning,
     )
 
     if maven_install_json != None:
@@ -154,6 +159,7 @@ def maven_install(
             jetify_include_list = jetify_include_list,
             additional_netrc_lines = additional_netrc_lines,
             fail_if_repin_required = fail_if_repin_required,
+            duplicate_version_warning = duplicate_version_warning,
         )
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+
+# A simple test framework to verify bazel output without setting up an entire WORKSPACE
+# in the bazel sandbox as is done in https://github.com/bazelbuild/bazel/blob/master/src/test/shell/unittest.bash
+#
+# Add a new test to the TESTS array and send all output to TEST_LOG
+
+function test_duplicate_version_warning() {
+  bazel run @duplicate_version_warning//:pin >> "$TEST_LOG" 2>&1
+    
+  expect_log "Found duplicate artifact versions"
+  expect_log "com.fasterxml.jackson.core:jackson-annotations has multiple versions"
+  expect_log "com.github.jnr:jffi:native has multiple versions"
+}
+
+function test_outdated() {
+  bazel run @regression_testing//:outdated >> "$TEST_LOG" 2>&1
+
+  expect_log "Checking for updates of .* artifacts against the following repositories"
+  expect_log "junit:junit \[4.12"
+}
+
+TESTS=("test_duplicate_version_warning" "test_outdated")
+
+function run_tests() {
+  printf "Running bazel run tests:\n"
+  for test in ${TESTS[@]}; do
+    printf "  ${test} "
+    TEST_LOG=/tmp/${test}_test.log
+    rm -f "$TEST_LOG"
+    DUMPED_TEST_LOG=0
+    ${test}
+    printf "PASSED\n"
+    rm -f "$TEST_LOG"
+  done
+}
+
+function expect_log() {
+  local pattern=$1
+  local message=${2:-Expected regexp "$pattern" not found}
+  grep -sq -- "$pattern" $TEST_LOG && return 0
+
+  printf "FAILED\n"
+  cat $TEST_LOG
+  DUMPED_TEST_LOG=1
+  printf "FAILURE: $message\n"
+  return 1
+}
+
+function exit_handler() {
+  local exit_code=$?
+  if [ $exit_code != "0" ] && [ $DUMPED_TEST_LOG == "0" ]; then
+    printf "ERROR\n"
+    cat $TEST_LOG
+  fi
+  return $exit_code
+}
+
+trap exit_handler EXIT
+
+run_tests


### PR DESCRIPTION
Print a warning when an artifact appears in the list more than once. For example for the following maven_install
```
maven_install(
    name = "maven",
    artifacts = [
        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
        "com.fasterxml.jackson.core:jackson-annotations:2.12.1",
        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
        "com.fasterxml.jackson.core:jackson-annotations:2.11.2",
        "com.github.jnr:jffi:1.3.3",
        maven.artifact(
            group = "com.github.jnr",
            artifact = "jffi",
            version = "1.3.3",
            classifier = "native",
        ),
        maven.artifact(
            group = "com.github.jnr",
            artifact = "jffi",
            version = "1.3.2",
            classifier = "native",
        ),
    ],
    repositories = [
        "https://repo.maven.apache.org/maven2/",
    ],
)
```

print the following

```
>  bazel run @maven//:pin         
DEBUG: /private/var/tmp/_bazel_cheister/60fd9b2f4bf06a7f576b88fee484f3ad/external/rules_jvm_external/coursier.bzl:598:18: com.fasterxml.jackson.core:jackson-annotations is in the artifact list more than once. Please remove duplicate artifacts from the artifact list so you do not get unexpected artifact versions
DEBUG: /private/var/tmp/_bazel_cheister/60fd9b2f4bf06a7f576b88fee484f3ad/external/rules_jvm_external/coursier.bzl:598:18: com.fasterxml.jackson.core:jackson-annotations is in the artifact list more than once. Please remove duplicate artifacts from the artifact list so you do not get unexpected artifact versions
DEBUG: /private/var/tmp/_bazel_cheister/60fd9b2f4bf06a7f576b88fee484f3ad/external/rules_jvm_external/coursier.bzl:598:18: com.fasterxml.jackson.core:jackson-annotations is in the artifact list more than once. Please remove duplicate artifacts from the artifact list so you do not get unexpected artifact versions
DEBUG: /private/var/tmp/_bazel_cheister/60fd9b2f4bf06a7f576b88fee484f3ad/external/rules_jvm_external/coursier.bzl:598:18: com.github.jnr:jffi:native is in the artifact list more than once. Please remove duplicate artifacts from the artifact list so you do not get unexpected artifact versions
INFO: Analyzed target @maven//:pin (18 packages loaded, 67 targets configured).
INFO: Found 1 target...
Target @maven//:pin up-to-date:
  bazel-bin/external/maven/pin
INFO: Elapsed time: 6.296s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
```