### PR TITLE
Make :outdated work with --nolegacy_external_runfiles

### DIFF
--- a/private/outdated.sh
+++ b/private/outdated.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 if [ -f "private/tools/prebuilt/outdated_deploy.jar" ]; then
     outdated_jar_path=private/tools/prebuilt/outdated_deploy.jar
 else
-    outdated_jar_path=external/rules_jvm_external/private/tools/prebuilt/outdated_deploy.jar
+    outdated_jar_path=../rules_jvm_external/private/tools/prebuilt/outdated_deploy.jar
 fi
 
-java {proxy_opts} -jar $outdated_jar_path external/{repository_name}/outdated.artifacts external/{repository_name}/outdated.repositories
+java {proxy_opts} -jar $outdated_jar_path ../{repository_name}/outdated.artifacts ../{repository_name}/outdated.repositories


### PR DESCRIPTION
With --nolegacy_external_runfiles, the working directory relative path
to outdated.jar should start with ../ rather than external/.

Fixes #538.