### PR TITLE
Remove build_tools_version pin from example repos.

### DIFF
--- a/examples/android_instrumentation_test/WORKSPACE
+++ b/examples/android_instrumentation_test/WORKSPACE
@@ -3,7 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 android_sdk_repository(
     name = "androidsdk",
     api_level = 28,
-    build_tools_version = "28.0.2",
 )
 
 android_ndk_repository(

--- a/examples/android_kotlin_app/WORKSPACE
+++ b/examples/android_kotlin_app/WORKSPACE
@@ -3,7 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 android_sdk_repository(
     name = "androidsdk",
     api_level = 28,
-    build_tools_version = "28.0.2",
 )
 
 # BEGIN io_bazel_rules_kotlin

--- a/examples/android_local_test/WORKSPACE
+++ b/examples/android_local_test/WORKSPACE
@@ -3,7 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 android_sdk_repository(
     name = "androidsdk",
     api_level = 28,
-    build_tools_version = "28.0.2",
 )
 
 http_archive(

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -1,7 +1,6 @@
 android_sdk_repository(
     name = "androidsdk",
     api_level = 28,
-    build_tools_version = "28.0.2",
 )
 
 local_repository(


### PR DESCRIPTION
The CI removed v28, and may change again, so let's just rely on the
autodiscovery mechanism in android_sdk_repository to use the right
build_tools_version.