### PR TITLE
Allow overriding rules_jvm_external_deps_install.json

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -5,13 +5,13 @@ _DEFAULT_REPOSITORIES = [
     "https://maven.google.com",
 ]
 
-def rules_jvm_external_deps(repositories = _DEFAULT_REPOSITORIES):
+def rules_jvm_external_deps(repositories = _DEFAULT_REPOSITORIES, maven_install_json = "@rules_jvm_external//:rules_jvm_external_deps_install.json"):
     maven_install(
         name = "rules_jvm_external_deps",
         artifacts = [
             "com.google.cloud:google-cloud-storage:1.113.4",
         ],
-        maven_install_json = "@rules_jvm_external//:rules_jvm_external_deps_install.json",
+        maven_install_json = maven_install_json,
         fail_if_repin_required = True,
         repositories = repositories,
     )


### PR DESCRIPTION
This can be useful for setting up alternative urls for internal dependencies of rules_jvm_external.
Some potential use-cases
- having slightly different version of those dependencies
- having an extra proxy hosting that could be faster / more local
- having an extra proxy hosting that is persisted / archived for extra reproducibility
- just having a uniform proxy for all / most external dependencies