### PR TITLE
Fix usage code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ or environment variables. See the [Coursier
 documentation](https://get-coursier.io/docs/other-credentials.html#property-file)
 for more information.
 
-`rules_jvm_external_setup` uses a default list of maven repositories to download
+`rules_jvm_external_deps` uses a default list of maven repositories to download
  `rules_jvm_external`'s own dependencies from. Should you wish to change this,
  use the `repositories` parameter:
 
  ```python
-rules_jvm_external_setup(repositories = ["https://mycorp.com/artifacts"])
+rules_jvm_external_deps(repositories = ["https://mycorp.com/artifacts"])
+rules_jvm_external_setup()
 ```
 
 Next, reference the artifacts in the BUILD file with their versionless label:


### PR DESCRIPTION
The README.md appears documented the `rules_jvm_external` usage incorrectly.

`rules_jvm_external_setup` doesn't have the parameter of `repositories`, instead `rules_jvm_external_deps` has it.

Reference to `rules_jvm_external_deps`
https://github.com/bazelbuild/rules_jvm_external/blob/fa73b1a8e4846cee88240d0019b8f80d39feb1c3/repositories.bzl#L8