### PR TITLE
Fix artifact["exclusions"]

### DIFF
--- a/private/artifact_utilities.bzl
+++ b/private/artifact_utilities.bzl
@@ -45,7 +45,7 @@ def deduplicate_and_sort_artifacts(dep_tree, artifacts, excluded_artifacts, verb
         deduped_artifact_with_exclusion = duplicate_artifacts_with_exclusions[duplicate_coord][0]
         found_artifact_with_exclusion = False
         for duplicate_artifact in duplicate_artifacts_with_exclusions[duplicate_coord]:
-            if sorted(duplicate_artifact["exclusions"]) == sorted(artifacts_with_exclusions[duplicate_coord]):
+            if "exclusions" in duplicate_artifact and sorted(duplicate_artifact["exclusions"]) == sorted(artifacts_with_exclusions[duplicate_coord]):
                 found_artifact_with_exclusion = True
                 deduped_artifact_with_exclusion = duplicate_artifact
         if verbose and not found_artifact_with_exclusion:


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/commit/d98ea59caa97e26a21e773a773c95dd5cf880126#r60658332

We encounter this bug when using the newest code.
```
ERROR: An error occurred during the fetch of repository 'unpinned_maven':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_haowang/67362b0cd09d93b47f4dadb7394eed77/external/rules_jvm_external/coursier.bzl", line 837, column 38, in _coursier_fetch_impl
		dep_tree = make_coursier_dep_tree(
	File "/private/var/tmp/_bazel_haowang/67362b0cd09d93b47f4dadb7394eed77/external/rules_jvm_external/coursier.bzl", line 770, column 42, in make_coursier_dep_tree
		return deduplicate_and_sort_artifacts(
	File "/private/var/tmp/_bazel_haowang/67362b0cd09d93b47f4dadb7394eed77/external/rules_jvm_external/private/artifact_utilities.bzl", line 49, column 41, in deduplicate_and_sort_artifacts
		if sorted(duplicate_artifact["exclusions"]) == sorted(artifacts_with_exclusions[duplicate_coord]):
Error: key "exclusions" not found in dictionary
ERROR: key "exclusions" not found in dictionary
```

Not sure whether this is the best solution, please take a look.