### PR TITLE
Respect NO_PROXY=.example.com

### DIFF
--- a/private/proxy.bzl
+++ b/private/proxy.bzl
@@ -71,6 +71,8 @@ def get_java_proxy_args(http_proxy, https_proxy, no_proxy):
     # Convert no_proxy-style exclusions, including base domain matching, into java.net nonProxyHosts:
     # localhost,example.com,foo.example.com,.otherexample.com -> "localhost|example.com|foo.example.com|*.otherexample.com"
     if no_proxy:
+        if no_proxy.startswith("."):
+            no_proxy = "*" + no_proxy
         proxy_args.append("-Dhttp.nonProxyHosts='%s'" % no_proxy.replace(",", "|").replace("|.", "|*."))
 
     return proxy_args


### PR DESCRIPTION
When processing the `NO_PROXY` environment variable,
rules_jvm_exported mapped `foo.example.com,.example.com` to the JVM's
`-Dhttp.nonProxyHosts=foo.example.com|*.example.com`.  However, it
failed to map `.example.com` to `*.example.com`, because it only
remapped subdomain expressions that followed a comma.

Address this by separately handling an environment string beginning
with a ".".

Resolves #636.