### PR TITLE
Use argsfile for java if we are using java 9 or higher to avoid command line length limits

### DIFF
--- a/private/java_utilities.bzl
+++ b/private/java_utilities.bzl
@@ -1,0 +1,27 @@
+#
+# Utilites for working with java versions
+#
+
+# Get numeric java version from `java -version` output e.g:
+#
+#     openjdk version "11.0.9" 2020-10-20
+#     OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
+#     OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
+#
+def parse_java_version(java_version_output):
+    # Look for 'version "x.y.z"' in the output'
+    if len(java_version_output.split("version ")) > 1:
+        java_version = java_version_output.split("version ")[1].partition("\n")[0].split(" ")[0].replace("\"", "")
+    else:
+        return None
+
+    if not java_version:
+        return None
+    elif "." not in java_version:
+        return int(java_version)
+    elif java_version.startswith("1."):
+        return int(java_version.split(".")[1])
+    else:
+        return int(java_version.split(".")[0])
+
+    return None

--- a/tests/unit/BUILD
+++ b/tests/unit/BUILD
@@ -1,5 +1,6 @@
 load(":coursier_test.bzl", "coursier_test_suite")
 load(":coursier_utilities_test.bzl", "coursier_utilities_test_suite")
+load(":java_utilities_test.bzl", "java_utilities_test_suite")
 load(":proxy_test.bzl", "proxy_test_suite")
 load(":specs_test.bzl", "artifact_specs_test_suite")
 
@@ -8,5 +9,7 @@ artifact_specs_test_suite()
 coursier_test_suite()
 
 coursier_utilities_test_suite()
+
+java_utilities_test_suite()
 
 proxy_test_suite()

--- a/tests/unit/java_utilities_test.bzl
+++ b/tests/unit/java_utilities_test.bzl
@@ -1,0 +1,79 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//:private/java_utilities.bzl", "parse_java_version")
+
+def _parse_java_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, None, parse_java_version(""))
+    asserts.equals(env, None, parse_java_version("version "))
+    asserts.equals(env, None, parse_java_version("java\nversion\n\"1.7.0_44\""))
+
+    asserts.equals(
+        env,
+        7,
+        parse_java_version("""
+java version "1.7.0_55"
+Java(TM) SE Runtime Environment (build 1.7.0_55-b13)
+Java HotSpot(TM) 64-Bit Server VM (build 24.55-b03, mixed mode)
+"""),
+    )
+
+    asserts.equals(
+        env,
+        8,
+        parse_java_version("""
+java version "1.8.0_202"
+Java(TM) SE Runtime Environment (build 1.8.0_202-b08)
+Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)
+"""),
+    )
+
+    asserts.equals(
+        env,
+        9,
+        parse_java_version("""
+java version "9"
+Java(TM) SE Runtime Environment (build 9+181)
+Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)
+"""),
+    )
+
+    asserts.equals(
+        env,
+        10,
+        parse_java_version("""
+java version "10.0.1" 2018-04-17
+Java(TM) SE Runtime Environment 18.3 (build 10.0.1+10)
+Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.1+10, mixed mode)
+"""),
+    )
+
+    asserts.equals(
+        env,
+        11,
+        parse_java_version("""
+openjdk version "11.0.9" 2020-10-20
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
+"""),
+    )
+
+    asserts.equals(
+        env,
+        15,
+        parse_java_version("""
+openjdk version "15" 2020-09-15
+OpenJDK Runtime Environment (build 15+36-1562)
+OpenJDK 64-Bit Server VM (build 15+36-1562, mixed mode, sharing)
+"""),
+    )
+
+    return unittest.end(env)
+
+parse_java_version_test = unittest.make(_parse_java_version_test_impl)
+
+def java_utilities_test_suite():
+    unittest.suite(
+        "java_utilities_tests",
+        parse_java_version_test,
+    )


### PR DESCRIPTION
Should fix https://github.com/bazelbuild/rules_jvm_external/issues/549 if they are using Java 9 or higher