### PR TITLE
Expose list of all artifacts, including transitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,9 @@ To use it, add the load statement to the top of your BUILD file:
 load("@rules_jvm_external//:defs.bzl", "artifact")
 ```
 
+Full `group:artifact:[packaging:[classifier:]]version` maven coordinates are also
+supported and translate to corresponding versionless target.
+
 Note that usage of this macro makes BUILD file refactoring with tools like
 `buildozer` more difficult, because the macro hides the actual target label at
 the syntax level.
@@ -852,6 +855,31 @@ maven_install(
         # ...
     ],
     strict_visibility = True
+)
+```
+
+It is also possible to change strict visibility value from default `//visibility:private`
+to a value specified by `strict_visibility_value` attribute.
+
+### Accessing transitive dependencies list
+
+It is possible to retrieve full list of dependencies in the dependency tree, including
+transitive, source, javadoc and other artifacts. `maven_artifacts` list contains full
+versioned maven coordinate strings of all dependencies.
+
+For example:
+```python
+load("@maven//:defs.bzl", "maven_artifacts")
+
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("@rules_jvm_external//:specs.bzl", "parse")
+
+all_jar_coordinates = [c for c in maven_artifacts if parse.parse_maven_coordinate(c).get("packaging", "jar") == "jar"]
+all_jar_targets = [artifact(c) for c in all_jar_coordinates]
+
+java_library(
+  name = "depends_on_everything",
+  runtime_deps = all_jar_targets,
 )
 ```
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -471,11 +471,13 @@ def _pinned_coursier_fetch_impl(repository_ctx):
         "load(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")",
         "def pinned_maven_install():",
     ]
+    maven_artifacts = []
     netrc_entries = {}
 
     for artifact in dep_tree["dependencies"]:
         if artifact.get("url") != None:
             http_file_repository_name = escape(artifact["coord"])
+            maven_artifacts.extend([artifact["coord"]])
             http_files.extend([
                 "    http_file(",
                 "        name = \"%s\"," % http_file_repository_name,
@@ -498,6 +500,8 @@ def _pinned_coursier_fetch_impl(repository_ctx):
             http_files.append("    )")
 
     http_files.extend(_get_jq_http_files())
+
+    http_files.extend(["maven_artifacts = [\n%s\n]" % (",\n".join(["    \"%s\"" % artifact for artifact in maven_artifacts]))])
 
     repository_ctx.file("defs.bzl", "\n".join(http_files), executable = False)
     repository_ctx.file(

--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -46,6 +46,10 @@ def strip_packaging_and_classifier(coord):
     return ":".join(coordinates)
 
 def strip_packaging_and_classifier_and_version(coord):
+    coordinates = coord.split(":")
+    # Support for simplified versionless groupId:artifactId coordinate format
+    if len(coordinates) == 2:
+        return ":".join(coordinates)
     return ":".join(strip_packaging_and_classifier(coord).split(":")[:-1])
 
 # TODO: Should these methods be combined with _parse_maven_coordinate_string in specs.

--- a/private/rules/artifact.bzl
+++ b/private/rules/artifact.bzl
@@ -12,6 +12,14 @@ def maven_artifact(a):
 def _escape(string):
     return string.replace(".", "_").replace("-", "_").replace(":", "_")
 
+# inverse of parse_maven_coordinate
 def _make_artifact_str(artifact_obj):
-    # TODO: add support for optional type, classifier and version parts in artifact_obj case
-    return artifact_obj["group"] + ":" + artifact_obj["artifact"]
+    # produce either simplified g:a or standard g:a:[p:[c:]]v Maven coordinate string
+    coord = [artifact_obj["group"], artifact_obj["artifact"]]
+    if "version" in artifact_obj:
+        if "packaging" in artifact_obj:
+           coord.extend([artifact_obj["packaging"]])
+           if "classifier" in artifact_obj:
+             coord.extend([artifact_obj["classifier"]])
+        coord.extend([artifact_obj["version"]])
+    return ":".join(coord)

--- a/private/rules/artifact.bzl
+++ b/private/rules/artifact.bzl
@@ -1,9 +1,10 @@
 load("//:specs.bzl", "parse")
 load("//private:constants.bzl", "DEFAULT_REPOSITORY_NAME")
+load("//private:coursier_utilities.bzl", "strip_packaging_and_classifier_and_version")
 
 def artifact(a, repository_name = DEFAULT_REPOSITORY_NAME):
-    artifact_obj = _parse_artifact_str(a) if type(a) == "string" else a
-    return "@%s//:%s" % (repository_name, _escape(artifact_obj["group"] + ":" + artifact_obj["artifact"]))
+    artifact_str = _make_artifact_str(a) if type(a) != "string" else a
+    return "@%s//:%s" % (repository_name, _escape(strip_packaging_and_classifier_and_version(artifact_str)))
 
 def maven_artifact(a):
     return artifact(a, repository_name = DEFAULT_REPOSITORY_NAME)
@@ -11,9 +12,6 @@ def maven_artifact(a):
 def _escape(string):
     return string.replace(".", "_").replace("-", "_").replace(":", "_")
 
-def _parse_artifact_str(artifact_str):
-    pieces = artifact_str.split(":")
-    if len(pieces) == 2:
-        return {"group": pieces[0], "artifact": pieces[1]}
-    else:
-        return parse.parse_maven_coordinate(artifact_str)
+def _make_artifact_str(artifact_obj):
+    # TODO: add support for optional type, classifier and version parts in artifact_obj case
+    return artifact_obj["group"] + ":" + artifact_obj["artifact"]

--- a/tests/unit/coursier_utilities_test.bzl
+++ b/tests/unit/coursier_utilities_test.bzl
@@ -80,6 +80,12 @@ def _strip_packaging_and_classifier_and_version_test_impl(ctx):
         "groupId:artifactId",
         strip_packaging_and_classifier_and_version("groupId:artifactId:pom:sources:version"),
     )
+    # versionless coordinates aren't standard Maven coordinates but are useful for the artifact() macro
+    asserts.equals(
+        env,
+        "groupId:artifactId",
+        strip_packaging_and_classifier_and_version("groupId:artifactId"),
+    )
     return unittest.end(env)
 
 strip_packaging_and_classifier_and_version_test = unittest.make(_strip_packaging_and_classifier_and_version_test_impl)


### PR DESCRIPTION
And add support for :type and :classifier in defs.bzl:artifact() by internally
using strip_packaging_and_classifier_and_version. To keep support for groupId:artifactId
update strip_packaging_and_classifier_and_version implementation for that case.

To be used like
```python
    load("@maven//:defs.bzl", "maven_artifacts")
```

and for example
```python
    load("@rules_jvm_external//:defs.bzl", "artifact")
    load("@rules_jvm_external//:specs.bzl", "parse")

    all_maven_targets = [artifact(a) for a in maven_artifacts if not parse.parse_maven_coordinate(a).get("classifier", "compile") in ["sources", "native"]]

    java_export(
        name = "maven-transitive-deps-lib",
        maven_coordinates = "com.example.deps:%s:%s" % (name, "0.1"),
        visibility = ["//visibility:public"],
        runtime_deps = all_maven_targets,
    )
```
which makes "maven-transitive-deps-lib-pom" target available that
can be useful for other tools like security scanners and/or dependabot
