### PR TITLE
Bump Robolectric to 4.4

### DIFF
--- a/examples/android_local_test/WORKSPACE
+++ b/examples/android_local_test/WORKSPACE
@@ -7,9 +7,9 @@ android_sdk_repository(
 
 http_archive(
     name = "robolectric",
-    sha256 = "2ee850ca521288db72b0dedb9ecbda55b64d11c470435a882f8daf615091253d",
-    strip_prefix = "robolectric-bazel-4.1",
-    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.1.tar.gz"],
+    sha256 = "d4f2eb078a51f4e534ebf5e18b6cd4646d05eae9b362ac40b93831bdf46112c7",
+    strip_prefix = "robolectric-bazel-4.4",
+    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.4.tar.gz"],
 )
 
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
@@ -28,7 +28,7 @@ maven_install(
         "androidx.appcompat:appcompat:1.0.2",
         "androidx.annotation:annotation:1.0.2",
         "androidx.test.ext:junit:1.1.0",
-        "org.robolectric:robolectric:4.1",
+        "org.robolectric:robolectric:4.4",
         "org.assertj:assertj-core:3.12.1",
     ],
     maven_install_json = "//:maven_install.json",


### PR DESCRIPTION
The `Robolectric` 4.4 has been released, https://github.com/robolectric/robolectric-bazel/releases/tag/4.4. This PR bumps example's `Robolectric` version to 4.4.