### PR TITLE
Do not warn if the same dependency version is in the list multiple times since there are several use cases that expect this

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -391,6 +391,30 @@ maven_install(
 )
 
 maven_install(
+    name = "duplicate_version_warning_same_version",
+    artifacts = [
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        maven.artifact(
+            group = "com.github.jnr",
+            artifact = "jffi",
+            version = "1.3.3",
+            classifier = "native",
+        ),
+        maven.artifact(
+            group = "com.github.jnr",
+            artifact = "jffi",
+            version = "1.3.3",
+            classifier = "native",
+        ),
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+)
+
+maven_install(
     name = "starlark_aar_import_with_sources_test",
     artifacts = [
         "androidx.work:work-runtime:2.6.0",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -623,10 +623,12 @@ def _check_artifacts_are_unique(artifacts, duplicate_version_warning):
     for artifact in artifacts:
         artifact_coordinate = artifact["group"] + ":" + artifact["artifact"] + (":%s" % artifact["classifier"] if artifact.get("classifier") != None else "")
         if artifact_coordinate in seen_artifacts:
-            if artifact_coordinate in duplicate_artifacts:
-                duplicate_artifacts[artifact_coordinate].append(artifact["version"])
-            else:
-                duplicate_artifacts[artifact_coordinate] = [artifact["version"]]
+            # Don't warn if the same version is in the list multiple times
+            if seen_artifacts[artifact_coordinate] != artifact["version"]:
+                if artifact_coordinate in duplicate_artifacts:
+                    duplicate_artifacts[artifact_coordinate].append(artifact["version"])
+                else:
+                    duplicate_artifacts[artifact_coordinate] = [artifact["version"]]
         else:
             seen_artifacts[artifact_coordinate] = artifact["version"]
 


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/pull/579#issuecomment-921760327 noted that the default Dagger instructions add the same dependency version multiple times to the list.

Since this is an expected use case and does not cause unexpected versions to be fetched lets relax the warning so nothing is printed in this case.