### PR TITLE
Remove android_instrumentation_test on RBE

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -40,15 +40,6 @@ tasks:
     working_directory: examples/pom_file_generation
     build_targets:
       - "//..."
-  android-instrumentation-test-linux-rbe:
-    name: "Android instrumentation test example on RBE"
-    platform: ubuntu1604
-    working_directory: examples/android_instrumentation_test
-    test_flags:
-      - "--config=remote_android"
-      - "--toolchain_resolution_debug"
-    test_targets:
-      - "//src/test:greeter_test"
   android-instrumentation-test-macos:
     name: "Android instrumentation test example"
     platform: macos


### PR DESCRIPTION
Android Emulator on RBE basically works accidentally on their platform and it could stop working any time.

I'm removing the test because it is failing (see https://buildkite.com/bazel/rules-jvm-external-examples/builds/1960#4cef1180-9796-4dff-ae98-222391d9bc5a)