### PR TITLE
Stop running UnsafeSharedCacheTest until it is re-written to work with Java 11

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -87,7 +87,8 @@ tasks:
     test_targets:
       - "//..."
       # manual tests
-      - "//tests/com/jvm/external:UnsafeSharedCacheTest"
+      # commented out until https://github.com/bazelbuild/rules_jvm_external/issues/610 is fixed for Java 11
+      # - "//tests/com/jvm/external:UnsafeSharedCacheTest"
       - "//tests/unit/manifest_stamp:diff_manifest_test" # https://github.com/bazelbuild/rules_jvm_external/issues/283
   windows:
     environment:


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/issues/610