### PR TITLE
Make generating javadoc jars optional

### DIFF
--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -75,6 +75,18 @@ java_export(
     ],
 )
 
+java_export(
+    name = "without-docs",
+    srcs = ["Main.java"],
+    tags = [
+        "no-javadocs",
+    ],
+    maven_coordinates = "com.example:no-docs:1.0.0",
+    deps = [
+        ":dep",
+    ],
+)
+
 genrule(
     name = "list-deploy-env-classes",
     srcs = [


### PR DESCRIPTION
Occasionally generating javadoc jars is more complicated than
compiling the raw source code (eg. when documenting code that uses
Lombok) Rather than make people jump hoops to generate the javadoc jar
(which may not actually be used) add a new tag we check for:
`no-javadocs`