### PR TITLE
support for javac options

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -62,6 +62,10 @@ def java_export(
     tags = tags + ["maven_coordinates=%s" % maven_coordinates]
     lib_name = "%s-lib" % name
 
+    javadocopts = kwargs.pop("javadocopts")
+    if javadocopts == None:
+        javadocopts = []
+
     # Construct the java_library we'll export from here.
     native.java_library(
         name = lib_name,
@@ -98,6 +102,7 @@ def java_export(
         deps = [
             ":%s-project" % name,
         ],
+        javadocopts = javadocopts
     )
 
     pom_file(

--- a/private/tools/java/rules/jvm/external/javadoc/JavadocJarMaker.java
+++ b/private/tools/java/rules/jvm/external/javadoc/JavadocJarMaker.java
@@ -59,10 +59,11 @@ public class JavadocJarMaker {
     Set<Path> sourceJars = new HashSet<>();
     Path out = null;
     Set<Path> classpath = new HashSet<>();
+    List<String> options = new ArrayList<>();
 
     for (int i = 0; i < args.length; i++) {
       String flag = args[i];
-      String next = args[++i];
+      String next = i + 1 < args.length ? args[++i] : null;
 
       switch (flag) {
         case "--cp":
@@ -75,6 +76,13 @@ public class JavadocJarMaker {
 
         case "--out":
           out = Paths.get(next);
+          break;
+
+        default:
+          options.add(flag);
+          if (next != null) {
+            options.add(next);
+          }
           break;
       }
     }
@@ -113,7 +121,6 @@ public class JavadocJarMaker {
         return;
       }
 
-      List<String> options = new ArrayList<>();
       if (!classpath.isEmpty()) {
         options.add("-cp");
         options.add(classpath.stream().map(String::valueOf).collect(Collectors.joining(File.pathSeparator)));

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -65,6 +65,10 @@ java_export(
     deploy_env = [
         ":dep",
     ],
+    javadocopts = [
+        "-windowtitle",
+        "My Deploy Env"
+    ],
     maven_coordinates = "com.example:lib:1.0.0",
     deps = [
         ":dep",


### PR DESCRIPTION
Added support for passing javac options while generating javadocs.

javac options need to be passed to javadoc compiler. This ensures that all the options passed while compiling sources are also passed to javadoc.

Ex: `--add-exports java.base/jdk.internal.misc=ALL-UNNAMED` is needed to be passed if source uses `jdk.internal.misc` package with the jdks that support modules.
