### PR TITLE
Quote http.nonProxyHosts argument to java so the pipes separating the hosts to not get interpreted by the shell

### DIFF
--- a/private/proxy.bzl
+++ b/private/proxy.bzl
@@ -71,6 +71,6 @@ def get_java_proxy_args(http_proxy, https_proxy, no_proxy):
     # Convert no_proxy-style exclusions, including base domain matching, into java.net nonProxyHosts:
     # localhost,example.com,foo.example.com,.otherexample.com -> "localhost|example.com|foo.example.com|*.otherexample.com"
     if no_proxy:
-        proxy_args.append("-Dhttp.nonProxyHosts=%s" % no_proxy.replace(",", "|").replace("|.", "|*."))
+        proxy_args.append("-Dhttp.nonProxyHosts='%s'" % no_proxy.replace(",", "|").replace("|.", "|*."))
 
     return proxy_args

--- a/tests/unit/proxy_test.bzl
+++ b/tests/unit/proxy_test.bzl
@@ -18,7 +18,7 @@ def _java_proxy_parsing_no_scheme_test_impl(ctx):
             "-Dhttp.proxyPort=8888",
             "-Dhttps.proxyHost=localhost",
             "-Dhttps.proxyPort=8843",
-            "-Dhttp.nonProxyHosts=google.com",
+            "-Dhttp.nonProxyHosts='google.com'",
         ],
         get_java_proxy_args("localhost:8888", "localhost:8843", "google.com"),
     )
@@ -35,7 +35,7 @@ def _java_proxy_parsing_no_user_test_impl(ctx):
             "-Dhttp.proxyPort=80",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
-            "-Dhttp.nonProxyHosts=google.com",
+            "-Dhttp.nonProxyHosts='google.com'",
         ],
         get_java_proxy_args("http://example.com:80", "https://secureexample.com:443", "google.com"),
     )
@@ -50,7 +50,7 @@ def _java_proxy_parsing_no_port_test_impl(ctx):
         [
             "-Dhttp.proxyHost=example.com",
             "-Dhttps.proxyHost=secureexample.com",
-            "-Dhttp.nonProxyHosts=google.com",
+            "-Dhttp.nonProxyHosts='google.com'",
         ],
         get_java_proxy_args("http://example.com", "https://secureexample.com", "google.com"),
     )
@@ -67,7 +67,7 @@ def _java_proxy_parsing_trailing_slash_test_impl(ctx):
             "-Dhttp.proxyPort=80",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
-            "-Dhttp.nonProxyHosts=google.com",
+            "-Dhttp.nonProxyHosts='google.com'",
         ],
         get_java_proxy_args("http://example.com:80", "https://secureexample.com:443/", "google.com"),
     )
@@ -88,7 +88,7 @@ def _java_proxy_parsing_all_test_impl(ctx):
             "-Dhttps.proxyPassword=pass2",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
-            "-Dhttp.nonProxyHosts=google.com|localhost",
+            "-Dhttp.nonProxyHosts='google.com|localhost'",
         ],
         get_java_proxy_args("http://user1:pass1@example.com:80", "https://user2:pass2@secureexample.com:443", "google.com,localhost"),
     )


### PR DESCRIPTION
Should fix https://github.com/bazelbuild/rules_jvm_external/issues/581