### PR TITLE
Check for native json by checking the bazel version

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -92,6 +92,7 @@ def _has_native_json():
         return False
 
     version = native.bazel_version
+    print("Version was read as: %s" % version)
 
     for i in range(len(version)):
         if not version[i].isdigit():


### PR DESCRIPTION
Apparently the native json decoder is not found at
`native.json_decode`, but the module `json` and a function `decode`

:facepalm:

Unfortunately, Bazel doesn't provide a handy mechanism to determine
whether a particular module is present.

Fortunately, we know that it arrived in Bazel 4, so all we need to do
is find the major version number of bazel and assert that it's 4 or
more.

We could use skylib for this, but it's not one of our dependencies,
and it seems like overkill to add a dependency for the single
`versions` module it offers. The check is simple enough to implement
ourselves, though, and we fall back to assuming we're on a modern
Bazel because 4.x has been out for a while now.