### PR TITLE
Fix jq not formatting large (> 4 MB) in linux

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -43,7 +43,6 @@ load("%s", "aar_import")
 """
 
 _BUILD_PIN = """
-exports_files(['unsorted_deps.json'])
 genrule(
     name = "jq-binary",
     cmd = "cp $< $@",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -43,6 +43,7 @@ load("%s", "aar_import")
 """
 
 _BUILD_PIN = """
+exports_files(['unsorted_deps.json'])
 genrule(
     name = "jq-binary",
     cmd = "cp $< $@",
@@ -59,9 +60,11 @@ sh_binary(
     srcs = ["pin.sh"],
     args = [
       "$(rootpath :jq-binary)",
+      "$(location :unsorted_deps.json)",
     ],
     data = [
         ":jq-binary",
+        ":unsorted_deps.json",
     ],
     visibility = ["//visibility:public"],
 )
@@ -1070,11 +1073,16 @@ def _coursier_fetch_impl(repository_ctx):
     #
     # Create the maven_install.json export script for unpinned repositories.
     dependency_tree_json = "{ \"dependency_tree\": " + repr(dep_tree).replace("None", "null") + "}"
+    repository_ctx.file(
+        "unsorted_deps.json",
+        content = "{dependency_tree_json}".format(
+            dependency_tree_json = dependency_tree_json
+        )
+    )
     repository_ctx.template(
         "pin.sh",
         repository_ctx.attr._pin,
         {
-            "{dependency_tree_json}": dependency_tree_json,
             "{maven_install_location}": "$BUILD_WORKSPACE_DIRECTORY/" + maven_install_location,
             "{predefined_maven_install}": str(predefined_maven_install),
             "{repository_name}": repository_name,

--- a/private/pin.sh
+++ b/private/pin.sh
@@ -7,10 +7,8 @@ readonly maven_install_json_loc={maven_install_location}
 # there is only pin.runfiles/unpinned_maven/jq not also pin.runfiles/user_repo/external/unpinned_maven/jq
 # So replace leading external/ with ../
 readonly jq=${1/#external\//..\/}
-cat <<"RULES_JVM_EXTERNAL_EOF" | "$jq" --sort-keys --indent 4 . - > $maven_install_json_loc
-{dependency_tree_json}
-RULES_JVM_EXTERNAL_EOF
-
+readonly maven_unsorted_file="$2"
+"$jq" --sort-keys --indent 4 < "$maven_unsorted_file" > $maven_install_json_loc
 if [ "{predefined_maven_install}" = "True" ]; then
     echo "Successfully pinned resolved artifacts for @{repository_name}, $maven_install_json_loc is now up-to-date."
 else


### PR DESCRIPTION
Redid pin.sh as this fails on linux when the json file for maven dependencies becomes very large. Switches to using a intermediary file. 