### PR TITLE
Disable https://github.com/bazelbuild/rules_jvm_external/issues/586 on Windows CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -107,3 +107,5 @@ tasks:
       # https://github.com/bazelbuild/rules_kotlin/blob/master/.bazelci/presubmit.yml
       - "-//tests/unit/kotlin/..."
       - "-//tests/integration/override_targets"
+      # https://github.com/bazelbuild/rules_jvm_external/issues/586
+      - "-//tests/unit/manifest_stamp:diff_signed_manifest_test"


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/issues/586

