### PR TITLE
Fix artifact de-duplication so it selects the artifact with the right exclusions

### DIFF
--- a/private/artifact_utilities.bzl
+++ b/private/artifact_utilities.bzl
@@ -1,0 +1,62 @@
+#
+# Utilites for working with artifacts
+#
+
+load("//:specs.bzl", "utils")
+
+def deduplicate_and_sort_artifacts(dep_tree, artifacts, excluded_artifacts, verbose):
+    # First we find all of the artifacts that have exclusions
+    artifacts_with_exclusions = {}
+    for a in artifacts:
+        coordinate = utils.artifact_coordinate(a)
+        if "exclusions" in a:
+            deduped_exclusions = {}
+            for e in excluded_artifacts:
+                deduped_exclusions["{}:{}".format(e["group"], e["artifact"])] = True
+            for e in a["exclusions"]:
+                if e["group"] == "*" and e["artifact"] == "*":
+                    deduped_exclusions = {"*:*": True}
+                    break
+                deduped_exclusions["{}:{}".format(e["group"], e["artifact"])] = True
+            artifacts_with_exclusions[coordinate] = deduped_exclusions.keys()
+
+    # As we de-duplicate the list keep the duplicate artifacts with exclusions separate
+    # so we can look at them and select the one that has the same exclusions
+    duplicate_artifacts_with_exclusions = {}
+    deduped_artifacts = {}
+    null_artifacts = []
+    for artifact in dep_tree["dependencies"]:
+        if artifact["file"] == None:
+            null_artifacts.append(artifact)
+            continue
+        if artifact["coord"] in artifacts_with_exclusions:
+            if artifact["coord"] in duplicate_artifacts_with_exclusions:
+                duplicate_artifacts_with_exclusions[artifact["coord"]].append(artifact)
+            else:
+                duplicate_artifacts_with_exclusions[artifact["coord"]] = [artifact]
+        else:
+            if artifact["file"] in deduped_artifacts:
+                continue
+            deduped_artifacts[artifact["file"]] = artifact
+
+    # Look through the duplicates with exclusions and try to select the artifact
+    # that has the same exclusions as specified in the artifact
+    for duplicate_coord in duplicate_artifacts_with_exclusions:
+        deduped_artifact_with_exclusion = duplicate_artifacts_with_exclusions[duplicate_coord][0]
+        found_artifact_with_exclusion = False
+        for duplicate_artifact in duplicate_artifacts_with_exclusions[duplicate_coord]:
+            if sorted(duplicate_artifact["exclusions"]) == sorted(artifacts_with_exclusions[duplicate_coord]):
+                found_artifact_with_exclusion = True
+                deduped_artifact_with_exclusion = duplicate_artifact
+        if verbose and not found_artifact_with_exclusion:
+            print("Could not find duplicate artifact with matching exclusions for {} when de-duplicating the dependency tree. Using exclusions {}".format(deduped_artifact_with_exclusion))
+        deduped_artifacts[deduped_artifact_with_exclusion["file"]] = deduped_artifact_with_exclusion
+
+    # After we have added the de-duped artifacts with exclusions we need to re-sort the list
+    sorted_deduped_values = []
+    for key in sorted(deduped_artifacts.keys()):
+        sorted_deduped_values.append(deduped_artifacts[key])
+
+    dep_tree.update({"dependencies": sorted_deduped_values + null_artifacts})
+
+    return dep_tree

--- a/rules_jvm_external_deps_install.json
+++ b/rules_jvm_external_deps_install.json
@@ -36,37 +36,6 @@
                 "url": "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/1.30.11/google-api-client-1.30.11.jar"
             },
             {
-                "coord": "com.google.api.grpc:proto-google-common-protos:2.0.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "com.google.protobuf:protobuf-java"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar",
-                    "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"
-                ],
-                "sha256": "5ce71656118618731e34a5d4c61aa3a031be23446dc7de8b5a5e77b66ebcd6ef",
-                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"
-            },
-            {
-                "coord": "com.google.api.grpc:proto-google-iam-v1:1.0.3",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "com.google.protobuf:protobuf-java",
-                    "com.google.api.grpc:proto-google-common-protos"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar",
-                    "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar"
-                ],
-                "sha256": "64cee7383a97e846da8d8e160e6c8fe30561e507260552c59e6ccfc81301fdc8",
-                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar"
-            },
-            {
                 "coord": "com.google.api:api-common:1.10.1",
                 "dependencies": [],
                 "directDependencies": [],
@@ -128,6 +97,37 @@
                 ],
                 "sha256": "02f37d4ff1a7b8d71dff8064cf9568aa4f4b61bcc4485085d16130f32afa5a79",
                 "url": "https://repo1.maven.org/maven2/com/google/api/gax/1.60.0/gax-1.60.0.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-common-protos:2.0.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "com.google.protobuf:protobuf-java"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar",
+                    "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"
+                ],
+                "sha256": "5ce71656118618731e34a5d4c61aa3a031be23446dc7de8b5a5e77b66ebcd6ef",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-iam-v1:1.0.3",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "com.google.protobuf:protobuf-java",
+                    "com.google.api.grpc:proto-google-common-protos"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar",
+                    "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar"
+                ],
+                "sha256": "64cee7383a97e846da8d8e160e6c8fe30561e507260552c59e6ccfc81301fdc8",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.0.3/proto-google-iam-v1-1.0.3.jar"
             },
             {
                 "coord": "com.google.apis:google-api-services-storage:v1-rev20200927-1.30.10",

--- a/tests/custom_maven_install/json_artifacts_testing_install.json
+++ b/tests/custom_maven_install/json_artifacts_testing_install.json
@@ -6,21 +6,6 @@
         "conflict_resolution": {},
         "dependencies": [
             {
-                "coord": "aopalliance:aopalliance:1.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
-                    "https://repo.spring.io/plugins-release/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
-                ],
-                "sha256": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-                "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
-            },
-            {
                 "coord": "aopalliance:aopalliance:jar:sources:1.0",
                 "dependencies": [],
                 "directDependencies": [],
@@ -36,16 +21,19 @@
                 "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
             },
             {
-                "coord": "com.eclipsesource.minimal-json:minimal-json:0.9.5",
+                "coord": "aopalliance:aopalliance:1.0",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar",
-                    "https://repo.spring.io/plugins-release/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar"
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "69ff84463d1d7cc5cfdb8baf2b6e5f7af153d351bf0dbee3bbc8916247afac74",
-                "url": "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+                    "https://repo.spring.io/plugins-release/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
+                ],
+                "sha256": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+                "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
             },
             {
                 "coord": "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
@@ -60,16 +48,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
+                "coord": "com.eclipsesource.minimal-json:minimal-json:0.9.5",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar",
-                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar"
+                    "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar",
+                    "https://repo.spring.io/plugins-release/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar"
                 ],
-                "sha256": "c876f2e85d0f108a34cdd11ccc9d8d7875697367efc75bf10a89c2c26aee994c",
-                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar"
+                "sha256": "69ff84463d1d7cc5cfdb8baf2b6e5f7af153d351bf0dbee3bbc8916247afac74",
+                "url": "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
@@ -84,16 +72,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-core:2.9.10",
+                "coord": "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar",
-                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar"
+                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar",
+                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar"
                 ],
-                "sha256": "65fe26d7554a4409652c86ee38f2e94bc42934326d88b3c78c61f66ff2222c53",
-                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar"
+                "sha256": "c876f2e85d0f108a34cdd11ccc9d8d7875697367efc75bf10a89c2c26aee994c",
+                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
@@ -108,22 +96,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
-                "dependencies": [
-                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:2.9.10"
-                ],
-                "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:2.9.10"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar",
+                "coord": "com.fasterxml.jackson.core:jackson-core:2.9.10",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar",
-                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar"
+                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar",
+                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar"
                 ],
-                "sha256": "737c1165a617eac7275431f76615fd18447b001c0dc4f4f4db4e24b3b3cce0f9",
-                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar"
+                "sha256": "65fe26d7554a4409652c86ee38f2e94bc42934326d88b3c78c61f66ff2222c53",
+                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
@@ -144,19 +126,22 @@
                 "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar"
             },
             {
-                "coord": "com.google.code.findbugs:jsr305:3.0.2",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "javax.inject:javax.inject"
+                "coord": "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                "dependencies": [
+                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.10"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.10"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-                    "https://repo.spring.io/plugins-release/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar",
+                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar"
                 ],
-                "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-                "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+                "sha256": "737c1165a617eac7275431f76615fd18447b001c0dc4f4f4db4e24b3b3cce0f9",
+                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar"
             },
             {
                 "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
@@ -172,6 +157,21 @@
                 ],
                 "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
                 "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+            },
+            {
+                "coord": "com.google.code.findbugs:jsr305:3.0.2",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+                    "https://repo.spring.io/plugins-release/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+                ],
+                "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+                "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
             },
             {
                 "coord": "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
@@ -206,21 +206,6 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/code/google-collections/google-collect/snapshot-20080530/google-collect-snapshot-20080530.jar"
             },
             {
-                "coord": "com.google.errorprone:error_prone_annotations:2.2.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
-                    "https://repo.spring.io/plugins-release/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
-                ],
-                "sha256": "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
-                "url": "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
-            },
-            {
                 "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
                 "dependencies": [],
                 "directDependencies": [],
@@ -236,16 +221,19 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
             },
             {
-                "coord": "com.google.guava:failureaccess:1.0.1",
+                "coord": "com.google.errorprone:error_prone_annotations:2.2.0",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
-                    "https://repo.spring.io/plugins-release/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "sha256": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
-                "url": "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
+                    "https://repo.spring.io/plugins-release/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
+                ],
+                "sha256": "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
+                "url": "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
             },
             {
                 "coord": "com.google.guava:failureaccess:jar:sources:1.0.1",
@@ -261,6 +249,46 @@
                 ],
                 "sha256": "092346eebbb1657b51aa7485a246bf602bb464cc0b0e2e1c7e7201fadce1e98f",
                 "url": "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
+            },
+            {
+                "coord": "com.google.guava:failureaccess:1.0.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
+                    "https://repo.spring.io/plugins-release/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+                ],
+                "sha256": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
+                "url": "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+            },
+            {
+                "coord": "com.google.guava:guava:jar:sources:27.0.1-jre",
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                ],
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
+                ],
+                "sha256": "cba2e5680186062f42998b895a5e9a9ceccbaab94644ccc9f35bb73c2b2c7d8e",
+                "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
             },
             {
                 "coord": "com.google.guava:guava:27.0.1-jre",
@@ -292,34 +320,6 @@
                 ],
                 "sha256": "e1c814fd04492a27c38e0317eabeaa1b3e950ec8010239e400fe90ad6c9107b4",
                 "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre.jar"
-            },
-            {
-                "coord": "com.google.guava:guava:jar:sources:27.0.1-jre",
-                "dependencies": [
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
-                ],
-                "directDependencies": [
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
-                ],
-                "sha256": "cba2e5680186062f42998b895a5e9a9ceccbaab94644ccc9f35bb73c2b2c7d8e",
-                "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
             },
             {
                 "coord": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
@@ -381,6 +381,18 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/inject/guice/4.2.0/guice-4.2.0-sources.jar"
             },
             {
+                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
+                ],
+                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f",
+                "url": "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
+            },
+            {
                 "coord": "com.google.j2objc:j2objc-annotations:1.1",
                 "dependencies": [],
                 "directDependencies": [],
@@ -394,40 +406,6 @@
                 ],
                 "sha256": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
                 "url": "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-            },
-            {
-                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
-                ],
-                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f",
-                "url": "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
-            },
-            {
-                "coord": "commons-cli:commons-cli:1.4",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "commons-lang:commons-lang",
-                    "commons-logging:commons-logging",
-                    "javax.inject:javax.inject",
-                    "org.sonatype.plexus:plexus-cipher",
-                    "org.apache.maven.wagon:wagon-provider-api",
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:jsr250-api",
-                    "org.sonatype.plexus:plexus-sec-dispatcher"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar",
-                    "https://repo.spring.io/plugins-release/commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
-                ],
-                "sha256": "fd3c7c9545a9cdb2051d1f9155c4f76b1e4ac5a57304404a6eedb578ffba7328",
-                "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
             },
             {
                 "coord": "commons-cli:commons-cli:jar:sources:1.4",
@@ -452,21 +430,26 @@
                 "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar"
             },
             {
-                "coord": "commons-codec:commons-codec:1.9",
+                "coord": "commons-cli:commons-cli:1.4",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
+                    "commons-lang:commons-lang",
                     "commons-logging:commons-logging",
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject",
+                    "org.sonatype.plexus:plexus-cipher",
+                    "org.apache.maven.wagon:wagon-provider-api",
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:jsr250-api",
+                    "org.sonatype.plexus:plexus-sec-dispatcher"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar",
-                    "https://repo.spring.io/plugins-release/commons-codec/commons-codec/1.9/commons-codec-1.9.jar"
+                    "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar",
+                    "https://repo.spring.io/plugins-release/commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
                 ],
-                "sha256": "ad19d2601c3abf0b946b5c3a4113e226a8c1e3305e395b90013b78dd94a723ce",
-                "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar"
+                "sha256": "fd3c7c9545a9cdb2051d1f9155c4f76b1e4ac5a57304404a6eedb578ffba7328",
+                "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
             },
             {
                 "coord": "commons-codec:commons-codec:jar:sources:1.9",
@@ -486,16 +469,21 @@
                 "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar"
             },
             {
-                "coord": "commons-io:commons-io:2.5",
+                "coord": "commons-codec:commons-codec:1.9",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar",
-                    "https://repo.spring.io/plugins-release/commons-io/commons-io/2.5/commons-io-2.5.jar"
+                "exclusions": [
+                    "commons-logging:commons-logging",
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
-                "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar",
+                    "https://repo.spring.io/plugins-release/commons-codec/commons-codec/1.9/commons-codec-1.9.jar"
+                ],
+                "sha256": "ad19d2601c3abf0b946b5c3a4113e226a8c1e3305e395b90013b78dd94a723ce",
+                "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar"
             },
             {
                 "coord": "commons-io:commons-io:jar:sources:2.5",
@@ -510,24 +498,16 @@
                 "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar"
             },
             {
-                "coord": "io.netty:netty-buffer:4.1.34.Final",
-                "dependencies": [
-                    "io.netty:netty-common:4.1.34.Final"
-                ],
-                "directDependencies": [
-                    "io.netty:netty-common:4.1.34.Final"
-                ],
-                "exclusions": [
-                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar",
+                "coord": "commons-io:commons-io:2.5",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar",
+                    "https://repo.spring.io/plugins-release/commons-io/commons-io/2.5/commons-io-2.5.jar"
                 ],
-                "sha256": "39dfe88df8505fd01fbf9c1dbb6b6fa9b0297e453c3dc4ce039ea578aea2eaa3",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar"
+                "sha256": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+                "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar"
             },
             {
                 "coord": "io.netty:netty-buffer:jar:sources:4.1.34.Final",
@@ -550,33 +530,24 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.netty:netty-codec-http:4.1.34.Final",
+                "coord": "io.netty:netty-buffer:4.1.34.Final",
                 "dependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-handler:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final"
+                    "io.netty:netty-common:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-handler:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final"
+                    "io.netty:netty-common:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar"
                 ],
-                "sha256": "5df5556ef6b0e7ce7c72a359e4ca774fcdf8d8fe12f0b6332715eaa44cfe41f8",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar"
+                "sha256": "39dfe88df8505fd01fbf9c1dbb6b6fa9b0297e453c3dc4ce039ea578aea2eaa3",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar"
             },
             {
                 "coord": "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
@@ -608,29 +579,33 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.netty:netty-codec:4.1.34.Final",
+                "coord": "io.netty:netty-codec-http:4.1.34.Final",
                 "dependencies": [
                     "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
                     "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-handler:4.1.34.Final",
                     "io.netty:netty-resolver:4.1.34.Final",
                     "io.netty:netty-transport:4.1.34.Final"
                 ],
                 "directDependencies": [
                     "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
                     "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-handler:4.1.34.Final",
                     "io.netty:netty-transport:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar"
                 ],
-                "sha256": "52e9eeb3638a8ed0911c72a508c05fa4f9d3391125eae46f287d3a8a0776211d",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar"
+                "sha256": "5df5556ef6b0e7ce7c72a359e4ca774fcdf8d8fe12f0b6332715eaa44cfe41f8",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar"
             },
             {
                 "coord": "io.netty:netty-codec:jar:sources:4.1.34.Final",
@@ -658,20 +633,29 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.netty:netty-common:4.1.34.Final",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "io.netty:netty-codec:4.1.34.Final",
+                "dependencies": [
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final"
+                ],
+                "directDependencies": [
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final"
+                ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar"
                 ],
-                "sha256": "122931117eacf370b054d0e8a2411efa81de4956a6c3f938b0f0eb915969a425",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar"
+                "sha256": "52e9eeb3638a8ed0911c72a508c05fa4f9d3391125eae46f287d3a8a0776211d",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar"
             },
             {
                 "coord": "io.netty:netty-common:jar:sources:4.1.34.Final",
@@ -690,31 +674,20 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.netty:netty-handler:4.1.34.Final",
-                "dependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final"
-                ],
-                "directDependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final"
-                ],
+                "coord": "io.netty:netty-common:4.1.34.Final",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar"
                 ],
-                "sha256": "035616801fe9894ca2490832cf9976536dac740f41e90de1cdd4ba46f04263d1",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar"
+                "sha256": "122931117eacf370b054d0e8a2411efa81de4956a6c3f938b0f0eb915969a425",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar"
             },
             {
                 "coord": "io.netty:netty-handler:jar:sources:4.1.34.Final",
@@ -744,24 +717,31 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.netty:netty-resolver:4.1.34.Final",
+                "coord": "io.netty:netty-handler:4.1.34.Final",
                 "dependencies": [
-                    "io.netty:netty-common:4.1.34.Final"
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-common:4.1.34.Final"
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar"
                 ],
-                "sha256": "774221ed4c130b532865770b10630bc12d0d400127da617ee0ac8de2a7ac2097",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar"
+                "sha256": "035616801fe9894ca2490832cf9976536dac740f41e90de1cdd4ba46f04263d1",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar"
             },
             {
                 "coord": "io.netty:netty-resolver:jar:sources:4.1.34.Final",
@@ -784,28 +764,24 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.netty:netty-transport:4.1.34.Final",
+                "coord": "io.netty:netty-resolver:4.1.34.Final",
                 "dependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final"
+                    "io.netty:netty-common:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final"
+                    "io.netty:netty-common:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar"
                 ],
-                "sha256": "2b3f7d3a595101def7d411793a675bf2a325964475fd7bdbbe448e908de09445",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar"
+                "sha256": "774221ed4c130b532865770b10630bc12d0d400127da617ee0ac8de2a7ac2097",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar"
             },
             {
                 "coord": "io.netty:netty-transport:jar:sources:4.1.34.Final",
@@ -832,26 +808,28 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus.gizmo:gizmo:1.0.0.Final",
+                "coord": "io.netty:netty-transport:4.1.34.Final",
                 "dependencies": [
-                    "org.jboss:jandex:2.1.2.Final",
-                    "org.ow2.asm:asm-analysis:7.1",
-                    "org.ow2.asm:asm-tree:7.1",
-                    "org.ow2.asm:asm-util:7.1",
-                    "org.ow2.asm:asm:7.1"
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "org.jboss:jandex:2.1.2.Final",
-                    "org.ow2.asm:asm-util:7.1",
-                    "org.ow2.asm:asm:7.1"
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar",
+                "exclusions": [
+                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar"
                 ],
-                "sha256": "13478de337fcd00e87548fe49d5ba335b92561bd1e6f80d5fb9fb0842e412bd9",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar"
+                "sha256": "2b3f7d3a595101def7d411793a675bf2a325964475fd7bdbbe448e908de09445",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar"
             },
             {
                 "coord": "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
@@ -876,34 +854,26 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
+                "coord": "io.quarkus.gizmo:gizmo:1.0.0.Final",
                 "dependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec-http:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-handler:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final"
+                    "org.jboss:jandex:2.1.2.Final",
+                    "org.ow2.asm:asm-analysis:7.1",
+                    "org.ow2.asm:asm-tree:7.1",
+                    "org.ow2.asm:asm-util:7.1",
+                    "org.ow2.asm:asm:7.1"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-codec-http:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final"
+                    "org.jboss:jandex:2.1.2.Final",
+                    "org.ow2.asm:asm-util:7.1",
+                    "org.ow2.asm:asm:7.1"
                 ],
-                "exclusions": [
-                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar"
                 ],
-                "sha256": "5600f3c987178607fd7072f450a7133be6ea181087bb63ed038a470c813c0cd3",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar"
+                "sha256": "13478de337fcd00e87548fe49d5ba335b92561bd1e6f80d5fb9fb0842e412bd9",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
@@ -936,27 +906,34 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
+                "coord": "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
                 "dependencies": [
                     "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec-http:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
                     "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-handler:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
                     "org.jboss.logging:jboss-logging:3.4.0.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec-http:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
                     "org.jboss.logging:jboss-logging:3.4.0.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar"
                 ],
-                "sha256": "8e992473797b906d0ba5b6da1c5953b9c3e3c0f0413808118389d4321a0ccbd7",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar"
+                "sha256": "5600f3c987178607fd7072f450a7133be6ea181087bb63ed038a470c813c0cd3",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
@@ -982,35 +959,27 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
+                "coord": "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
                 "dependencies": [
                     "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec-http:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
                     "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-handler:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
+                    "org.jboss.logging:jboss-logging:3.4.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar"
                 ],
-                "sha256": "1a07c32107ed7c1939b1137bd9e17191fbe053b2b372d67fd055026751073590",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar"
+                "sha256": "8e992473797b906d0ba5b6da1c5953b9c3e3c0f0413808118389d4321a0ccbd7",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
@@ -1044,7 +1013,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
+                "coord": "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
                 "dependencies": [
                     "io.netty:netty-buffer:4.1.34.Final",
                     "io.netty:netty-codec-http:4.1.34.Final",
@@ -1055,25 +1024,24 @@
                     "io.netty:netty-transport:4.1.34.Final",
                     "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
                     "org.jboss.logging:jboss-logging:3.4.0.Final",
                     "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
                 ],
                 "directDependencies": [
                     "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1"
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar"
                 ],
-                "sha256": "4a9b665d256f76c61b64aa1f4f5b73691c2a9a943693cac3bd3039f22984b441",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar"
+                "sha256": "1a07c32107ed7c1939b1137bd9e17191fbe053b2b372d67fd055026751073590",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
@@ -1108,6 +1076,38 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar"
             },
             {
+                "coord": "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
+                "dependencies": [
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec-http:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-handler:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
+                ],
+                "directDependencies": [
+                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1"
+                ],
+                "exclusions": [
+                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar"
+                ],
+                "sha256": "4a9b665d256f76c61b64aa1f4f5b73691c2a9a943693cac3bd3039f22984b441",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar"
+            },
+            {
                 "coord": "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
                 "dependencies": [],
                 "directDependencies": [],
@@ -1118,91 +1118,6 @@
                 ],
                 "sha256": "247a9edb9364ad1fd92a56e398d3f2c81db7147530710aecc101c4687e6f71d6",
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bom-descriptor-json/1.0.1.Final/quarkus-bom-descriptor-json-1.0.1.Final.json"
-            },
-            {
-                "coord": "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                "dependencies": [
-                    "aopalliance:aopalliance:1.0",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:2.2.0",
-                    "com.google.guava:failureaccess:1.0.1",
-                    "com.google.guava:guava:27.0.1-jre",
-                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "com.google.j2objc:j2objc-annotations:1.1",
-                    "commons-cli:commons-cli:1.4",
-                    "commons-codec:commons-codec:1.9",
-                    "commons-io:commons-io:2.5",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                    "jakarta.el:jakarta.el-api:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.apache.maven.wagon:wagon-file:3.0.0",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:3.0.0",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-embedder:3.5.4",
-                    "org.apache.maven:maven-model-builder:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:3.5.4",
-                    "org.apache.maven:maven-settings-builder:3.5.4",
-                    "org.apache.maven:maven-settings:3.5.4",
-                    "org.checkerframework:checker-qual:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:1.24",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.sonatype.plexus:plexus-cipher:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
-                ],
-                "directDependencies": [
-                    "com.google.guava:guava:27.0.1-jre",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
-                    "org.apache.maven.wagon:wagon-file:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:3.0.0",
-                    "org.apache.maven:maven-embedder:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:3.5.4",
-                    "org.apache.maven:maven-settings-builder:3.5.4",
-                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar"
-                ],
-                "sha256": "facf9d2b2514a4c56f57a9c202623100270ac13c3bc2fca201db76e795198629",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
@@ -1290,47 +1205,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-builder:1.0.1.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
-                ],
-                "sha256": "d2a712894dad4b5217c0d05609e6e29a0715addc8df4c9286d11482589043c41",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
-                ],
-                "sha256": "39f64e99da753c96f498516c22be51db997b869efbfb15413898438d58dde6ca",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-core-deployment:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
                     "com.google.code.findbugs:jsr305:3.0.2",
@@ -1343,11 +1218,6 @@
                     "commons-cli:commons-cli:1.4",
                     "commons-codec:commons-codec:1.9",
                     "commons-io:commons-io:2.5",
-                    "io.quarkus.gizmo:gizmo:1.0.0.Final",
-                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                    "io.quarkus:quarkus-builder:1.0.1.Final",
-                    "io.quarkus:quarkus-core:1.0.1.Final",
-                    "io.smallrye:smallrye-config:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:1.3.5",
                     "jakarta.ejb:jakarta.ejb-api:3.2.6",
                     "jakarta.el:jakarta.el-api:3.0.3",
@@ -1386,44 +1256,78 @@
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
                     "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
                     "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.jboss:jandex:2.1.2.Final",
                     "org.jsoup:jsoup:1.7.2",
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
-                    "org.ow2.asm:asm-analysis:7.1",
-                    "org.ow2.asm:asm-tree:7.1",
-                    "org.ow2.asm:asm-util:7.1",
-                    "org.ow2.asm:asm:7.1",
                     "org.slf4j:slf4j-api:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
+                ],
+                "directDependencies": [
+                    "com.google.guava:guava:27.0.1-jre",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
+                    "org.apache.maven.wagon:wagon-file:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:3.0.0",
+                    "org.apache.maven:maven-embedder:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:3.5.4",
+                    "org.apache.maven:maven-settings-builder:3.5.4",
+                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar"
+                ],
+                "sha256": "facf9d2b2514a4c56f57a9c202623100270ac13c3bc2fca201db76e795198629",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
+                ],
+                "sha256": "39f64e99da753c96f498516c22be51db997b869efbfb15413898438d58dde6ca",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-builder:1.0.1.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
                     "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus.gizmo:gizmo:1.0.0.Final",
-                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                    "io.quarkus:quarkus-builder:1.0.1.Final",
-                    "io.quarkus:quarkus-core:1.0.1.Final",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
-                    "org.jboss:jandex:2.1.2.Final",
-                    "org.ow2.asm:asm:7.1",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
                     "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
                 ],
-                "sha256": "fbc145b587ef82ec77b7bb827829738907b948eb178bbdc3943cc8dabcabf303",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar"
+                "sha256": "d2a712894dad4b5217c0d05609e6e29a0715addc8df4c9286d11482589043c41",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
@@ -1522,95 +1426,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-core:1.0.1.Final",
-                "dependencies": [
-                    "io.smallrye:smallrye-config:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                    "jakarta.el:jakarta.el-api:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
-                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "io.smallrye:smallrye-config:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
-                ],
-                "sha256": "6b046557b9680bb04522e15f2d45a720c9d0207fc10d804aa916c5f5dd45f9ed",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
-                "dependencies": [
-                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
-                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
-                ],
-                "sha256": "7a06ddd062aad6e7b781d898336659bfcf66c7448cb8f31944e0d92128b28831",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-creator:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-core-deployment:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
                     "com.google.code.findbugs:jsr305:3.0.2",
@@ -1626,7 +1442,6 @@
                     "io.quarkus.gizmo:gizmo:1.0.0.Final",
                     "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
                     "io.quarkus:quarkus-builder:1.0.1.Final",
-                    "io.quarkus:quarkus-core-deployment:1.0.1.Final",
                     "io.quarkus:quarkus-core:1.0.1.Final",
                     "io.smallrye:smallrye-config:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:1.3.5",
@@ -1689,15 +1504,110 @@
                     "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus:quarkus-core-deployment:1.0.1.Final"
+                    "io.quarkus.gizmo:gizmo:1.0.0.Final",
+                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
+                    "io.quarkus:quarkus-builder:1.0.1.Final",
+                    "io.quarkus:quarkus-core:1.0.1.Final",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss:jandex:2.1.2.Final",
+                    "org.ow2.asm:asm:7.1",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar"
                 ],
-                "sha256": "aff458590e7c103a97c3ef4a3cd4b99f2769824945dc98a922cc3ac2d143dea9",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar"
+                "sha256": "fbc145b587ef82ec77b7bb827829738907b948eb178bbdc3943cc8dabcabf303",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
+                "dependencies": [
+                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
+                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
+                ],
+                "sha256": "7a06ddd062aad6e7b781d898336659bfcf66c7448cb8f31944e0d92128b28831",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-core:1.0.1.Final",
+                "dependencies": [
+                    "io.smallrye:smallrye-config:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                    "jakarta.el:jakarta.el-api:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
+                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "io.smallrye:smallrye-config:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
+                ],
+                "sha256": "6b046557b9680bb04522e15f2d45a720c9d0207fc10d804aa916c5f5dd45f9ed",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
@@ -1790,7 +1700,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-development-mode:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-creator:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
                     "com.google.code.findbugs:jsr305:3.0.2",
@@ -1869,16 +1779,15 @@
                     "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus:quarkus-core-deployment:1.0.1.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4"
+                    "io.quarkus:quarkus-core-deployment:1.0.1.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar"
                 ],
-                "sha256": "dab38c2d1f7f2599f4934f127c066bc7ede661aa014c2ff463b8f4e697790231",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar"
+                "sha256": "aff458590e7c103a97c3ef4a3cd4b99f2769824945dc98a922cc3ac2d143dea9",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
@@ -1972,45 +1881,50 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-devtools-common:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-development-mode:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:2.2.0",
+                    "com.google.guava:failureaccess:1.0.1",
                     "com.google.guava:guava:27.0.1-jre",
+                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.inject:guice:jar:no_aop:4.2.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "commons-cli:commons-cli:1.4",
+                    "commons-codec:commons-codec:1.9",
                     "commons-io:commons-io:2.5",
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec-http:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-handler:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
-                    "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
+                    "io.quarkus.gizmo:gizmo:1.0.0.Final",
+                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
+                    "io.quarkus:quarkus-builder:1.0.1.Final",
+                    "io.quarkus:quarkus-core-deployment:1.0.1.Final",
+                    "io.quarkus:quarkus-core:1.0.1.Final",
+                    "io.smallrye:smallrye-config:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:1.3.5",
                     "jakarta.ejb:jakarta.ejb-api:3.2.6",
                     "jakarta.el:jakarta.el-api:3.0.3",
                     "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
                     "jakarta.inject:jakarta.inject-api:1.0",
                     "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                    "jakarta.servlet:jakarta.servlet-api:4.0.3",
                     "jakarta.transaction:jakarta.transaction-api:1.3.2",
-                    "jakarta.websocket:jakarta.websocket-api:1.1.2",
-                    "javax.annotation:jsr250-api:1.0",
-                    "javax.enterprise:cdi-api:1.0",
                     "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
                     "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:1.1.1",
                     "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.apache.maven.wagon:wagon-file:3.0.0",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:3.0.0",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
                     "org.apache.maven:maven-artifact:3.5.4",
                     "org.apache.maven:maven-builder-support:3.5.4",
                     "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-embedder:3.5.4",
                     "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
                     "org.apache.maven:maven-plugin-api:3.5.4",
@@ -2018,34 +1932,44 @@
                     "org.apache.maven:maven-resolver-provider:3.5.4",
                     "org.apache.maven:maven-settings-builder:3.5.4",
                     "org.apache.maven:maven-settings:3.5.4",
+                    "org.checkerframework:checker-qual:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
                     "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
+                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
                     "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.jboss:jandex:2.1.2.Final",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
+                    "org.ow2.asm:asm-analysis:7.1",
+                    "org.ow2.asm:asm-tree:7.1",
+                    "org.ow2.asm:asm-util:7.1",
+                    "org.ow2.asm:asm:7.1",
+                    "org.slf4j:slf4j-api:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
+                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
-                    "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
-                    "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.servlet:jakarta.servlet-api:4.0.3",
-                    "jakarta.websocket:jakarta.websocket-api:1.1.2",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4"
+                    "io.quarkus:quarkus-core-deployment:1.0.1.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar"
                 ],
-                "sha256": "a1937aadfe251e709559d607c2953f64ad6269149135d812be2e972aa2cb6b57",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar"
+                "sha256": "dab38c2d1f7f2599f4934f127c066bc7ede661aa014c2ff463b8f4e697790231",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
@@ -2124,23 +2048,12 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-maven-plugin:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-devtools-common:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
-                    "com.eclipsesource.minimal-json:minimal-json:0.9.5",
-                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.google.code.google-collections:google-collect:snapshot-20080530",
-                    "com.google.errorprone:error_prone_annotations:2.2.0",
-                    "com.google.guava:failureaccess:1.0.1",
                     "com.google.guava:guava:27.0.1-jre",
-                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "com.google.j2objc:j2objc-annotations:1.1",
-                    "commons-cli:commons-cli:1.4",
-                    "commons-codec:commons-codec:1.9",
                     "commons-io:commons-io:2.5",
                     "io.netty:netty-buffer:4.1.34.Final",
                     "io.netty:netty-codec-http:4.1.34.Final",
@@ -2149,23 +2062,11 @@
                     "io.netty:netty-handler:4.1.34.Final",
                     "io.netty:netty-resolver:4.1.34.Final",
                     "io.netty:netty-transport:4.1.34.Final",
-                    "io.quarkus.gizmo:gizmo:1.0.0.Final",
                     "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
-                    "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
-                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                    "io.quarkus:quarkus-builder:1.0.1.Final",
-                    "io.quarkus:quarkus-core-deployment:1.0.1.Final",
-                    "io.quarkus:quarkus-core:1.0.1.Final",
-                    "io.quarkus:quarkus-creator:1.0.1.Final",
-                    "io.quarkus:quarkus-development-mode:1.0.1.Final",
-                    "io.quarkus:quarkus-devtools-common:1.0.1.Final",
                     "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
-                    "io.smallrye:smallrye-config:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:1.3.5",
                     "jakarta.ejb:jakarta.ejb-api:3.2.6",
                     "jakarta.el:jakarta.el-api:3.0.3",
@@ -2177,30 +2078,15 @@
                     "jakarta.websocket:jakarta.websocket-api:1.1.2",
                     "javax.annotation:jsr250-api:1.0",
                     "javax.enterprise:cdi-api:1.0",
-                    "jline:jline:2.14.6",
-                    "junit:junit:3.8.2",
                     "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
                     "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
-                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                    "org.apache.maven.shared:maven-invoker:3.0.1",
                     "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.apache.maven.wagon:wagon-file:3.0.0",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:3.0.0",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
                     "org.apache.maven:maven-artifact:3.5.4",
                     "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-compat:3.0-alpha-2",
                     "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-embedder:3.5.4",
                     "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
                     "org.apache.maven:maven-plugin-api:3.5.4",
@@ -2208,71 +2094,34 @@
                     "org.apache.maven:maven-resolver-provider:3.5.4",
                     "org.apache.maven:maven-settings-builder:3.5.4",
                     "org.apache.maven:maven-settings:3.5.4",
-                    "org.apache.maven:maven-toolchain:3.0-alpha-2",
-                    "org.apache.xbean:xbean-reflect:3.4",
-                    "org.checkerframework:checker-qual:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
                     "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
                     "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
                     "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.freemarker:freemarker:2.3.28",
-                    "org.glassfish:jakarta.json:1.1.6",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
-                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
                     "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
                     "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.jboss:jandex:2.1.2.Final",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
-                    "org.ow2.asm:asm-analysis:7.1",
-                    "org.ow2.asm:asm-tree:7.1",
-                    "org.ow2.asm:asm-util:7.1",
-                    "org.ow2.asm:asm:7.1",
-                    "org.slf4j:slf4j-api:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2",
-                    "org.twdata.maven:mojo-executor:2.3.0",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
                 ],
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
-                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                    "io.quarkus:quarkus-creator:1.0.1.Final",
-                    "io.quarkus:quarkus-development-mode:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
+                    "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
+                    "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
                     "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jline:jline:2.14.6",
-                    "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
-                    "org.apache.maven.shared:maven-invoker:3.0.1",
+                    "jakarta.servlet:jakarta.servlet-api:4.0.3",
+                    "jakarta.websocket:jakarta.websocket-api:1.1.2",
                     "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.apache.maven:maven-toolchain:3.0-alpha-2",
-                    "org.freemarker:freemarker:2.3.28",
-                    "org.glassfish:jakarta.json:1.1.6",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
-                    "org.twdata.maven:mojo-executor:2.3.0"
+                    "org.apache.maven:maven-plugin-api:3.5.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar"
                 ],
-                "sha256": "607c196c31543a73c6fb40c4b69067cb9cda95fe34b4063a9fcfe7f6f224e3fc",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar"
+                "sha256": "a1937aadfe251e709559d607c2953f64ad6269149135d812be2e972aa2cb6b57",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-maven-plugin:jar:sources:1.0.1.Final",
@@ -2426,22 +2275,155 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-maven-plugin:1.0.1.Final",
                 "dependencies": [
+                    "aopalliance:aopalliance:1.0",
+                    "com.eclipsesource.minimal-json:minimal-json:0.9.5",
+                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.code.google-collections:google-collect:snapshot-20080530",
+                    "com.google.errorprone:error_prone_annotations:2.2.0",
+                    "com.google.guava:failureaccess:1.0.1",
+                    "com.google.guava:guava:27.0.1-jre",
+                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.inject:guice:jar:no_aop:4.2.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "commons-cli:commons-cli:1.4",
+                    "commons-codec:commons-codec:1.9",
+                    "commons-io:commons-io:2.5",
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec-http:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-handler:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final",
+                    "io.quarkus.gizmo:gizmo:1.0.0.Final",
+                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
+                    "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
+                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
+                    "io.quarkus:quarkus-builder:1.0.1.Final",
+                    "io.quarkus:quarkus-core-deployment:1.0.1.Final",
+                    "io.quarkus:quarkus-core:1.0.1.Final",
+                    "io.quarkus:quarkus-creator:1.0.1.Final",
+                    "io.quarkus:quarkus-development-mode:1.0.1.Final",
+                    "io.quarkus:quarkus-devtools-common:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
+                    "io.smallrye:smallrye-config:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                    "jakarta.el:jakarta.el-api:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
+                    "jakarta.servlet:jakarta.servlet-api:4.0.3",
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
+                    "jakarta.websocket:jakarta.websocket-api:1.1.2",
+                    "javax.annotation:jsr250-api:1.0",
+                    "javax.enterprise:cdi-api:1.0",
+                    "jline:jline:2.14.6",
+                    "junit:junit:3.8.2",
                     "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                    "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
+                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                    "org.apache.maven.shared:maven-invoker:3.0.1",
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.apache.maven.wagon:wagon-file:3.0.0",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:3.0.0",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-compat:3.0-alpha-2",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-embedder:3.5.4",
+                    "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:3.5.4",
+                    "org.apache.maven:maven-settings-builder:3.5.4",
+                    "org.apache.maven:maven-settings:3.5.4",
+                    "org.apache.maven:maven-toolchain:3.0-alpha-2",
+                    "org.apache.xbean:xbean-reflect:3.4",
+                    "org.checkerframework:checker-qual:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
+                    "org.codehaus.plexus:plexus-interpolation:1.24",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
+                    "org.freemarker:freemarker:2.3.28",
+                    "org.glassfish:jakarta.json:1.1.6",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
+                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.jboss:jandex:2.1.2.Final",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
+                    "org.ow2.asm:asm-analysis:7.1",
+                    "org.ow2.asm:asm-tree:7.1",
+                    "org.ow2.asm:asm-util:7.1",
+                    "org.ow2.asm:asm:7.1",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.sonatype.plexus:plexus-cipher:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2",
+                    "org.twdata.maven:mojo-executor:2.3.0",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-model:3.5.4"
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
+                    "io.quarkus:quarkus-creator:1.0.1.Final",
+                    "io.quarkus:quarkus-development-mode:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jline:jline:2.14.6",
+                    "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
+                    "org.apache.maven.shared:maven-invoker:3.0.1",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.apache.maven:maven-toolchain:3.0-alpha-2",
+                    "org.freemarker:freemarker:2.3.28",
+                    "org.glassfish:jakarta.json:1.1.6",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.twdata.maven:mojo-executor:2.3.0"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar"
                 ],
-                "sha256": "ad9996d460fa979f08c63be5ee543448b4ff735b0805f57a470cc7f69726c8ca",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar"
+                "sha256": "607c196c31543a73c6fb40c4b69067cb9cda95fe34b4063a9fcfe7f6f224e3fc",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
@@ -2462,102 +2444,22 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
                 "dependencies": [
-                    "aopalliance:aopalliance:1.0",
-                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:2.2.0",
-                    "com.google.guava:failureaccess:1.0.1",
-                    "com.google.guava:guava:27.0.1-jre",
-                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "com.google.j2objc:j2objc-annotations:1.1",
-                    "commons-cli:commons-cli:1.4",
-                    "commons-codec:commons-codec:1.9",
-                    "commons-io:commons-io:2.5",
-                    "io.netty:netty-buffer:4.1.34.Final",
-                    "io.netty:netty-codec-http:4.1.34.Final",
-                    "io.netty:netty-codec:4.1.34.Final",
-                    "io.netty:netty-common:4.1.34.Final",
-                    "io.netty:netty-handler:4.1.34.Final",
-                    "io.netty:netty-resolver:4.1.34.Final",
-                    "io.netty:netty-transport:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
-                    "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
-                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                    "io.quarkus:quarkus-devtools-common:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                    "jakarta.el:jakarta.el-api:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                    "jakarta.servlet:jakarta.servlet-api:4.0.3",
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
-                    "jakarta.websocket:jakarta.websocket-api:1.1.2",
-                    "javax.annotation:jsr250-api:1.0",
-                    "javax.enterprise:cdi-api:1.0",
                     "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.apache.maven.wagon:wagon-file:3.0.0",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:3.0.0",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-embedder:3.5.4",
-                    "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:3.5.4",
-                    "org.apache.maven:maven-settings-builder:3.5.4",
-                    "org.apache.maven:maven-settings:3.5.4",
-                    "org.checkerframework:checker-qual:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:1.24",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.sonatype.plexus:plexus-cipher:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
-                    "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
-                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
-                    "io.quarkus:quarkus-devtools-common:1.0.1.Final"
+                    "org.apache.maven:maven-model:3.5.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar"
                 ],
-                "sha256": "faf1f23047fc23342f52c0d921ed21dace38be841ec5f9fc5ed655b8e33ecb6a",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar"
+                "sha256": "ad9996d460fa979f08c63be5ee543448b4ff735b0805f57a470cc7f69726c8ca",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
@@ -2658,13 +2560,21 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
-                    "com.eclipsesource.minimal-json:minimal-json:0.9.5",
+                    "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:2.2.0",
+                    "com.google.guava:failureaccess:1.0.1",
                     "com.google.guava:guava:27.0.1-jre",
+                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.inject:guice:jar:no_aop:4.2.0",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "commons-cli:commons-cli:1.4",
+                    "commons-codec:commons-codec:1.9",
                     "commons-io:commons-io:2.5",
                     "io.netty:netty-buffer:4.1.34.Final",
                     "io.netty:netty-codec-http:4.1.34.Final",
@@ -2677,6 +2587,8 @@
                     "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
+                    "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
+                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
                     "io.quarkus:quarkus-devtools-common:1.0.1.Final",
                     "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
                     "jakarta.annotation:jakarta.annotation-api:1.3.5",
@@ -2691,14 +2603,23 @@
                     "javax.annotation:jsr250-api:1.0",
                     "javax.enterprise:cdi-api:1.0",
                     "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
                     "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:1.1.1",
                     "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.apache.maven.wagon:wagon-file:3.0.0",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:3.0.0",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
                     "org.apache.maven:maven-artifact:3.5.4",
                     "org.apache.maven:maven-builder-support:3.5.4",
                     "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-embedder:3.5.4",
                     "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
                     "org.apache.maven:maven-plugin-api:3.5.4",
@@ -2706,29 +2627,35 @@
                     "org.apache.maven:maven-resolver-provider:3.5.4",
                     "org.apache.maven:maven-settings-builder:3.5.4",
                     "org.apache.maven:maven-settings:3.5.4",
+                    "org.checkerframework:checker-qual:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
                     "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
                     "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
+                    "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
                     "org.jboss.logging:jboss-logging:3.4.0.Final",
                     "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:1.4",
                     "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
                 ],
                 "directDependencies": [
-                    "com.eclipsesource.minimal-json:minimal-json:0.9.5",
-                    "io.quarkus:quarkus-devtools-common:1.0.1.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final"
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                    "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
+                    "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
+                    "io.quarkus:quarkus-devtools-common:1.0.1.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar"
                 ],
-                "sha256": "5cf18e23e0e63eb02a244f898256b43cf37e6035ea1ec78d5116c95506abe6e4",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar"
+                "sha256": "faf1f23047fc23342f52c0d921ed21dace38be841ec5f9fc5ed655b8e33ecb6a",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
@@ -2804,27 +2731,77 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar"
             },
             {
-                "coord": "io.smallrye:smallrye-config:1.3.9",
+                "coord": "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
                 "dependencies": [
-                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "aopalliance:aopalliance:1.0",
+                    "com.eclipsesource.minimal-json:minimal-json:0.9.5",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
+                    "com.google.guava:guava:27.0.1-jre",
+                    "com.google.inject:guice:jar:no_aop:4.2.0",
+                    "commons-io:commons-io:2.5",
+                    "io.netty:netty-buffer:4.1.34.Final",
+                    "io.netty:netty-codec-http:4.1.34.Final",
+                    "io.netty:netty-codec:4.1.34.Final",
+                    "io.netty:netty-common:4.1.34.Final",
+                    "io.netty:netty-handler:4.1.34.Final",
+                    "io.netty:netty-resolver:4.1.34.Final",
+                    "io.netty:netty-transport:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
+                    "io.quarkus:quarkus-devtools-common:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                    "jakarta.el:jakarta.el-api:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
+                    "jakarta.servlet:jakarta.servlet-api:4.0.3",
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
+                    "jakarta.websocket:jakarta.websocket-api:1.1.2",
+                    "javax.annotation:jsr250-api:1.0",
+                    "javax.enterprise:cdi-api:1.0",
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-model-builder:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:3.5.4",
+                    "org.apache.maven:maven-settings-builder:3.5.4",
+                    "org.apache.maven:maven-settings:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:1.24",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
                     "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0"
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
+                    "org.sonatype.plexus:plexus-cipher:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
                 ],
                 "directDependencies": [
-                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "com.eclipsesource.minimal-json:minimal-json:0.9.5",
+                    "io.quarkus:quarkus-devtools-common:1.0.1.Final",
                     "org.jboss.logging:jboss-logging:3.4.0.Final"
                 ],
-                "exclusions": [
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:javax.annotation-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar",
-                    "https://repo.spring.io/plugins-release/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar"
                 ],
-                "sha256": "61a850ebdfc8510df682533c6691428a2998951cf7b57cf0e2e718b1c7c91c67",
-                "url": "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar"
+                "sha256": "5cf18e23e0e63eb02a244f898256b43cf37e6035ea1ec78d5116c95506abe6e4",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar"
             },
             {
                 "coord": "io.smallrye:smallrye-config:jar:sources:1.3.9",
@@ -2850,16 +2827,27 @@
                 "url": "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar"
             },
             {
-                "coord": "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
+                "coord": "io.smallrye:smallrye-config:1.3.9",
+                "dependencies": [
+                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0"
                 ],
-                "sha256": "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
+                "directDependencies": [
+                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final"
+                ],
+                "exclusions": [
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:javax.annotation-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar",
+                    "https://repo.spring.io/plugins-release/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar"
+                ],
+                "sha256": "61a850ebdfc8510df682533c6691428a2998951cf7b57cf0e2e718b1c7c91c67",
+                "url": "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar"
             },
             {
                 "coord": "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
@@ -2874,20 +2862,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
             },
             {
-                "coord": "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                "dependencies": [
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
-                ],
-                "directDependencies": [
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar",
+                "coord": "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
                 ],
-                "sha256": "47bf067a03e2f4d57e37ff8acacfa57caefbf89d77167dc6f5c36896aaf8b1c3",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar"
+                "sha256": "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
             },
             {
                 "coord": "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
@@ -2906,16 +2890,20 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar"
             },
             {
-                "coord": "jakarta.el:jakarta.el-api:3.0.3",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar"
+                "coord": "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                "dependencies": [
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
                 ],
-                "sha256": "47ae0a91fb6dd32fdaa5d9bda63df043ac8148e00c297ccce8ab9c56b95cf261",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar"
+                "directDependencies": [
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar"
+                ],
+                "sha256": "47bf067a03e2f4d57e37ff8acacfa57caefbf89d77167dc6f5c36896aaf8b1c3",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar"
             },
             {
                 "coord": "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
@@ -2930,27 +2918,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar"
             },
             {
-                "coord": "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                "dependencies": [
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                    "jakarta.el:jakarta.el-api:3.0.3",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
-                ],
-                "directDependencies": [
-                    "jakarta.el:jakarta.el-api:3.0.3",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar",
+                "coord": "jakarta.el:jakarta.el-api:3.0.3",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar"
                 ],
-                "sha256": "e71bbe0e4cacfce5b7d609021344d883531aa3e19321db17390f849fdb04a509",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar"
+                "sha256": "47ae0a91fb6dd32fdaa5d9bda63df043ac8148e00c297ccce8ab9c56b95cf261",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar"
             },
             {
                 "coord": "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
@@ -2976,16 +2953,27 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar"
             },
             {
-                "coord": "jakarta.inject:jakarta.inject-api:1.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar"
+                "coord": "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                "dependencies": [
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                    "jakarta.el:jakarta.el-api:3.0.3",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
                 ],
-                "sha256": "3655ffdcdc058816632666a8bcbcf4bfd09751c6a77dedf70619f37294abb01f",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar"
+                "directDependencies": [
+                    "jakarta.el:jakarta.el-api:3.0.3",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar"
+                ],
+                "sha256": "e71bbe0e4cacfce5b7d609021344d883531aa3e19321db17390f849fdb04a509",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar"
             },
             {
                 "coord": "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
@@ -3000,23 +2988,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar"
             },
             {
-                "coord": "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                "dependencies": [
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
-                ],
-                "directDependencies": [
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar",
+                "coord": "jakarta.inject:jakarta.inject-api:1.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar"
                 ],
-                "sha256": "210c4f0a5a8f387457d58afa3982b9abdd28f0a891e6289b329a6d8cf2210299",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar"
+                "sha256": "3655ffdcdc058816632666a8bcbcf4bfd09751c6a77dedf70619f37294abb01f",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar"
             },
             {
                 "coord": "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
@@ -3038,16 +3019,23 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar"
             },
             {
-                "coord": "jakarta.servlet:jakarta.servlet-api:4.0.3",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar"
+                "coord": "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
+                "dependencies": [
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2"
                 ],
-                "sha256": "6d93010ca93301383c5ca960d55611a5c91798da1efb0f1fe9356f27831bf499",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar"
+                "directDependencies": [
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar"
+                ],
+                "sha256": "210c4f0a5a8f387457d58afa3982b9abdd28f0a891e6289b329a6d8cf2210299",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar"
             },
             {
                 "coord": "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
@@ -3062,16 +3050,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar"
             },
             {
-                "coord": "jakarta.transaction:jakarta.transaction-api:1.3.2",
+                "coord": "jakarta.servlet:jakarta.servlet-api:4.0.3",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar"
                 ],
-                "sha256": "0dda6ab4160077a5f18d5b24994a44e24576058db9b3da65dfbf14e9e750ce2c",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar"
+                "sha256": "6d93010ca93301383c5ca960d55611a5c91798da1efb0f1fe9356f27831bf499",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar"
             },
             {
                 "coord": "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
@@ -3086,16 +3074,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar"
             },
             {
-                "coord": "jakarta.websocket:jakarta.websocket-api:1.1.2",
+                "coord": "jakarta.transaction:jakarta.transaction-api:1.3.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar"
                 ],
-                "sha256": "e2f4e99e04130a29fc8e57e334fa029e96e2ca6672ba0166585c59d19798904c",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar"
+                "sha256": "0dda6ab4160077a5f18d5b24994a44e24576058db9b3da65dfbf14e9e750ce2c",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar"
             },
             {
                 "coord": "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
@@ -3108,6 +3096,37 @@
                 ],
                 "sha256": "c66adcb71ea4d8a1d3e75b9b21edc8ad14f90b8abf0ab1f6689564c0e8ed2fa9",
                 "url": "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar"
+            },
+            {
+                "coord": "jakarta.websocket:jakarta.websocket-api:1.1.2",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar"
+                ],
+                "sha256": "e2f4e99e04130a29fc8e57e334fa029e96e2ca6672ba0166585c59d19798904c",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar"
+            },
+            {
+                "coord": "javax.annotation:jsr250-api:jar:sources:1.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.el:el-api",
+                    "org.jboss.ejb3:jboss-ejb3-api",
+                    "org.jboss.interceptor:jboss-interceptor-api",
+                    "log4j:log4j",
+                    "commons-logging:commons-logging-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
+                ],
+                "sha256": "025c47d76c60199381be07012a0c5f9e74661aac5bd67f5aec847741c5b7f838",
+                "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
             },
             {
                 "coord": "javax.annotation:jsr250-api:1.0",
@@ -3128,9 +3147,15 @@
                 "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
             },
             {
-                "coord": "javax.annotation:jsr250-api:jar:sources:1.0",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "javax.enterprise:cdi-api:jar:sources:1.0",
+                "dependencies": [
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.inject:javax.inject:jar:sources:1"
+                ],
+                "directDependencies": [
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.inject:javax.inject:jar:sources:1"
+                ],
                 "exclusions": [
                     "javax.el:el-api",
                     "org.jboss.ejb3:jboss-ejb3-api",
@@ -3138,13 +3163,13 @@
                     "log4j:log4j",
                     "commons-logging:commons-logging-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
                 ],
-                "sha256": "025c47d76c60199381be07012a0c5f9e74661aac5bd67f5aec847741c5b7f838",
-                "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
+                "sha256": "0e7c351dfe05759f84dc3eddaac1da4ef72578b494b53338829d34b12271374f",
+                "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
             },
             {
                 "coord": "javax.enterprise:cdi-api:1.0",
@@ -3175,29 +3200,19 @@
                 "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
             },
             {
-                "coord": "javax.enterprise:cdi-api:jar:sources:1.0",
-                "dependencies": [
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.inject:javax.inject:jar:sources:1"
-                ],
-                "directDependencies": [
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.inject:javax.inject:jar:sources:1"
-                ],
+                "coord": "javax.inject:javax.inject:jar:sources:1",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "javax.el:el-api",
-                    "org.jboss.ejb3:jboss-ejb3-api",
-                    "org.jboss.interceptor:jboss-interceptor-api",
-                    "log4j:log4j",
-                    "commons-logging:commons-logging-api"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
+                    "https://repo.spring.io/plugins-release/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
                 ],
-                "sha256": "0e7c351dfe05759f84dc3eddaac1da4ef72578b494b53338829d34b12271374f",
-                "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
+                "sha256": "c4b87ee2911c139c3daf498a781967f1eb2e75bc1a8529a2e7b328a15d0e433e",
+                "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
             },
             {
                 "coord": "javax.inject:javax.inject:1",
@@ -3219,33 +3234,6 @@
                 "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar"
             },
             {
-                "coord": "javax.inject:javax.inject:jar:sources:1",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
-                    "https://repo.spring.io/plugins-release/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
-                ],
-                "sha256": "c4b87ee2911c139c3daf498a781967f1eb2e75bc1a8529a2e7b328a15d0e433e",
-                "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
-            },
-            {
-                "coord": "jline:jline:2.14.6",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar",
-                    "https://repo.spring.io/plugins-release/jline/jline/2.14.6/jline-2.14.6.jar"
-                ],
-                "sha256": "97d1acaac82409be42e622d7a54d3ae9d08517e8aefdea3d2ba9791150c2f02d",
-                "url": "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar"
-            },
-            {
                 "coord": "jline:jline:jar:sources:2.14.6",
                 "dependencies": [],
                 "directDependencies": [],
@@ -3258,20 +3246,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar"
             },
             {
-                "coord": "junit:junit:3.8.2",
+                "coord": "jline:jline:2.14.6",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar",
-                    "https://repo.spring.io/plugins-release/junit/junit/3.8.2/junit-3.8.2.jar"
+                    "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar",
+                    "https://repo.spring.io/plugins-release/jline/jline/2.14.6/jline-2.14.6.jar"
                 ],
-                "sha256": "ecdcc08183708ea3f7b0ddc96f19678a0db8af1fb397791d484aed63200558b0",
-                "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar"
+                "sha256": "97d1acaac82409be42e622d7a54d3ae9d08517e8aefdea3d2ba9791150c2f02d",
+                "url": "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar"
             },
             {
                 "coord": "junit:junit:jar:sources:3.8.2",
@@ -3290,19 +3274,20 @@
                 "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar"
             },
             {
-                "coord": "org.apache.commons:commons-lang3:3.9",
+                "coord": "junit:junit:3.8.2",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
+                    "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar",
+                    "https://repo.spring.io/plugins-release/junit/junit/3.8.2/junit-3.8.2.jar"
                 ],
-                "sha256": "de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
+                "sha256": "ecdcc08183708ea3f7b0ddc96f19678a0db8af1fb397791d484aed63200558b0",
+                "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar"
             },
             {
                 "coord": "org.apache.commons:commons-lang3:jar:sources:3.9",
@@ -3320,27 +3305,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar"
             },
             {
-                "coord": "org.apache.httpcomponents:httpclient:4.5.3",
-                "dependencies": [
-                    "commons-codec:commons-codec:1.9",
-                    "org.apache.httpcomponents:httpcore:4.4.6"
-                ],
-                "directDependencies": [
-                    "commons-codec:commons-codec:1.9",
-                    "org.apache.httpcomponents:httpcore:4.4.6"
-                ],
+                "coord": "org.apache.commons:commons-lang3:3.9",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "commons-logging:commons-logging",
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
                 ],
-                "sha256": "db3d1b6c2d6a5e5ad47577ad61854e2f0e0936199b8e05eb541ed52349263135",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar"
+                "sha256": "de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
             },
             {
                 "coord": "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
@@ -3366,21 +3343,27 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar"
             },
             {
-                "coord": "org.apache.httpcomponents:httpcore:4.4.6",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "org.apache.httpcomponents:httpclient:4.5.3",
+                "dependencies": [
+                    "commons-codec:commons-codec:1.9",
+                    "org.apache.httpcomponents:httpcore:4.4.6"
+                ],
+                "directDependencies": [
+                    "commons-codec:commons-codec:1.9",
+                    "org.apache.httpcomponents:httpcore:4.4.6"
+                ],
                 "exclusions": [
+                    "commons-logging:commons-logging",
                     "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar"
                 ],
-                "sha256": "d7f853dee87680b07293d30855b39b9eb56c1297bd16ff1cd6f19ddb8fa745fb",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar"
+                "sha256": "db3d1b6c2d6a5e5ad47577ad61854e2f0e0936199b8e05eb541ed52349263135",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar"
             },
             {
                 "coord": "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
@@ -3400,682 +3383,21 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar"
             },
             {
-                "coord": "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                "coord": "org.apache.httpcomponents:httpcore:4.4.6",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
-                ],
-                "sha256": "a4ce03467f0c47615c53533ad1682fe00b8170f760e7ed0c57f5afc3035fe38b",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
-                ],
-                "sha256": "d6f618875c02e12f4b64e173c2a3897306694b0c4f613567907be2d0e906c7fa",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
-                ],
-                "sha256": "5efa36fa5e8f14be6013301fcba012aa8dc651fea886ab9f902a4122a7debb93",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
-                ],
-                "sha256": "bb8ecdb9ac7715873b0a316351adf96d31641647ef42f26feefd211177426756",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
-                ],
-                "sha256": "6c8adfb6415b46e31f399132e5d8d0faee3443b7493ba709746ce2614d2acf97",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
-                ],
-                "sha256": "6dd833726534cae3b0ba6ddae2b6899917b77ddd8cacd1dd0cda0d24755cd19d",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
-                ],
-                "sha256": "8b686318f0675719afd6a97d6856d498ea554bd7da6522b6798d94d235e74c16",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
-                ],
-                "sha256": "4efe32a8c8517bace826a5d91fa2b65d8ca35d90f8ecb92981c1ad37806fe680",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
-                ],
-                "sha256": "c45247527daa9536f5fb31b3063dd456d41543d06490fec040fc37da5c88a4af",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
-                ],
-                "sha256": "6a0c64f62be47314bba1f0aa3dd49cb26f8debe730642bce2f2cb5f29fef8944",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
-                ],
-                "sha256": "040e6bb13a34bc3fd721e9256784e996d2700a518476c6f9801c112699320208",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
-                ],
-                "sha256": "db5556b7023f3c4dc8a26c6c0700defd9b9da64a9b8ae2b113b7bdf54adc4de8",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
-                "dependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
-                ],
-                "sha256": "6f919f97c9272263fa910cfe7fa88595982a0451e7d7b121cca8ac85f6162882",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
-                "dependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
-                ],
-                "sha256": "ee55923f7ca080f751e49b0a9751c32c1d36068467a6bad7ccfe5db7719348ae",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                "dependencies": [
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
-                ],
-                "sha256": "b291bd2d46ecd42ba26938a78ec053eedb240e5a3eef3ffc82c46ecafa95c306",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                "dependencies": [
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
-                ],
-                "sha256": "562a67e2888d6f70379d89f7c78b3226dd26c5b5e77c8554c6854f9001dc8d18",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-invoker:3.0.1",
-                "dependencies": [
-                    "commons-io:commons-io:2.5",
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
-                ],
-                "sha256": "d20e5d26c19c04199c73fd4f0b6caebf4bbdc6b872a4504c5e71a192751d9464",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
-                "dependencies": [
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
-                ],
-                "sha256": "94b766c063bf6345faa571ada4bd19fd4804ff2354ea6779d5894b3e37c7afa7",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                "dependencies": [
-                    "commons-io:commons-io:2.5"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:2.5"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-                ],
-                "sha256": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                "dependencies": [
-                    "commons-io:commons-io:jar:sources:2.5"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:jar:sources:2.5"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
-                ],
-                "sha256": "25064c72c178a98335048d0f7c3e08839e949426bc92bf905ea964146235f388",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-file:3.0.0",
-                "dependencies": [
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
-                ],
-                "sha256": "63324036899559f94154e6f845e62453a1f202c1b21b80060f2d88a05a05a272",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
-                ],
-                "sha256": "4481a2ab7ceca66e57401d3d3528c095dac22dc7ce7e67124a19cc172da30d74",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:1.9",
-                    "commons-io:commons-io:2.5",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:2.5",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
-                ],
-                "sha256": "40c51265b3ed90b6919c08dcdf3620dc614894ef60bacdf4c34bdbe295b44c49",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
-                ],
-                "sha256": "399e420f09b69e34b53897affd2723c06a133f6e9dbff68d74b3e55498c7a83a",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:1.9",
-                    "commons-io:commons-io:2.5",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
                     "org.slf4j:jcl-over-slf4j",
                     "org.slf4j:slf4j-simple",
                     "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar"
                 ],
-                "sha256": "9f68fed6684c2245a62d5d3c8b4954b882562797e96b15ce0f18514c543fb999",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
-                ],
-                "sha256": "1b16a3eb55393e2c96184f0222d644675d5b439d0ed00ea4100bebbd8f8eaa22",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
-                ],
-                "sha256": "04de4d2f39178998ef3ce5f6d91a358363ad3f5270e897d5547321ea69fa2992",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
-                ],
-                "sha256": "c356c99bad5f0e8e99203e2e5b3c83ab5eafe0bd80e3346f7dfbe1fce94c9bb6",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-artifact:3.5.4",
-                "dependencies": [
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
-                ],
-                "sha256": "6fbf25de86cce3afbaf5c502dff57df6d7c90cf9bec0ae0ffe5ab2467243c35b",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
+                "sha256": "d7f853dee87680b07293d30855b39b9eb56c1297bd16ff1cd6f19ddb8fa745fb",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar"
             },
             {
                 "coord": "org.apache.maven:maven-artifact:jar:sources:3.5.4",
@@ -4101,23 +3423,25 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-builder-support:3.5.4",
+                "coord": "org.apache.maven:maven-artifact:3.5.4",
                 "dependencies": [
-                    "org.apache.commons:commons-lang3:3.9"
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
-                    "org.apache.commons:commons-lang3:3.9"
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
                 ],
-                "sha256": "43855ce29fc8001ef663a5bb2bb0473481b1f8f80cea7b3cc1d426af996960b2",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
+                "sha256": "6fbf25de86cce3afbaf5c502dff57df6d7c90cf9bec0ae0ffe5ab2467243c35b",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
@@ -4140,35 +3464,23 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-compat:3.0-alpha-2",
+                "coord": "org.apache.maven:maven-builder-support:3.5.4",
                 "dependencies": [
-                    "com.google.code.google-collections:google-collect:snapshot-20080530",
-                    "junit:junit:3.8.2",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.xbean:xbean-reflect:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.commons:commons-lang3:3.9"
                 ],
                 "directDependencies": [
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5"
+                    "org.apache.commons:commons-lang3:3.9"
                 ],
                 "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
                 ],
-                "sha256": "85500348730f338599e5f454be4a9909a6d01e86effc1ed0650a71e544bc67d5",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar"
+                "sha256": "43855ce29fc8001ef663a5bb2bb0473481b1f8f80cea7b3cc1d426af996960b2",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
@@ -4202,74 +3514,35 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-core:3.5.4",
+                "coord": "org.apache.maven:maven-compat:3.0-alpha-2",
                 "dependencies": [
-                    "aopalliance:aopalliance:1.0",
-                    "com.google.guava:guava:27.0.1-jre",
-                    "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "commons-io:commons-io:2.5",
-                    "javax.annotation:jsr250-api:1.0",
-                    "javax.enterprise:cdi-api:1.0",
-                    "javax.inject:javax.inject:1",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-model-builder:3.5.4",
+                    "com.google.code.google-collections:google-collect:snapshot-20080530",
+                    "junit:junit:3.8.2",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
                     "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:3.5.4",
-                    "org.apache.maven:maven-settings-builder:3.5.4",
-                    "org.apache.maven:maven-settings:3.5.4",
+                    "org.apache.xbean:xbean-reflect:3.4",
                     "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:1.24",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.sonatype.plexus:plexus-cipher:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
+                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
-                    "com.google.guava:guava:27.0.1-jre",
-                    "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "javax.inject:javax.inject:1",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-model-builder:3.5.4",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
                     "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:3.5.4",
-                    "org.apache.maven:maven-settings-builder:3.5.4",
-                    "org.apache.maven:maven-settings:3.5.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
+                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar"
                 ],
-                "sha256": "58c248d75cf32d7de10c897e0f96693cb51832f6bad7a413ae149ca499056f72",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar"
+                "sha256": "85500348730f338599e5f454be4a9909a6d01e86effc1ed0650a71e544bc67d5",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar"
             },
             {
                 "coord": "org.apache.maven:maven-core:jar:sources:3.5.4",
@@ -4342,13 +3615,15 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-embedder:3.5.4",
+                "coord": "org.apache.maven:maven-core:3.5.4",
                 "dependencies": [
                     "aopalliance:aopalliance:1.0",
                     "com.google.guava:guava:27.0.1-jre",
                     "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "commons-cli:commons-cli:1.4",
                     "commons-io:commons-io:2.5",
+                    "javax.annotation:jsr250-api:1.0",
+                    "javax.enterprise:cdi-api:1.0",
+                    "javax.inject:javax.inject:1",
                     "org.apache.commons:commons-lang3:3.9",
                     "org.apache.maven.resolver:maven-resolver-api:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
@@ -4357,7 +3632,6 @@
                     "org.apache.maven.shared:maven-shared-utils:3.2.1",
                     "org.apache.maven:maven-artifact:3.5.4",
                     "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-core:3.5.4",
                     "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
                     "org.apache.maven:maven-plugin-api:3.5.4",
@@ -4371,43 +3645,44 @@
                     "org.codehaus.plexus:plexus-utils:3.1.0",
                     "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.slf4j:slf4j-api:1.7.25"
+                    "org.sonatype.plexus:plexus-cipher:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:1.4"
                 ],
                 "directDependencies": [
                     "com.google.guava:guava:27.0.1-jre",
                     "com.google.inject:guice:jar:no_aop:4.2.0",
-                    "commons-cli:commons-cli:1.4",
+                    "javax.inject:javax.inject:1",
                     "org.apache.commons:commons-lang3:3.9",
                     "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:1.1.1",
                     "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.apache.maven:maven-artifact:3.5.4",
                     "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-core:3.5.4",
                     "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
                     "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:3.5.4",
                     "org.apache.maven:maven-settings-builder:3.5.4",
                     "org.apache.maven:maven-settings:3.5.4",
                     "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
-                    "org.slf4j:slf4j-api:1.7.25"
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
                 ],
                 "exclusions": [
-                    "javax.inject:javax.inject",
-                    "org.sonatype.plexus:plexus-cipher",
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:jsr250-api",
-                    "org.sonatype.plexus:plexus-sec-dispatcher"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar"
                 ],
-                "sha256": "d9216ac3c62c5a478e0c6d723ab4efef3bd730b63f36a9a19572c56e5b8985a6",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar"
+                "sha256": "58c248d75cf32d7de10c897e0f96693cb51832f6bad7a413ae149ca499056f72",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-embedder:jar:sources:3.5.4",
@@ -4479,37 +3754,72 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-model-builder:3.5.4",
+                "coord": "org.apache.maven:maven-embedder:3.5.4",
                 "dependencies": [
+                    "aopalliance:aopalliance:1.0",
                     "com.google.guava:guava:27.0.1-jre",
+                    "com.google.inject:guice:jar:no_aop:4.2.0",
+                    "commons-cli:commons-cli:1.4",
+                    "commons-io:commons-io:2.5",
                     "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
                     "org.apache.maven:maven-artifact:3.5.4",
                     "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:3.5.4",
+                    "org.apache.maven:maven-settings-builder:3.5.4",
+                    "org.apache.maven:maven-settings:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:1.24",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
+                    "org.slf4j:slf4j-api:1.7.25"
                 ],
                 "directDependencies": [
                     "com.google.guava:guava:27.0.1-jre",
+                    "com.google.inject:guice:jar:no_aop:4.2.0",
+                    "commons-cli:commons-cli:1.4",
                     "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
                     "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-model-builder:3.5.4",
                     "org.apache.maven:maven-model:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.apache.maven:maven-settings-builder:3.5.4",
+                    "org.apache.maven:maven-settings:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:1.24",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
+                    "org.slf4j:slf4j-api:1.7.25"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject",
+                    "org.sonatype.plexus:plexus-cipher",
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:jsr250-api",
+                    "org.sonatype.plexus:plexus-sec-dispatcher"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar"
                 ],
-                "sha256": "5dc10d69fd0a6e38f3ac3788bf1e63efd668af1fc23a08a2fdcffd85921d6f56",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar"
+                "sha256": "d9216ac3c62c5a478e0c6d723ab4efef3bd730b63f36a9a19572c56e5b8985a6",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
@@ -4545,22 +3855,37 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-model:3.5.4",
+                "coord": "org.apache.maven:maven-model-builder:3.5.4",
                 "dependencies": [
+                    "com.google.guava:guava:27.0.1-jre",
                     "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
+                    "com.google.guava:guava:27.0.1-jre",
                     "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "5ec1b94e9254c25480548633a48b7ae8a9ada7527e28f5c575943fe0c2ab7350",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar"
+                ],
+                "sha256": "5dc10d69fd0a6e38f3ac3788bf1e63efd668af1fc23a08a2fdcffd85921d6f56",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-model:jar:sources:3.5.4",
@@ -4585,36 +3910,22 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-plugin-api:3.5.4",
+                "coord": "org.apache.maven:maven-model:3.5.4",
                 "dependencies": [
-                    "javax.annotation:jsr250-api:1.0",
-                    "javax.enterprise:cdi-api:1.0",
                     "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
                 ],
-                "sha256": "6ef2f5977d400f636f86dafd2321bad6e230787321238e0bd206d553eb4d2406",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
+                "sha256": "5ec1b94e9254c25480548633a48b7ae8a9ada7527e28f5c575943fe0c2ab7350",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
@@ -4651,23 +3962,36 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-repository-metadata:3.5.4",
+                "coord": "org.apache.maven:maven-plugin-api:3.5.4",
                 "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "javax.annotation:jsr250-api:1.0",
+                    "javax.enterprise:cdi-api:1.0",
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
                 ],
                 "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
                 ],
                 "exclusions": [
                     "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
                 ],
-                "sha256": "159d4f7ebe63c0bbc81144c865ea4bf1bd0add710b5725964ac22bea3c53b803",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
+                "sha256": "6ef2f5977d400f636f86dafd2321bad6e230787321238e0bd206d553eb4d2406",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
@@ -4690,47 +4014,23 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-resolver-provider:3.5.4",
+                "coord": "org.apache.maven:maven-repository-metadata:3.5.4",
                 "dependencies": [
-                    "com.google.guava:guava:27.0.1-jre",
-                    "javax.inject:javax.inject:1",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven:maven-builder-support:3.5.4",
-                    "org.apache.maven:maven-model-builder:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:1.24",
                     "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
-                    "javax.inject:javax.inject:1",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                    "org.apache.maven:maven-model-builder:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:3.5.4",
                     "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
+                    "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
                 ],
-                "sha256": "3a5d15bf994da32621a3beabe76f8a611bf92b6a1e42a43d827ff5a3d94851c4",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar"
+                "sha256": "159d4f7ebe63c0bbc81144c865ea4bf1bd0add710b5725964ac22bea3c53b803",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
@@ -4776,6 +4076,78 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar"
             },
             {
+                "coord": "org.apache.maven:maven-resolver-provider:3.5.4",
+                "dependencies": [
+                    "com.google.guava:guava:27.0.1-jre",
+                    "javax.inject:javax.inject:1",
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                    "org.apache.maven:maven-builder-support:3.5.4",
+                    "org.apache.maven:maven-model-builder:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:1.24",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "javax.inject:javax.inject:1",
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                    "org.apache.maven:maven-model-builder:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:3.5.4",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar"
+                ],
+                "sha256": "3a5d15bf994da32621a3beabe76f8a611bf92b6a1e42a43d827ff5a3d94851c4",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar"
+            },
+            {
+                "coord": "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                "dependencies": [
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                ],
+                "directDependencies": [
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
+                ],
+                "sha256": "e08658d03c721221d76b5f5e7b0a7a1f0ba19a6788a83198600733f52cdcbd71",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
+            },
+            {
                 "coord": "org.apache.maven:maven-settings-builder:3.5.4",
                 "dependencies": [
                     "org.apache.commons:commons-lang3:3.9",
@@ -4808,33 +4180,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4.jar"
             },
             {
-                "coord": "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                "coord": "org.apache.maven:maven-settings:jar:sources:3.5.4",
                 "dependencies": [
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
                 "directDependencies": [
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
                 ],
-                "sha256": "e08658d03c721221d76b5f5e7b0a7a1f0ba19a6788a83198600733f52cdcbd71",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
+                "sha256": "0e27222242ee3e41763e8cdc3d1785b1bfc50f3cc842dfb3f00b45e463a4d4ff",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-settings:3.5.4",
@@ -4858,53 +4217,6 @@
                 ],
                 "sha256": "3b36d4653060d28574623c41634867597a303cb84288e441be2ec00935fe360e",
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
-                ],
-                "sha256": "0e27222242ee3e41763e8cdc3d1785b1bfc50f3cc842dfb3f00b45e463a4d4ff",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-toolchain:3.0-alpha-2",
-                "dependencies": [
-                    "com.google.code.google-collections:google-collect:snapshot-20080530",
-                    "junit:junit:3.8.2",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.apache.maven:maven-compat:3.0-alpha-2",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.xbean:xbean-reflect:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.apache.maven:maven-compat:3.0-alpha-2",
-                    "org.apache.maven:maven-core:3.5.4"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar"
-                ],
-                "sha256": "e0bb64267e6cd6e51d38cc88ba72e8a8adf616c2dc317782127cd61a8ae2a65c",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar"
             },
             {
                 "coord": "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
@@ -4938,20 +4250,692 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar"
             },
             {
-                "coord": "org.apache.xbean:xbean-reflect:3.4",
+                "coord": "org.apache.maven:maven-toolchain:3.0-alpha-2",
+                "dependencies": [
+                    "com.google.code.google-collections:google-collect:snapshot-20080530",
+                    "junit:junit:3.8.2",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.apache.maven:maven-compat:3.0-alpha-2",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.apache.xbean:xbean-reflect:3.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.apache.maven:maven-compat:3.0-alpha-2",
+                    "org.apache.maven:maven-core:3.5.4"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar"
+                ],
+                "sha256": "e0bb64267e6cd6e51d38cc88ba72e8a8adf616c2dc317782127cd61a8ae2a65c",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
                     "commons-logging:commons-logging-api",
                     "log4j:log4j"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
                 ],
-                "sha256": "17e0efa187127034623197fb88c50c30d3baa62baa0f07d6ec693047ac92ec3b",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
+                "sha256": "d6f618875c02e12f4b64e173c2a3897306694b0c4f613567907be2d0e906c7fa",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
+                ],
+                "sha256": "a4ce03467f0c47615c53533ad1682fe00b8170f760e7ed0c57f5afc3035fe38b",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
+                ],
+                "sha256": "bb8ecdb9ac7715873b0a316351adf96d31641647ef42f26feefd211177426756",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
+                ],
+                "sha256": "5efa36fa5e8f14be6013301fcba012aa8dc651fea886ab9f902a4122a7debb93",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
+                ],
+                "sha256": "6dd833726534cae3b0ba6ddae2b6899917b77ddd8cacd1dd0cda0d24755cd19d",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
+                ],
+                "sha256": "6c8adfb6415b46e31f399132e5d8d0faee3443b7493ba709746ce2614d2acf97",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
+                ],
+                "sha256": "4efe32a8c8517bace826a5d91fa2b65d8ca35d90f8ecb92981c1ad37806fe680",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
+                ],
+                "sha256": "8b686318f0675719afd6a97d6856d498ea554bd7da6522b6798d94d235e74c16",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
+                ],
+                "sha256": "6a0c64f62be47314bba1f0aa3dd49cb26f8debe730642bce2f2cb5f29fef8944",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
+                ],
+                "sha256": "c45247527daa9536f5fb31b3063dd456d41543d06490fec040fc37da5c88a4af",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
+                ],
+                "sha256": "db5556b7023f3c4dc8a26c6c0700defd9b9da64a9b8ae2b113b7bdf54adc4de8",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
+                ],
+                "sha256": "040e6bb13a34bc3fd721e9256784e996d2700a518476c6f9801c112699320208",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
+                "dependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
+                ],
+                "sha256": "ee55923f7ca080f751e49b0a9751c32c1d36068467a6bad7ccfe5db7719348ae",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
+                "dependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
+                ],
+                "sha256": "6f919f97c9272263fa910cfe7fa88595982a0451e7d7b121cca8ac85f6162882",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                "dependencies": [
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
+                ],
+                "sha256": "562a67e2888d6f70379d89f7c78b3226dd26c5b5e77c8554c6854f9001dc8d18",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                "dependencies": [
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
+                ],
+                "sha256": "b291bd2d46ecd42ba26938a78ec053eedb240e5a3eef3ffc82c46ecafa95c306",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
+                "dependencies": [
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
+                ],
+                "sha256": "94b766c063bf6345faa571ada4bd19fd4804ff2354ea6779d5894b3e37c7afa7",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-invoker:3.0.1",
+                "dependencies": [
+                    "commons-io:commons-io:2.5",
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
+                ],
+                "sha256": "d20e5d26c19c04199c73fd4f0b6caebf4bbdc6b872a4504c5e71a192751d9464",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                "dependencies": [
+                    "commons-io:commons-io:jar:sources:2.5"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:jar:sources:2.5"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
+                ],
+                "sha256": "25064c72c178a98335048d0f7c3e08839e949426bc92bf905ea964146235f388",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                "dependencies": [
+                    "commons-io:commons-io:2.5"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:2.5"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+                ],
+                "sha256": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
+                ],
+                "sha256": "4481a2ab7ceca66e57401d3d3528c095dac22dc7ce7e67124a19cc172da30d74",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-file:3.0.0",
+                "dependencies": [
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
+                ],
+                "sha256": "63324036899559f94154e6f845e62453a1f202c1b21b80060f2d88a05a05a272",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
+                ],
+                "sha256": "399e420f09b69e34b53897affd2723c06a133f6e9dbff68d74b3e55498c7a83a",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:1.9",
+                    "commons-io:commons-io:2.5",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:2.5",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
+                ],
+                "sha256": "40c51265b3ed90b6919c08dcdf3620dc614894ef60bacdf4c34bdbe295b44c49",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
+                ],
+                "sha256": "1b16a3eb55393e2c96184f0222d644675d5b439d0ed00ea4100bebbd8f8eaa22",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:1.9",
+                    "commons-io:commons-io:2.5",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
+                ],
+                "sha256": "9f68fed6684c2245a62d5d3c8b4954b882562797e96b15ce0f18514c543fb999",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
+                ],
+                "sha256": "c356c99bad5f0e8e99203e2e5b3c83ab5eafe0bd80e3346f7dfbe1fce94c9bb6",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
+                ],
+                "sha256": "04de4d2f39178998ef3ce5f6d91a358363ad3f5270e897d5547321ea69fa2992",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
             },
             {
                 "coord": "org.apache.xbean:xbean-reflect:jar:sources:3.4",
@@ -4970,16 +4954,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar"
             },
             {
-                "coord": "org.checkerframework:checker-qual:2.5.2",
+                "coord": "org.apache.xbean:xbean-reflect:3.4",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
-                    "https://repo.spring.io/plugins-release/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
                 ],
-                "sha256": "64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a",
-                "url": "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
+                ],
+                "sha256": "17e0efa187127034623197fb88c50c30d3baa62baa0f07d6ec693047ac92ec3b",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
             },
             {
                 "coord": "org.checkerframework:checker-qual:jar:sources:2.5.2",
@@ -4997,19 +4985,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
             },
             {
-                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+                "coord": "org.checkerframework:checker-qual:2.5.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                    "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
+                    "https://repo.spring.io/plugins-release/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
                 ],
-                "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                "sha256": "64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a",
+                "url": "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
             },
             {
                 "coord": "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
@@ -5024,19 +5009,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
                 ],
-                "sha256": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+                "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
@@ -5055,16 +5040,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2-sources.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                "coord": "org.codehaus.plexus:plexus-classworlds:2.5.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+                ],
+                "sha256": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
@@ -5079,32 +5067,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
-                "dependencies": [
-                    "com.google.code.google-collections:google-collect:snapshot-20080530",
-                    "junit:junit:3.8.2",
-                    "org.apache.xbean:xbean-reflect:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "com.google.code.google-collections:google-collect:snapshot-20080530",
-                    "junit:junit:3.8.2",
-                    "org.apache.xbean:xbean-reflect:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar",
+                "coord": "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
                 ],
-                "sha256": "00aa0be06a029e4b45032f682089d5052b014c028f9187f83c70adc073672c46",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar"
+                "sha256": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
@@ -5135,6 +5107,46 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar"
             },
             {
+                "coord": "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
+                "dependencies": [
+                    "com.google.code.google-collections:google-collect:snapshot-20080530",
+                    "junit:junit:3.8.2",
+                    "org.apache.xbean:xbean-reflect:3.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "com.google.code.google-collections:google-collect:snapshot-20080530",
+                    "junit:junit:3.8.2",
+                    "org.apache.xbean:xbean-reflect:3.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar"
+                ],
+                "sha256": "00aa0be06a029e4b45032f682089d5052b014c028f9187f83c70adc073672c46",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar"
+            },
+            {
+                "coord": "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
+                ],
+                "sha256": "0b372b91236c4a2c63dc0d6b2010e10c98b993fc8491f6a02b73052a218b6644",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
+            },
+            {
                 "coord": "org.codehaus.plexus:plexus-interpolation:1.24",
                 "dependencies": [],
                 "directDependencies": [],
@@ -5150,16 +5162,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                "coord": "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
                 ],
-                "sha256": "0b372b91236c4a2c63dc0d6b2010e10c98b993fc8491f6a02b73052a218b6644",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
+                "sha256": "06eb127e188a940ebbcf340c43c95537c3052298acdc943a9b2ec2146c7238d9",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-utils:3.1.0",
@@ -5175,38 +5187,6 @@
                 ],
                 "sha256": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
-            },
-            {
-                "coord": "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
-                ],
-                "sha256": "06eb127e188a940ebbcf340c43c95537c3052298acdc943a9b2ec2146c7238d9",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
-            },
-            {
-                "coord": "org.eclipse.microprofile.config:microprofile-config-api:1.3",
-                "dependencies": [
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0"
-                ],
-                "directDependencies": [
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0"
-                ],
-                "exclusions": [
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:javax.annotation-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar",
-                    "https://repo.spring.io/plugins-release/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar"
-                ],
-                "sha256": "6a1bf1548909e97d4866847cf8e96e2f30d15b959a68c95385daccba8abe3072",
-                "url": "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar"
             },
             {
                 "coord": "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
@@ -5229,6 +5209,41 @@
                 "url": "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar"
             },
             {
+                "coord": "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                "dependencies": [
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0"
+                ],
+                "directDependencies": [
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0"
+                ],
+                "exclusions": [
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:javax.annotation-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar",
+                    "https://repo.spring.io/plugins-release/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar"
+                ],
+                "sha256": "6a1bf1548909e97d4866847cf8e96e2f30d15b959a68c95385daccba8abe3072",
+                "url": "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar"
+            },
+            {
+                "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
+                ],
+                "sha256": "1f4d2575cb004f3fbd8e687c5dfa42d7478e1cf98e0cafa6e22dd1304cdfc6d7",
+                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
+            },
+            {
                 "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
                 "dependencies": [],
                 "directDependencies": [],
@@ -5248,19 +5263,32 @@
                 "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
             },
             {
-                "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                "dependencies": [
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
+                ],
+                "directDependencies": [
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
+                ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
                 ],
-                "sha256": "1f4d2575cb004f3fbd8e687c5dfa42d7478e1cf98e0cafa6e22dd1304cdfc6d7",
-                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
+                "sha256": "349dd64dca9d0007d7037862759fd8f74c7a0a5de29cfa1cec1ae2fb25eaa49b",
+                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
             },
             {
                 "coord": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
@@ -5294,32 +5322,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
             },
             {
-                "coord": "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                "dependencies": [
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
-                ],
-                "directDependencies": [
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
-                ],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
+                "coord": "org.freemarker:freemarker:jar:sources:2.3.28",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
                 ],
-                "sha256": "349dd64dca9d0007d7037862759fd8f74c7a0a5de29cfa1cec1ae2fb25eaa49b",
-                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
+                "sha256": "a855ab20a0b72d1a876f708e2c377f549d9b46527e7e5845cf3cd02dc906668d",
+                "url": "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
             },
             {
                 "coord": "org.freemarker:freemarker:2.3.28",
@@ -5334,16 +5346,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28.jar"
             },
             {
-                "coord": "org.freemarker:freemarker:jar:sources:2.3.28",
+                "coord": "org.glassfish:jakarta.json:jar:sources:1.1.6",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
                 ],
-                "sha256": "a855ab20a0b72d1a876f708e2c377f549d9b46527e7e5845cf3cd02dc906668d",
-                "url": "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
+                "sha256": "1580d5a07866922912eb2cbad8304180b84b5e4f7f47ae5303fcde4618c282fa",
+                "url": "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
             },
             {
                 "coord": "org.glassfish:jakarta.json:1.1.6",
@@ -5358,16 +5370,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6.jar"
             },
             {
-                "coord": "org.glassfish:jakarta.json:jar:sources:1.1.6",
+                "coord": "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
                 ],
-                "sha256": "1580d5a07866922912eb2cbad8304180b84b5e4f7f47ae5303fcde4618c282fa",
-                "url": "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
+                "sha256": "39d6c5ebbecd48c0918bdf5e1b674e5715078f6d72df319e85663dae0fbcacca",
+                "url": "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
             },
             {
                 "coord": "org.graalvm.sdk:graal-sdk:19.2.1",
@@ -5382,35 +5394,28 @@
                 "url": "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1.jar"
             },
             {
-                "coord": "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                "coord": "org.jboss:jandex:jar:sources:2.1.2.Final",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
                 ],
-                "sha256": "39d6c5ebbecd48c0918bdf5e1b674e5715078f6d72df319e85663dae0fbcacca",
-                "url": "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
+                "sha256": "80ce8274e5b5eeeb60f37bf2fd5504a6b509874588823a9301a25ee27a935292",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
             },
             {
-                "coord": "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final"
-                ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar",
+                "coord": "org.jboss:jandex:2.1.2.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
                 ],
-                "sha256": "f12176263ea25f4e78bb4fa4b36d335a29738dde6a8123e1b6da89a655d150ff",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar"
+                "sha256": "d7a90668526b56e5530e71c0d9d0426043cdc10c543d1c75f660eaff0af857b7",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
             },
             {
                 "coord": "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
@@ -5432,16 +5437,23 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar"
             },
             {
-                "coord": "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar"
+                "coord": "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final"
                 ],
-                "sha256": "b212f95613ad416ab2e75f2bb125f93f576cba95ec9b90aaf9a05e082a786a98",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar"
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar"
+                ],
+                "sha256": "f12176263ea25f4e78bb4fa4b36d335a29738dde6a8123e1b6da89a655d150ff",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar"
             },
             {
                 "coord": "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
@@ -5456,19 +5468,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar"
             },
             {
-                "coord": "org.jboss.logging:jboss-logging:3.4.0.Final",
+                "coord": "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar"
                 ],
-                "sha256": "5974492fbbecae31e38f8a8a86c91756303f36b3ce6d6743350a0ce41c76f3d3",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar"
+                "sha256": "b212f95613ad416ab2e75f2bb125f93f576cba95ec9b90aaf9a05e082a786a98",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar"
             },
             {
                 "coord": "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
@@ -5486,25 +5495,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar"
             },
             {
-                "coord": "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                "dependencies": [
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
+                "coord": "org.jboss.logging:jboss-logging:3.4.0.Final",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "com.oracle.substratevm:svm",
-                    "org.jboss.modules:jboss-modules",
-                    "org.glassfish:javax.json"
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar"
                 ],
-                "sha256": "3fbd749c53a1d028e49803378c5c6e408eef497891ec220fb7e98526efad8d8b",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar"
+                "sha256": "5974492fbbecae31e38f8a8a86c91756303f36b3ce6d6743350a0ce41c76f3d3",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar"
             },
             {
                 "coord": "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
@@ -5528,22 +5531,25 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar"
             },
             {
-                "coord": "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                "coord": "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
                 "dependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.slf4j:slf4j-api:1.7.25"
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.slf4j:slf4j-api:1.7.25"
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar",
+                "exclusions": [
+                    "com.oracle.substratevm:svm",
+                    "org.jboss.modules:jboss-modules",
+                    "org.glassfish:javax.json"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar"
                 ],
-                "sha256": "15c573e27ee617c996a423da7ce75560a43663155a81158701342baca2faa0da",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar"
+                "sha256": "3fbd749c53a1d028e49803378c5c6e408eef497891ec220fb7e98526efad8d8b",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar"
             },
             {
                 "coord": "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
@@ -5564,20 +5570,22 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar"
             },
             {
-                "coord": "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
+                "coord": "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.slf4j:slf4j-api:1.7.25"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar",
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar"
                 ],
-                "sha256": "76b19995ff0f56f884d7ae58a0b0e6d9663e4bcac6a6b1f4d56c25493ab0c606",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar"
+                "sha256": "15c573e27ee617c996a423da7ce75560a43663155a81158701342baca2faa0da",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar"
             },
             {
                 "coord": "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
@@ -5596,22 +5604,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar"
             },
             {
-                "coord": "org.jboss.threads:jboss-threads:3.0.0.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                "coord": "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar"
                 ],
-                "sha256": "9c4d89e412ca771222ff4fff93f2428eaa1f7296f70988537fc09968f7f61776",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar"
+                "sha256": "76b19995ff0f56f884d7ae58a0b0e6d9663e4bcac6a6b1f4d56c25493ab0c606",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar"
             },
             {
                 "coord": "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
@@ -5632,40 +5638,22 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar"
             },
             {
-                "coord": "org.jboss:jandex:2.1.2.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
+                "coord": "org.jboss.threads:jboss-threads:3.0.0.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
-                "sha256": "d7a90668526b56e5530e71c0d9d0426043cdc10c543d1c75f660eaff0af857b7",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
-            },
-            {
-                "coord": "org.jboss:jandex:jar:sources:2.1.2.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
                 ],
-                "sha256": "80ce8274e5b5eeeb60f37bf2fd5504a6b509874588823a9301a25ee27a935292",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
-            },
-            {
-                "coord": "org.json:json:20190722",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar",
-                    "https://repo.spring.io/plugins-release/org/json/json/20190722/json-20190722.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar"
                 ],
-                "sha256": "e35b3830de02a8992ca8beb6936f52ee80e509753d64469c8f0dde93e17a880b",
-                "url": "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar"
+                "sha256": "9c4d89e412ca771222ff4fff93f2428eaa1f7296f70988537fc09968f7f61776",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar"
             },
             {
                 "coord": "org.json:json:jar:sources:20190722",
@@ -5680,20 +5668,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar"
             },
             {
-                "coord": "org.jsoup:jsoup:1.7.2",
+                "coord": "org.json:json:20190722",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar",
-                    "https://repo.spring.io/plugins-release/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar"
+                    "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar",
+                    "https://repo.spring.io/plugins-release/org/json/json/20190722/json-20190722.jar"
                 ],
-                "sha256": "bdd2f2b281dae829915fbd1802c09269f7f5add5a886242eaa0d1ae362d329cc",
-                "url": "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar"
+                "sha256": "e35b3830de02a8992ca8beb6936f52ee80e509753d64469c8f0dde93e17a880b",
+                "url": "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar"
             },
             {
                 "coord": "org.jsoup:jsoup:jar:sources:1.7.2",
@@ -5712,20 +5696,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar"
             },
             {
-                "coord": "org.osgi:org.osgi.annotation.versioning:1.0.0",
+                "coord": "org.jsoup:jsoup:1.7.2",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:javax.annotation-api"
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar"
+                    "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar",
+                    "https://repo.spring.io/plugins-release/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar"
                 ],
-                "sha256": "b299b3ca50b3a57504e131fddd34d5f3e10a581a6c81e74b6d8fba81c6e055a7",
-                "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar"
+                "sha256": "bdd2f2b281dae829915fbd1802c09269f7f5add5a886242eaa0d1ae362d329cc",
+                "url": "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar"
             },
             {
                 "coord": "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
@@ -5744,21 +5728,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar"
             },
             {
-                "coord": "org.ow2.asm:asm-analysis:7.1",
-                "dependencies": [
-                    "org.ow2.asm:asm-tree:7.1",
-                    "org.ow2.asm:asm:7.1"
+                "coord": "org.osgi:org.osgi.annotation.versioning:1.0.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:javax.annotation-api"
                 ],
-                "directDependencies": [
-                    "org.ow2.asm:asm-tree:7.1"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar"
+                    "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar"
                 ],
-                "sha256": "4612c0511a63db2a2570f07ad1959e19ed8eb703e4114da945cb85682519a55c",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar"
+                "sha256": "b299b3ca50b3a57504e131fddd34d5f3e10a581a6c81e74b6d8fba81c6e055a7",
+                "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-analysis:jar:sources:7.1",
@@ -5778,20 +5761,21 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar"
             },
             {
-                "coord": "org.ow2.asm:asm-tree:7.1",
+                "coord": "org.ow2.asm:asm-analysis:7.1",
                 "dependencies": [
+                    "org.ow2.asm:asm-tree:7.1",
                     "org.ow2.asm:asm:7.1"
                 ],
                 "directDependencies": [
-                    "org.ow2.asm:asm:7.1"
+                    "org.ow2.asm:asm-tree:7.1"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar"
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar"
                 ],
-                "sha256": "c0e82b220b0a52c71c7ca2a58c99a2530696c7b58b173052b9d48fe3efb10073",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar"
+                "sha256": "4612c0511a63db2a2570f07ad1959e19ed8eb703e4114da945cb85682519a55c",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-tree:jar:sources:7.1",
@@ -5810,24 +5794,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar"
             },
             {
-                "coord": "org.ow2.asm:asm-util:7.1",
+                "coord": "org.ow2.asm:asm-tree:7.1",
                 "dependencies": [
-                    "org.ow2.asm:asm-analysis:7.1",
-                    "org.ow2.asm:asm-tree:7.1",
                     "org.ow2.asm:asm:7.1"
                 ],
                 "directDependencies": [
-                    "org.ow2.asm:asm-analysis:7.1",
-                    "org.ow2.asm:asm-tree:7.1",
                     "org.ow2.asm:asm:7.1"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar"
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar"
                 ],
-                "sha256": "a24485517596ae1003dcf2329c044a2a861e5c25d4476a695ccaacf560c74d1a",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar"
+                "sha256": "c0e82b220b0a52c71c7ca2a58c99a2530696c7b58b173052b9d48fe3efb10073",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-util:jar:sources:7.1",
@@ -5850,16 +5830,24 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar"
             },
             {
-                "coord": "org.ow2.asm:asm:7.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm/7.1/asm-7.1.jar"
+                "coord": "org.ow2.asm:asm-util:7.1",
+                "dependencies": [
+                    "org.ow2.asm:asm-analysis:7.1",
+                    "org.ow2.asm:asm-tree:7.1",
+                    "org.ow2.asm:asm:7.1"
                 ],
-                "sha256": "4ab2fa2b6d2cc9ccb1eaa05ea329c407b47b13ed2915f62f8c4b8cc96258d4de",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar"
+                "directDependencies": [
+                    "org.ow2.asm:asm-analysis:7.1",
+                    "org.ow2.asm:asm-tree:7.1",
+                    "org.ow2.asm:asm:7.1"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar"
+                ],
+                "sha256": "a24485517596ae1003dcf2329c044a2a861e5c25d4476a695ccaacf560c74d1a",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar"
             },
             {
                 "coord": "org.ow2.asm:asm:jar:sources:7.1",
@@ -5874,19 +5862,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar"
             },
             {
-                "coord": "org.slf4j:slf4j-api:1.7.25",
+                "coord": "org.ow2.asm:asm:7.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
-                    "https://repo.spring.io/plugins-release/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm/7.1/asm-7.1.jar"
                 ],
-                "sha256": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
-                "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+                "sha256": "4ab2fa2b6d2cc9ccb1eaa05ea329c407b47b13ed2915f62f8c4b8cc96258d4de",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar"
             },
             {
                 "coord": "org.slf4j:slf4j-api:jar:sources:1.7.25",
@@ -5904,19 +5889,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
             },
             {
-                "coord": "org.sonatype.plexus:plexus-cipher:1.4",
+                "coord": "org.slf4j:slf4j-api:1.7.25",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+                    "https://repo.spring.io/plugins-release/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
                 ],
-                "sha256": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+                "sha256": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
+                "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
             },
             {
                 "coord": "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
@@ -5934,25 +5919,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar"
             },
             {
-                "coord": "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.sonatype.plexus:plexus-cipher:1.4"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.sonatype.plexus:plexus-cipher:1.4"
-                ],
+                "coord": "org.sonatype.plexus:plexus-cipher:1.4",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
                     "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
                 ],
-                "sha256": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+                "sha256": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
             },
             {
                 "coord": "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
@@ -5974,6 +5953,27 @@
                 ],
                 "sha256": "2e5de23342c1f130b0244149dee6aaae7f2d4f5ff668e329265cea08830d39c2",
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar"
+            },
+            {
+                "coord": "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.sonatype.plexus:plexus-cipher:1.4"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.sonatype.plexus:plexus-cipher:1.4"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+                ],
+                "sha256": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
             },
             {
                 "coord": "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
@@ -6018,29 +6018,6 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-sources.jar"
             },
             {
-                "coord": "org.sonatype.sisu:sisu-inject-bean:1.4.2",
-                "dependencies": [
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7"
-                ],
-                "directDependencies": [
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
-                ],
-                "sha256": "fb3160e1e3a7852b441016dbcc97a34e3cf4eeb8ceb9e82edf2729439858f080",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
-            },
-            {
                 "coord": "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
                 "dependencies": [
                     "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7"
@@ -6064,17 +6041,12 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar"
             },
             {
-                "coord": "org.sonatype.sisu:sisu-inject-plexus:1.4.2",
+                "coord": "org.sonatype.sisu:sisu-inject-bean:1.4.2",
                 "dependencies": [
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2"
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7"
                 ],
                 "directDependencies": [
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2"
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7"
                 ],
                 "exclusions": [
                     "org.apache.maven:maven-artifact",
@@ -6083,13 +6055,13 @@
                     "org.apache.maven.shared:maven-shared-utils",
                     "org.apache.maven:maven-model"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
+                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
                 ],
-                "sha256": "a65e27aefbe74102d73cd7e3c5c7637021d294a9e7f33132f3c782a76714d0a3",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
+                "sha256": "fb3160e1e3a7852b441016dbcc97a34e3cf4eeb8ceb9e82edf2729439858f080",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
             },
             {
                 "coord": "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2",
@@ -6120,31 +6092,32 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar"
             },
             {
-                "coord": "org.twdata.maven:mojo-executor:2.3.0",
+                "coord": "org.sonatype.sisu:sisu-inject-plexus:1.4.2",
                 "dependencies": [
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.slf4j:slf4j-api:1.7.25"
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                     "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.slf4j:slf4j-api:1.7.25"
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar",
-                    "https://repo.spring.io/plugins-release/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar"
+                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
                 ],
-                "sha256": "470b5e9e505f99f81ff3a75593bfe03f6d32ea52a167df1ba66cee833c8c08ce",
-                "url": "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar"
+                "sha256": "a65e27aefbe74102d73cd7e3c5c7637021d294a9e7f33132f3c782a76714d0a3",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
             },
             {
                 "coord": "org.twdata.maven:mojo-executor:jar:sources:2.3.0",
@@ -6174,16 +6147,31 @@
                 "url": "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar"
             },
             {
-                "coord": "org.wildfly.common:wildfly-common:1.5.0.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar"
+                "coord": "org.twdata.maven:mojo-executor:2.3.0",
+                "dependencies": [
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.slf4j:slf4j-api:1.7.25"
                 ],
-                "sha256": "3f4f72fbdcee33611e0535eeb53ecded9e0c4e374ac06cc2ff2f012c642af6a9",
-                "url": "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar"
+                "directDependencies": [
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar",
+                    "https://repo.spring.io/plugins-release/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar"
+                ],
+                "sha256": "470b5e9e505f99f81ff3a75593bfe03f6d32ea52a167df1ba66cee833c8c08ce",
+                "url": "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar"
             },
             {
                 "coord": "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final",
@@ -6196,6 +6184,18 @@
                 ],
                 "sha256": "7cef50710671842c76999e0a974aeeb7e4568a686640893e77ad6b5eba324eef",
                 "url": "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar"
+            },
+            {
+                "coord": "org.wildfly.common:wildfly-common:1.5.0.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar"
+                ],
+                "sha256": "3f4f72fbdcee33611e0535eeb53ecded9e0c4e374ac06cc2ff2f012c642af6a9",
+                "url": "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar"
             },
             {
                 "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",

--- a/tests/custom_maven_install/policy_pinned_testing_install.json
+++ b/tests/custom_maven_install/policy_pinned_testing_install.json
@@ -40,42 +40,6 @@
                 "url": "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/1.27.0/google-api-client-1.27.0.jar"
             },
             {
-                "coord": "com.google.api.grpc:proto-google-common-protos:1.14.0",
-                "dependencies": [
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "directDependencies": [
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
-                    "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
-                ],
-                "sha256": "d94b529c39f94765fdb81f1835ee9c006de2707c0ef4a49445999d00cb99eec2",
-                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
-            },
-            {
-                "coord": "com.google.api.grpc:proto-google-iam-v1:0.12.0",
-                "dependencies": [
-                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
-                    "com.google.api:api-common:1.7.0",
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "directDependencies": [
-                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
-                    "com.google.api:api-common:1.7.0",
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
-                    "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
-                ],
-                "sha256": "ddabb48fe072ada50484c98f00893a3e1356b4f05d2d0bf0045bc830145d1e0c",
-                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
-            },
-            {
                 "coord": "com.google.api:api-common:1.7.0",
                 "dependencies": [
                     "com.google.code.findbugs:jsr305:3.0.2",
@@ -163,6 +127,42 @@
                 ],
                 "sha256": "9c8540678f209092191e19c59b6ca3092bd75b782f30823bdadf5567e2a1515a",
                 "url": "https://repo1.maven.org/maven2/com/google/api/gax/1.42.0/gax-1.42.0.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                "dependencies": [
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
+                    "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
+                ],
+                "sha256": "d94b529c39f94765fdb81f1835ee9c006de2707c0ef4a49445999d00cb99eec2",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-iam-v1:0.12.0",
+                "dependencies": [
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                    "com.google.api:api-common:1.7.0",
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "directDependencies": [
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                    "com.google.api:api-common:1.7.0",
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
+                    "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
+                ],
+                "sha256": "ddabb48fe072ada50484c98f00893a3e1356b4f05d2d0bf0045bc830145d1e0c",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
             },
             {
                 "coord": "com.google.apis:google-api-services-storage:v1-rev20181109-1.27.0",

--- a/tests/custom_maven_install/regression_testing_install.json
+++ b/tests/custom_maven_install/regression_testing_install.json
@@ -142,51 +142,6 @@
                 "url": "https://maven.google.com/android/arch/lifecycle/viewmodel/1.1.1/viewmodel-1.1.1.aar"
             },
             {
-                "coord": "ch.epfl.scala:compiler-interface:1.3.0-M4+20-c8a2f9bd",
-                "dependencies": [
-                    "com.google.protobuf:protobuf-java:3.7.0",
-                    "org.scala-sbt:util-interface:1.3.0-M4"
-                ],
-                "directDependencies": [
-                    "com.google.protobuf:protobuf-java:3.7.0",
-                    "org.scala-sbt:util-interface:1.3.0-M4"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
-                    "https://maven.google.com/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
-                    "https://packages.confluent.io/maven/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
-                ],
-                "sha256": "b5080bbfd4dc2beef489e4a7153b1b6099724ae7860b720e64d2b3b3b96570a5",
-                "url": "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
-            },
-            {
-                "coord": "com.101tec:zkclient:0.11",
-                "dependencies": [
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "exclusions": [
-                    "*:jline",
-                    "*:jmxtools",
-                    "*:jms",
-                    "*:mail",
-                    "*:javax",
-                    "*:jmxri",
-                    "*:zookeeper"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
-                    "https://maven.google.com/com/101tec/zkclient/0.11/zkclient-0.11.jar",
-                    "https://packages.confluent.io/maven/com/101tec/zkclient/0.11/zkclient-0.11.jar"
-                ],
-                "sha256": "72e05e5031508115cafa6092cd53af306c5584957a34012511a20aac5e6c45e5",
-                "url": "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar"
-            },
-            {
                 "coord": "com.android.support:animated-vector-drawable:aar:28.0.0",
                 "dependencies": [
                     "android.arch.core:common:1.1.1",
@@ -854,6 +809,340 @@
                 "url": "https://maven.google.com/com/android/support/viewpager/28.0.0/viewpager-28.0.0.aar"
             },
             {
+                "coord": "com.google.android.gms:play-services-base:16.1.0",
+                "dependencies": [
+                    "com.android.support:support-annotations:28.0.0",
+                    "com.android.support:support-compat:28.0.0",
+                    "com.android.support:support-core-ui:28.0.0",
+                    "com.android.support:support-core-utils:28.0.0",
+                    "com.android.support:support-fragment:28.0.0",
+                    "com.android.support:support-media-compat:26.1.0",
+                    "com.android.support:support-v4:aar:26.1.0",
+                    "com.google.android.gms:play-services-basement:aar:16.2.0",
+                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
+                ],
+                "directDependencies": [
+                    "com.google.android.gms:play-services-basement:aar:16.2.0",
+                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
+                ],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
+                    "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
+                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
+                ],
+                "sha256": "3a543b05dfa09ca84fb47ed5e166ec7fbd7715ce630bbde44c10ffa5fb81daa4",
+                "url": "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
+            },
+            {
+                "coord": "com.google.android.gms:play-services-basement:aar:16.2.0",
+                "dependencies": [
+                    "com.android.support:support-annotations:28.0.0",
+                    "com.android.support:support-compat:28.0.0",
+                    "com.android.support:support-core-ui:28.0.0",
+                    "com.android.support:support-core-utils:28.0.0",
+                    "com.android.support:support-fragment:28.0.0",
+                    "com.android.support:support-media-compat:26.1.0",
+                    "com.android.support:support-v4:aar:26.1.0"
+                ],
+                "directDependencies": [
+                    "com.android.support:support-v4:aar:26.1.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
+                    "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
+                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
+                ],
+                "sha256": "5ccead5a05a632f93df0a807752a034adcd0cd62fcf30da287c6dd5b05bd3d5a",
+                "url": "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
+            },
+            {
+                "coord": "com.google.android.gms:play-services-tasks:aar:16.0.1",
+                "dependencies": [
+                    "com.google.android.gms:play-services-basement:aar:16.2.0"
+                ],
+                "directDependencies": [
+                    "com.google.android.gms:play-services-basement:aar:16.2.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
+                    "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
+                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
+                ],
+                "sha256": "b31c18d8d1cc8d9814f295ee7435471333f370ba5bd904ca14f8f2bec4f35c35",
+                "url": "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
+            },
+            {
+                "coord": "com.google.ar:core:aar:1.10.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/core/1.10.0/core-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/core/1.10.0/core-1.10.0.aar"
+                ],
+                "sha256": "6624df5075cb9db0887abd6c84eb0889d1d7ba11bfd930b4e06a56eaffab820a",
+                "url": "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:core:aar:1.10.0",
+                "dependencies": [
+                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                    "com.google.ar.sceneform:rendering:aar:1.10.0",
+                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "directDependencies": [
+                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                    "com.google.ar.sceneform:rendering:aar:1.10.0",
+                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
+                ],
+                "sha256": "0652b7feb93b5c19ab314b79977aa739ec58c48a1bd727a4f8c31e61fe105e09",
+                "url": "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
+                ],
+                "sha256": "24751cbda2bfa49d5ab0d53f36efa7ac4f0b1ba6c7356c8bf418cb5a61dd067f",
+                "url": "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:rendering:aar:1.10.0",
+                "dependencies": [
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "directDependencies": [
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
+                ],
+                "sha256": "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
+                "url": "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
+                ],
+                "sha256": "fe2191f8a0b622bf35c91cdbe83074ff025f1641b6fe25ea0b554f208a62daff",
+                "url": "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform.ux:sceneform-ux:1.10.0",
+                "dependencies": [
+                    "com.android.support:support-fragment:aar:28.0.0",
+                    "com.google.ar.sceneform:core:aar:1.10.0",
+                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                    "com.google.ar.sceneform:rendering:aar:1.10.0",
+                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "directDependencies": [
+                    "com.android.support:support-fragment:aar:28.0.0",
+                    "com.google.ar.sceneform:core:aar:1.10.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
+                ],
+                "sha256": "f37d622f5f44facf953e23bcc01175c4f2df5f7234f71cd8855ca669d7c179fc",
+                "url": "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
+            },
+            {
+                "coord": "io.confluent:common-config:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "io.confluent:common-utils:5.0.1",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
+                ],
+                "sha256": "d4375cdff2296888f598af6764697dc6215ceb61c023eeb0c7d5ab60583122ed",
+                "url": "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
+            },
+            {
+                "coord": "io.confluent:common-utils:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
+                ],
+                "sha256": "fec75e2c7da2db6f4a1b2d288576b96cb72fa06029bcf5adfd444573e57f2a7f",
+                "url": "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
+            },
+            {
+                "coord": "io.confluent:kafka-avro-serializer:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:2.7",
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.confluent:kafka-schema-registry-client:5.0.1",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.avro:avro:1.8.1",
+                    "org.apache.commons:commons-compress:1.18",
+                    "org.apache.kafka:kafka-clients:2.1.1",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
+                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.tukaani:xz:1.5",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "directDependencies": [
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.confluent:kafka-schema-registry-client:5.0.1",
+                    "org.apache.avro:avro:1.8.1"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
+                ],
+                "sha256": "2372bb93a753ce754d0c10514cf4c61501e2c3d8960873541f72377689cb1a48",
+                "url": "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
+            },
+            {
+                "coord": "io.confluent:kafka-schema-registry-client:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:2.7",
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.avro:avro:1.8.1",
+                    "org.apache.commons:commons-compress:1.18",
+                    "org.apache.kafka:kafka-clients:2.1.1",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
+                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.tukaani:xz:1.5",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "org.apache.avro:avro:1.8.1",
+                    "org.apache.kafka:kafka-clients:2.1.1"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
+                ],
+                "sha256": "74111b8c628d5f6fe55569f49af12ea094942a7f17192011795180b970110f8c",
+                "url": "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
+            },
+            {
+                "coord": "ch.epfl.scala:compiler-interface:1.3.0-M4+20-c8a2f9bd",
+                "dependencies": [
+                    "com.google.protobuf:protobuf-java:3.7.0",
+                    "org.scala-sbt:util-interface:1.3.0-M4"
+                ],
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:3.7.0",
+                    "org.scala-sbt:util-interface:1.3.0-M4"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
+                    "https://maven.google.com/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
+                    "https://packages.confluent.io/maven/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
+                ],
+                "sha256": "b5080bbfd4dc2beef489e4a7153b1b6099724ae7860b720e64d2b3b3b96570a5",
+                "url": "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
+            },
+            {
+                "coord": "com.101tec:zkclient:0.11",
+                "dependencies": [
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "*:jline",
+                    "*:jmxtools",
+                    "*:jms",
+                    "*:mail",
+                    "*:javax",
+                    "*:jmxri",
+                    "*:zookeeper"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
+                    "https://maven.google.com/com/101tec/zkclient/0.11/zkclient-0.11.jar",
+                    "https://packages.confluent.io/maven/com/101tec/zkclient/0.11/zkclient-0.11.jar"
+                ],
+                "sha256": "72e05e5031508115cafa6092cd53af306c5584957a34012511a20aac5e6c45e5",
+                "url": "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar"
+            },
+            {
                 "coord": "com.esotericsoftware.kryo:kryo:2.24.0",
                 "dependencies": [
                     "com.esotericsoftware.minlog:minlog:1.2",
@@ -953,6 +1242,19 @@
                 ],
                 "sha256": "2351c3eba73a545db9079f5d6d768347ad72666537362c8220fe3e950a55a864",
                 "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.8/jackson-databind-2.9.8.jar"
+            },
+            {
+                "coord": "com.github.fommil:jniloader:1.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
+                    "https://maven.google.com/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
+                    "https://packages.confluent.io/maven/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
+                ],
+                "sha256": "2f1def54f30e1db5f1e7f2fd600fe2ab331bd6b52037e9a21505c237020b5573",
+                "url": "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
             },
             {
                 "coord": "com.github.fommil.netlib:core:1.1.2",
@@ -1266,19 +1568,6 @@
                 "url": "https://repo1.maven.org/maven2/com/github/fommil/netlib/netlib-native_system-win-x86_64/1.1/netlib-native_system-win-x86_64-1.1-natives.jar"
             },
             {
-                "coord": "com.github.fommil:jniloader:1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
-                    "https://maven.google.com/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
-                    "https://packages.confluent.io/maven/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
-                ],
-                "sha256": "2f1def54f30e1db5f1e7f2fd600fe2ab331bd6b52037e9a21505c237020b5573",
-                "url": "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
-            },
-            {
                 "coord": "com.github.luben:zstd-jni:1.3.7-1",
                 "dependencies": [],
                 "directDependencies": [],
@@ -1457,173 +1746,6 @@
                 ],
                 "sha256": "4fccff8382aafc589962c4edb262f6aa595e34f1e11e61057d1c6a96e8fc7323",
                 "url": "https://repo1.maven.org/maven2/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1.jar"
-            },
-            {
-                "coord": "com.google.android.gms:play-services-base:16.1.0",
-                "dependencies": [
-                    "com.android.support:support-annotations:28.0.0",
-                    "com.android.support:support-compat:28.0.0",
-                    "com.android.support:support-core-ui:28.0.0",
-                    "com.android.support:support-core-utils:28.0.0",
-                    "com.android.support:support-fragment:28.0.0",
-                    "com.android.support:support-media-compat:26.1.0",
-                    "com.android.support:support-v4:aar:26.1.0",
-                    "com.google.android.gms:play-services-basement:aar:16.2.0",
-                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
-                ],
-                "directDependencies": [
-                    "com.google.android.gms:play-services-basement:aar:16.2.0",
-                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
-                ],
-                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
-                    "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
-                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
-                ],
-                "sha256": "3a543b05dfa09ca84fb47ed5e166ec7fbd7715ce630bbde44c10ffa5fb81daa4",
-                "url": "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
-            },
-            {
-                "coord": "com.google.android.gms:play-services-basement:aar:16.2.0",
-                "dependencies": [
-                    "com.android.support:support-annotations:28.0.0",
-                    "com.android.support:support-compat:28.0.0",
-                    "com.android.support:support-core-ui:28.0.0",
-                    "com.android.support:support-core-utils:28.0.0",
-                    "com.android.support:support-fragment:28.0.0",
-                    "com.android.support:support-media-compat:26.1.0",
-                    "com.android.support:support-v4:aar:26.1.0"
-                ],
-                "directDependencies": [
-                    "com.android.support:support-v4:aar:26.1.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
-                    "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
-                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
-                ],
-                "sha256": "5ccead5a05a632f93df0a807752a034adcd0cd62fcf30da287c6dd5b05bd3d5a",
-                "url": "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
-            },
-            {
-                "coord": "com.google.android.gms:play-services-tasks:aar:16.0.1",
-                "dependencies": [
-                    "com.google.android.gms:play-services-basement:aar:16.2.0"
-                ],
-                "directDependencies": [
-                    "com.google.android.gms:play-services-basement:aar:16.2.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
-                    "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
-                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
-                ],
-                "sha256": "b31c18d8d1cc8d9814f295ee7435471333f370ba5bd904ca14f8f2bec4f35c35",
-                "url": "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform.ux:sceneform-ux:1.10.0",
-                "dependencies": [
-                    "com.android.support:support-fragment:aar:28.0.0",
-                    "com.google.ar.sceneform:core:aar:1.10.0",
-                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                    "com.google.ar.sceneform:rendering:aar:1.10.0",
-                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "directDependencies": [
-                    "com.android.support:support-fragment:aar:28.0.0",
-                    "com.google.ar.sceneform:core:aar:1.10.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
-                ],
-                "sha256": "f37d622f5f44facf953e23bcc01175c4f2df5f7234f71cd8855ca669d7c179fc",
-                "url": "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:core:aar:1.10.0",
-                "dependencies": [
-                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                    "com.google.ar.sceneform:rendering:aar:1.10.0",
-                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "directDependencies": [
-                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                    "com.google.ar.sceneform:rendering:aar:1.10.0",
-                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
-                ],
-                "sha256": "0652b7feb93b5c19ab314b79977aa739ec58c48a1bd727a4f8c31e61fe105e09",
-                "url": "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
-                ],
-                "sha256": "24751cbda2bfa49d5ab0d53f36efa7ac4f0b1ba6c7356c8bf418cb5a61dd067f",
-                "url": "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:rendering:aar:1.10.0",
-                "dependencies": [
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "directDependencies": [
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
-                ],
-                "sha256": "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
-                "url": "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
-                ],
-                "sha256": "fe2191f8a0b622bf35c91cdbe83074ff025f1641b6fe25ea0b554f208a62daff",
-                "url": "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar:core:aar:1.10.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/core/1.10.0/core-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/core/1.10.0/core-1.10.0.aar"
-                ],
-                "sha256": "6624df5075cb9db0887abd6c84eb0889d1d7ba11bfd930b4e06a56eaffab820a",
-                "url": "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar"
             },
             {
                 "coord": "com.google.code.findbugs:jsr305:3.0.2",
@@ -1871,6 +1993,19 @@
                 "url": "https://repo1.maven.org/maven2/com/nimbusds/oauth2-oidc-sdk/5.24.1/oauth2-oidc-sdk-5.24.1.jar"
             },
             {
+                "coord": "com.squareup:javapoet:1.11.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
+                    "https://maven.google.com/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
+                    "https://packages.confluent.io/maven/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
+                ],
+                "sha256": "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90",
+                "url": "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
+            },
+            {
                 "coord": "com.squareup.okhttp:logging-interceptor:2.7.5",
                 "dependencies": [
                     "com.squareup.okhttp:okhttp:2.7.5",
@@ -1935,19 +2070,6 @@
                 ],
                 "sha256": "114bdc1f47338a68bcbc95abf2f5cdc72beeec91812f2fcd7b521c1937876266",
                 "url": "https://repo1.maven.org/maven2/com/squareup/okio/okio/1.6.0/okio-1.6.0.jar"
-            },
-            {
-                "coord": "com.squareup:javapoet:1.11.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
-                    "https://maven.google.com/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
-                    "https://packages.confluent.io/maven/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
-                ],
-                "sha256": "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90",
-                "url": "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
             },
             {
                 "coord": "com.thoughtworks.paranamer:paranamer:2.7",
@@ -2090,6 +2212,22 @@
                 "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.12/2.4.20/akka-stream_2.12-2.4.20.jar"
             },
             {
+                "coord": "com.typesafe:config:1.3.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.scala-lang:scala-library"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
+                    "https://maven.google.com/com/typesafe/config/1.3.0/config-1.3.0.jar",
+                    "https://packages.confluent.io/maven/com/typesafe/config/1.3.0/config-1.3.0.jar"
+                ],
+                "sha256": "d3e9dca258786c51fcbcc47d34d3b44158476af55c47d22dd8c2e38e41a2c89a",
+                "url": "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar"
+            },
+            {
                 "coord": "com.typesafe.scala-logging:scala-logging_2.11:3.9.0",
                 "dependencies": [
                     "org.scala-lang:scala-library:2.11.12",
@@ -2117,22 +2255,6 @@
                 ],
                 "sha256": "6f58222c736833066894f51de21fdac840e573a545e776dafff670b673ed52e4",
                 "url": "https://repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.11/3.9.0/scala-logging_2.11-3.9.0.jar"
-            },
-            {
-                "coord": "com.typesafe:config:1.3.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.scala-lang:scala-library"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
-                    "https://maven.google.com/com/typesafe/config/1.3.0/config-1.3.0.jar",
-                    "https://packages.confluent.io/maven/com/typesafe/config/1.3.0/config-1.3.0.jar"
-                ],
-                "sha256": "d3e9dca258786c51fcbcc47d34d3b44158476af55c47d22dd8c2e38e41a2c89a",
-                "url": "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar"
             },
             {
                 "coord": "com.typesafe:ssl-config-core_2.12:0.2.1",
@@ -2231,128 +2353,6 @@
                 ],
                 "sha256": "cc6a41dc3eaacc9e440a6bd0d2890b20d36b4ee408fe2d67122f328bb6e01581",
                 "url": "https://repo1.maven.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.jar"
-            },
-            {
-                "coord": "io.confluent:common-config:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "io.confluent:common-utils:5.0.1",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
-                ],
-                "sha256": "d4375cdff2296888f598af6764697dc6215ceb61c023eeb0c7d5ab60583122ed",
-                "url": "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
-            },
-            {
-                "coord": "io.confluent:common-utils:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
-                ],
-                "sha256": "fec75e2c7da2db6f4a1b2d288576b96cb72fa06029bcf5adfd444573e57f2a7f",
-                "url": "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
-            },
-            {
-                "coord": "io.confluent:kafka-avro-serializer:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "com.thoughtworks.paranamer:paranamer:2.7",
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.confluent:kafka-schema-registry-client:5.0.1",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.avro:avro:1.8.1",
-                    "org.apache.commons:commons-compress:1.18",
-                    "org.apache.kafka:kafka-clients:2.1.1",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
-                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.tukaani:xz:1.5",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "directDependencies": [
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.confluent:kafka-schema-registry-client:5.0.1",
-                    "org.apache.avro:avro:1.8.1"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
-                ],
-                "sha256": "2372bb93a753ce754d0c10514cf4c61501e2c3d8960873541f72377689cb1a48",
-                "url": "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
-            },
-            {
-                "coord": "io.confluent:kafka-schema-registry-client:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "com.thoughtworks.paranamer:paranamer:2.7",
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.avro:avro:1.8.1",
-                    "org.apache.commons:commons-compress:1.18",
-                    "org.apache.kafka:kafka-clients:2.1.1",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
-                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.tukaani:xz:1.5",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "org.apache.avro:avro:1.8.1",
-                    "org.apache.kafka:kafka-clients:2.1.1"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
-                ],
-                "sha256": "74111b8c628d5f6fe55569f49af12ea094942a7f17192011795180b970110f8c",
-                "url": "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
             },
             {
                 "coord": "io.kubernetes:client-java-api:4.0.0-beta1",
@@ -3567,84 +3567,6 @@
                 "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-queryable-state-client-java_2.12/1.8.0/flink-queryable-state-client-java_2.12-1.8.0.jar"
             },
             {
-                "coord": "org.apache.flink:flink-runtime_2.12:1.8.0",
-                "dependencies": [
-                    "com.esotericsoftware.kryo:kryo:2.24.0",
-                    "com.esotericsoftware.minlog:minlog:1.2",
-                    "com.github.scopt:scopt_2.12:3.5.0",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.twitter:chill-java:0.7.6",
-                    "com.twitter:chill_2.12:0.7.6",
-                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
-                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
-                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
-                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
-                    "com.typesafe:config:1.3.0",
-                    "com.typesafe:ssl-config-core_2.12:0.2.1",
-                    "commons-cli:commons-cli:1.3.1",
-                    "commons-collections:commons-collections:3.2.2",
-                    "commons-io:commons-io:2.4",
-                    "org.apache.commons:commons-compress:1.18",
-                    "org.apache.commons:commons-lang3:3.7",
-                    "org.apache.commons:commons-math3:3.5",
-                    "org.apache.flink:flink-annotations:1.8.0",
-                    "org.apache.flink:flink-core:1.8.0",
-                    "org.apache.flink:flink-hadoop-fs:1.8.0",
-                    "org.apache.flink:flink-java:1.8.0",
-                    "org.apache.flink:flink-metrics-core:1.8.0",
-                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
-                    "org.apache.flink:flink-shaded-asm-6:6.2.1-6.0",
-                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
-                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
-                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
-                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
-                    "org.apache.flink:force-shading:1.8.0",
-                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
-                    "org.javassist:javassist:3.19.0-GA",
-                    "org.objenesis:objenesis:2.1",
-                    "org.reactivestreams:reactive-streams:1.0.0",
-                    "org.scala-lang.modules:scala-java8-compat_2.12:0.8.0",
-                    "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4",
-                    "org.scala-lang:scala-library:2.11.12",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "directDependencies": [
-                    "com.github.scopt:scopt_2.12:3.5.0",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.twitter:chill_2.12:0.7.6",
-                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
-                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
-                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
-                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
-                    "commons-cli:commons-cli:1.3.1",
-                    "commons-io:commons-io:2.4",
-                    "org.apache.commons:commons-lang3:3.7",
-                    "org.apache.flink:flink-core:1.8.0",
-                    "org.apache.flink:flink-hadoop-fs:1.8.0",
-                    "org.apache.flink:flink-java:1.8.0",
-                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
-                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
-                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
-                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
-                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
-                    "org.apache.flink:force-shading:1.8.0",
-                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
-                    "org.javassist:javassist:3.19.0-GA",
-                    "org.scala-lang:scala-library:2.11.12",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar",
-                    "https://maven.google.com/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar",
-                    "https://packages.confluent.io/maven/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar"
-                ],
-                "sha256": "14121e60d1e8215ebfe9c997b17b1e8b508a36835f5ec5be4269d71a472fa07c",
-                "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar"
-            },
-            {
                 "coord": "org.apache.flink:flink-runtime_2.12:test-jar:tests:1.8.0",
                 "dependencies": [
                     "com.esotericsoftware.kryo:kryo:2.24.0",
@@ -3721,6 +3643,84 @@
                 ],
                 "sha256": "a09b2cc02a67476d5c1876dc34b0dea9fdefc4aaa2f79e61b19d38af8007b49c",
                 "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar"
+            },
+            {
+                "coord": "org.apache.flink:flink-runtime_2.12:1.8.0",
+                "dependencies": [
+                    "com.esotericsoftware.kryo:kryo:2.24.0",
+                    "com.esotericsoftware.minlog:minlog:1.2",
+                    "com.github.scopt:scopt_2.12:3.5.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.twitter:chill-java:0.7.6",
+                    "com.twitter:chill_2.12:0.7.6",
+                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
+                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
+                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
+                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
+                    "com.typesafe:config:1.3.0",
+                    "com.typesafe:ssl-config-core_2.12:0.2.1",
+                    "commons-cli:commons-cli:1.3.1",
+                    "commons-collections:commons-collections:3.2.2",
+                    "commons-io:commons-io:2.4",
+                    "org.apache.commons:commons-compress:1.18",
+                    "org.apache.commons:commons-lang3:3.7",
+                    "org.apache.commons:commons-math3:3.5",
+                    "org.apache.flink:flink-annotations:1.8.0",
+                    "org.apache.flink:flink-core:1.8.0",
+                    "org.apache.flink:flink-hadoop-fs:1.8.0",
+                    "org.apache.flink:flink-java:1.8.0",
+                    "org.apache.flink:flink-metrics-core:1.8.0",
+                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
+                    "org.apache.flink:flink-shaded-asm-6:6.2.1-6.0",
+                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
+                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
+                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
+                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
+                    "org.apache.flink:force-shading:1.8.0",
+                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
+                    "org.javassist:javassist:3.19.0-GA",
+                    "org.objenesis:objenesis:2.1",
+                    "org.reactivestreams:reactive-streams:1.0.0",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:0.8.0",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4",
+                    "org.scala-lang:scala-library:2.11.12",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "directDependencies": [
+                    "com.github.scopt:scopt_2.12:3.5.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.twitter:chill_2.12:0.7.6",
+                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
+                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
+                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
+                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
+                    "commons-cli:commons-cli:1.3.1",
+                    "commons-io:commons-io:2.4",
+                    "org.apache.commons:commons-lang3:3.7",
+                    "org.apache.flink:flink-core:1.8.0",
+                    "org.apache.flink:flink-hadoop-fs:1.8.0",
+                    "org.apache.flink:flink-java:1.8.0",
+                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
+                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
+                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
+                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
+                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
+                    "org.apache.flink:force-shading:1.8.0",
+                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
+                    "org.javassist:javassist:3.19.0-GA",
+                    "org.scala-lang:scala-library:2.11.12",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar",
+                    "https://maven.google.com/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar",
+                    "https://packages.confluent.io/maven/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar"
+                ],
+                "sha256": "14121e60d1e8215ebfe9c997b17b1e8b508a36835f5ec5be4269d71a472fa07c",
+                "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar"
             },
             {
                 "coord": "org.apache.flink:flink-shaded-asm-6:6.2.1-6.0",
@@ -4313,19 +4313,6 @@
                 "url": "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
             },
             {
-                "coord": "org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
-                    "https://maven.google.com/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
-                    "https://packages.confluent.io/maven/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
-                ],
-                "sha256": "a2cc192a076d9effd10becee8aacbe157f0fe2010fd4322e58aaeff198e56dbe",
-                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
-            },
-            {
                 "coord": "org.eclipse.jetty:jetty-http:jar:tests:9.4.20.v20190813",
                 "dependencies": [
                     "org.eclipse.jetty:jetty-io:9.4.20.v20190813",
@@ -4373,6 +4360,19 @@
                 ],
                 "sha256": "5816ef44f73e76b8ef1c1ea848cc34c7b1f24771f3675353e2ef23eb920121d8",
                 "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.20.v20190813/jetty-util-9.4.20.v20190813.jar"
+            },
+            {
+                "coord": "org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
+                    "https://maven.google.com/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
+                    "https://packages.confluent.io/maven/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
+                ],
+                "sha256": "a2cc192a076d9effd10becee8aacbe157f0fe2010fd4322e58aaeff198e56dbe",
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
             },
             {
                 "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.2",
@@ -4480,6 +4480,19 @@
                 "url": "https://repo1.maven.org/maven2/org/jboss/spec/javax/servlet/jboss-servlet-api_4.0_spec/1.0.0.Final/jboss-servlet-api_4.0_spec-1.0.0.Final.jar"
             },
             {
+                "coord": "org.jetbrains:annotations:13.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+                    "https://maven.google.com/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+                    "https://packages.confluent.io/maven/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+                ],
+                "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+                "url": "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+            },
+            {
                 "coord": "org.jetbrains.kotlin:kotlin-stdlib-common:1.3.21",
                 "dependencies": [],
                 "directDependencies": [],
@@ -4550,19 +4563,6 @@
                 "url": "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-test/1.3.21/kotlin-test-1.3.21.jar"
             },
             {
-                "coord": "org.jetbrains:annotations:13.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
-                    "https://maven.google.com/org/jetbrains/annotations/13.0/annotations-13.0.jar",
-                    "https://packages.confluent.io/maven/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-                ],
-                "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
-                "url": "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-            },
-            {
                 "coord": "org.joda:joda-convert:1.2",
                 "dependencies": [],
                 "directDependencies": [],
@@ -4610,23 +4610,6 @@
                 "url": "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.1/objenesis-2.1.jar"
             },
             {
-                "coord": "org.openjfx:javafx-base:11.0.1",
-                "dependencies": [
-                    "org.openjfx:javafx-base:jar:mac:11.0.1"
-                ],
-                "directDependencies": [
-                    "org.openjfx:javafx-base:jar:mac:11.0.1"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar",
-                    "https://maven.google.com/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar",
-                    "https://packages.confluent.io/maven/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar"
-                ],
-                "sha256": "c5084a74417a89c69a0c122fae96a4b70bf619fc3d6218ea102a4047ec85ad04",
-                "url": "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar"
-            },
-            {
                 "coord": "org.openjfx:javafx-base:jar:mac:11.0.1",
                 "dependencies": [
                     "org.openjfx:javafx-base:jar:mac:11.0.1"
@@ -4642,6 +4625,23 @@
                 ],
                 "sha256": "2d8052a08fd2e5d98e1d5a16d724ea5dd02102879de20a193225f57199803983",
                 "url": "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar"
+            },
+            {
+                "coord": "org.openjfx:javafx-base:11.0.1",
+                "dependencies": [
+                    "org.openjfx:javafx-base:jar:mac:11.0.1"
+                ],
+                "directDependencies": [
+                    "org.openjfx:javafx-base:jar:mac:11.0.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar",
+                    "https://maven.google.com/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar",
+                    "https://packages.confluent.io/maven/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar"
+                ],
+                "sha256": "c5084a74417a89c69a0c122fae96a4b70bf619fc3d6218ea102a4047ec85ad04",
+                "url": "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-analysis:6.2",

--- a/tests/custom_maven_install/unsafe_shared_cache_with_pinning_install.json
+++ b/tests/custom_maven_install/unsafe_shared_cache_with_pinning_install.json
@@ -6,17 +6,6 @@
         "conflict_resolution": {},
         "dependencies": [
             {
-                "coord": "com.google.code.findbugs:jsr305:3.0.2",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-                ],
-                "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-                "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-            },
-            {
                 "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                 "dependencies": [],
                 "directDependencies": [],
@@ -28,15 +17,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
             },
             {
-                "coord": "com.google.errorprone:error_prone_annotations:2.2.0",
+                "coord": "com.google.code.findbugs:jsr305:3.0.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
+                    "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
                 ],
-                "sha256": "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
-                "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
+                "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+                "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
             },
             {
                 "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
@@ -50,15 +39,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
             },
             {
-                "coord": "com.google.guava:failureaccess:1.0",
+                "coord": "com.google.errorprone:error_prone_annotations:2.2.0",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar"
+                    "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
                 ],
-                "sha256": "d084bef9cd07a8537a1753e4850a69b7e8bab1d1e22e9f3a1e4826309a7a2336",
-                "url": "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar"
+                "sha256": "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
+                "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
             },
             {
                 "coord": "com.google.guava:failureaccess:jar:sources:1.0",
@@ -72,31 +61,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar"
             },
             {
-                "coord": "com.google.guava:guava:27.0-jre",
-                "dependencies": [
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:2.2.0",
-                    "com.google.guava:failureaccess:1.0",
-                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:1.1",
-                    "org.checkerframework:checker-qual:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:1.17"
-                ],
-                "directDependencies": [
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:2.2.0",
-                    "com.google.guava:failureaccess:1.0",
-                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:1.1",
-                    "org.checkerframework:checker-qual:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:1.17"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "coord": "com.google.guava:failureaccess:1.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar"
+                    "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar"
                 ],
-                "sha256": "63b09db6861011e7fb2481be7790c7fd4b03f0bb884b3de2ecba8823ad19bf3f",
-                "url": "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar"
+                "sha256": "d084bef9cd07a8537a1753e4850a69b7e8bab1d1e22e9f3a1e4826309a7a2336",
+                "url": "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar"
             },
             {
                 "coord": "com.google.guava:guava:jar:sources:27.0-jre",
@@ -126,6 +99,33 @@
                 "url": "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar"
             },
             {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:2.2.0",
+                    "com.google.guava:failureaccess:1.0",
+                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "org.checkerframework:checker-qual:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.17"
+                ],
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:2.2.0",
+                    "com.google.guava:failureaccess:1.0",
+                    "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "org.checkerframework:checker-qual:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.17"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar"
+                ],
+                "sha256": "63b09db6861011e7fb2481be7790c7fd4b03f0bb884b3de2ecba8823ad19bf3f",
+                "url": "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar"
+            },
+            {
                 "coord": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
                 "dependencies": [],
                 "directDependencies": [],
@@ -135,17 +135,6 @@
                 ],
                 "sha256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
                 "url": "https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
-            },
-            {
-                "coord": "com.google.j2objc:j2objc-annotations:1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-                ],
-                "sha256": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
-                "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
             },
             {
                 "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
@@ -159,15 +148,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
             },
             {
-                "coord": "org.checkerframework:checker-qual:2.5.2",
+                "coord": "com.google.j2objc:j2objc-annotations:1.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                    "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
                 ],
-                "sha256": "64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a",
-                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                "sha256": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+                "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
             },
             {
                 "coord": "org.checkerframework:checker-qual:jar:sources:2.5.2",
@@ -181,15 +170,15 @@
                 "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
             },
             {
-                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+                "coord": "org.checkerframework:checker-qual:2.5.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                    "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
                 ],
-                "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
-                "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                "sha256": "64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a",
+                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
             },
             {
                 "coord": "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
@@ -201,6 +190,17 @@
                 ],
                 "sha256": "2571474a676f775a8cdd15fb9b1da20c4c121ed7f42a5d93fca0e7b6e2015b40",
                 "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
+            },
+            {
+                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                ],
+                "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
+                "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
             },
             {
                 "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",

--- a/tests/unit/BUILD
+++ b/tests/unit/BUILD
@@ -1,3 +1,4 @@
+load(":artifact_utilities_test.bzl", "artifact_utilities_test_suite")
 load(":coursier_test.bzl", "coursier_test_suite")
 load(":coursier_utilities_test.bzl", "coursier_utilities_test_suite")
 load(":java_utilities_test.bzl", "java_utilities_test_suite")
@@ -5,6 +6,8 @@ load(":proxy_test.bzl", "proxy_test_suite")
 load(":specs_test.bzl", "artifact_specs_test_suite")
 
 artifact_specs_test_suite()
+
+artifact_utilities_test_suite()
 
 coursier_test_suite()
 

--- a/tests/unit/artifact_utilities_test.bzl
+++ b/tests/unit/artifact_utilities_test.bzl
@@ -1,0 +1,365 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//:private/artifact_utilities.bzl", "deduplicate_and_sort_artifacts")
+
+
+def _empty_test_impl(ctx):
+    env = unittest.begin(ctx)  
+    asserts.equals(env, {"dependencies": []}, deduplicate_and_sort_artifacts({"dependencies": []}, [], [], False))
+    return unittest.end(env)
+
+empty_test = unittest.make(_empty_test_impl)
+
+def _one_artifact_no_exclusions_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            }
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": []
+    }]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, [], False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 1)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["exclusions"], [])
+
+    return unittest.end(env)
+
+one_artifact_no_exclusions_test = unittest.make(_one_artifact_no_exclusions_test_impl)
+
+def _one_artifact_no_exclusions_with_nulls_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+            {
+                "coord": "org.checkerframework:checker-qual:2.5.2",
+                "file": None,
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": []
+    }]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, [], False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 2)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["exclusions"], [])
+    asserts.equals(env, sorted_dep_tree["dependencies"][1]["coord"], "org.checkerframework:checker-qual:2.5.2")
+
+    return unittest.end(env)
+
+one_artifact_no_exclusions_with_nulls_test = unittest.make(_one_artifact_no_exclusions_with_nulls_test_impl)
+
+def _one_artifact_duplicate_no_exclusions_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            }
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": []
+    }]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, [], False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 1)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["exclusions"], [])
+
+    return unittest.end(env)
+
+one_artifact_duplicate_no_exclusions_test = unittest.make(_one_artifact_duplicate_no_exclusions_test_impl)
+
+def _one_artifact_duplicate_matches_exclusions_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "*:*"
+                ],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                     "org.codehaus.mojo:animal-sniffer-annotations",
+                     "com.google.j2objc:j2objc-annotations",
+                 ]
+            }
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": [
+            {"group": "*", "artifact": "*"}
+        ]
+    }]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, [], False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 1)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["exclusions"], ["*:*"])
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "*:*"
+                ],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                     "org.codehaus.mojo:animal-sniffer-annotations",
+                     "com.google.j2objc:j2objc-annotations",
+                 ]
+            }
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": [
+            {"group": "org.codehaus.mojo", "artifact": "animal-sniffer-annotations"},
+            {"group": "com.google.j2objc", "artifact": "j2objc-annotations"},
+        ]
+    }]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, [], False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 1)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(
+        env,
+        sorted_dep_tree["dependencies"][0]["exclusions"],
+        ["org.codehaus.mojo:animal-sniffer-annotations", "com.google.j2objc:j2objc-annotations"]
+    )
+
+    return unittest.end(env)
+
+one_artifact_duplicate_matches_exclusions_test = unittest.make(_one_artifact_duplicate_matches_exclusions_test_impl)
+
+def _one_artifact_duplicate_with_global_exclusions_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "*:*"
+                ],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                     "org.codehaus.mojo:animal-sniffer-annotations",
+                     "com.google.j2objc:j2objc-annotations",
+                     "org.checkerframework:checker-qual",
+                 ]
+            }
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": [
+            {"group": "*", "artifact": "*"}
+        ]
+    }]
+
+    excluded_artifacts = [
+        {"group": "com.google.j2objc", "artifact": "j2objc-annotations"},
+        {"group": "org.checkerframework", "artifact": "checker-qual"},
+    ]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, excluded_artifacts, False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 1)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["exclusions"], ["*:*"])
+
+    dep_tree = {
+        "conflict_resolution": {},
+        "dependencies": [
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "*:*"
+                ],
+            },
+            {
+                "coord": "com.google.guava:guava:27.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                     "org.codehaus.mojo:animal-sniffer-annotations",
+                     "com.google.j2objc:j2objc-annotations",
+                     "org.checkerframework:checker-qual",
+                 ]
+            }
+        ],
+        "version": "0.1.0",
+    }
+
+    artifacts = [{
+        "group": "com.google.guava",
+        "artifact": "guava",
+        "version": "27.0-jre",
+        "exclusions": [
+            {"group": "org.codehaus.mojo", "artifact": "animal-sniffer-annotations"},
+            {"group": "com.google.j2objc", "artifact": "j2objc-annotations"},
+        ]
+    }]
+
+    sorted_dep_tree = deduplicate_and_sort_artifacts(dep_tree, artifacts, excluded_artifacts, False)
+
+    asserts.equals(env, len(sorted_dep_tree["dependencies"]), 1)
+    asserts.equals(env, sorted_dep_tree["dependencies"][0]["coord"], "com.google.guava:guava:27.0-jre")
+    asserts.equals(
+        env,
+        sorted_dep_tree["dependencies"][0]["exclusions"],
+        [
+            "org.codehaus.mojo:animal-sniffer-annotations",
+            "com.google.j2objc:j2objc-annotations",
+            "org.checkerframework:checker-qual",
+        ]
+    )
+
+    return unittest.end(env)
+
+one_artifact_duplicate_with_global_exclusions_test = unittest.make(_one_artifact_duplicate_with_global_exclusions_test_impl)
+
+def artifact_utilities_test_suite():
+    unittest.suite(
+        "artifact_utilities_tests",
+        empty_test,
+        one_artifact_no_exclusions_test,
+        one_artifact_no_exclusions_with_nulls_test,
+        one_artifact_duplicate_no_exclusions_test,
+        one_artifact_duplicate_matches_exclusions_test,
+        one_artifact_duplicate_with_global_exclusions_test,
+    )


### PR DESCRIPTION
When we de-duplicate artifacts from coursier we just take the first artifact in the list. This is sometimes breaking artifacts that specify exclusions because the first artifact in the list may not match the exclusions for the dependency.  The result is that you specify exclusions but nothing is excluded.

This PR fixes the de-duplication logic so it will select the duplicate artifact with the correct exclusions.

Since this also re-arranged the artifacts in the list I also sorted the list after all of the de-duplication was done.  Sorting the artifacts based on their file path does re-arrange the sorting from coursier though.