### PR TITLE
Add new strict_visibility_value= attribute to allow exposing strict dependencies to some scopes

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -28,7 +28,7 @@ load(
 )
 
 _BUILD = """
-package(default_visibility = ["//visibility:{visibility}"])
+# package(default_visibility = [{visibilities}])  # https://github.com/bazelbuild/bazel/issues/13681
 
 load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
 load("@rules_jvm_external//private/rules:jetifier.bzl", "jetify_aar_import", "jetify_jvm_import")
@@ -539,7 +539,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
     repository_ctx.file(
         "BUILD",
         (_BUILD + _BUILD_OUTDATED).format(
-            visibility = "private" if repository_ctx.attr.strict_visibility else "public",
+            visibilities = ",".join(["\"%s\"" % s for s in (["//visibility:public"] if not repository_ctx.attr.strict_visibility else repository_ctx.attr.strict_visibility_value)]),
             repository_name = repository_ctx.name,
             imports = generated_imports,
             aar_import_statement = _get_aar_import_statement_or_empty_str(repository_ctx),
@@ -1041,7 +1041,7 @@ def _coursier_fetch_impl(repository_ctx):
     repository_ctx.file(
         "BUILD",
         (_BUILD + _BUILD_PIN + outdated_build_file_content).format(
-            visibility = "private" if repository_ctx.attr.strict_visibility else "public",
+            visibilities = ",".join(["\"%s\"" % s for s in (["//visibility:public"] if not repository_ctx.attr.strict_visibility else repository_ctx.attr.strict_visibility_value)]),
             repository_name = repository_name,
             imports = generated_imports,
             aar_import_statement = _get_aar_import_statement_or_empty_str(repository_ctx),
@@ -1146,6 +1146,7 @@ pinned_coursier_fetch = repository_rule(
             """,
             default = False,
         ),
+        "strict_visibility_value": attr.label_list(default = ["//visibility:private"]),
         "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),
         "additional_netrc_lines": attr.string_list(doc = "Additional lines prepended to the netrc file used by `http_file` (with `maven_install_json` only).", default = []),
@@ -1206,6 +1207,7 @@ coursier_fetch = repository_rule(
             """,
             default = False,
         ),
+        "strict_visibility_value": attr.label_list(default = ["//visibility:private"]),
         "resolve_timeout": attr.int(default = 600),
         "jetify": attr.bool(doc = "Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.", default = False),
         "jetify_include_list": attr.string_list(doc = "List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.", default = JETIFY_INCLUDE_LIST_JETIFY_ALL),

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -79,6 +79,7 @@ sh_binary(
         "outdated.artifacts",
         "outdated.repositories"
     ],
+    visibility = ["//visibility:public"],
 )
 """
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,18 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# API Reference
-
-- [Basic functions](#basic-functions)
-  - [javadoc](#javadoc)
-  - [java_export](#java_export)
-  - [maven_install](#maven_install)
-- [Maven specification functions](#maven-specification-functions)
-  - [maven.repository](#mavenrepository)
-  - [maven.artifact](#mavenartifact)
-  - [maven.exclusion](#mavenexclusion)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Basic functions
 
 These are the basic functions to get started.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+# API Reference
+
+- [Basic functions](#basic-functions)
+  - [javadoc](#javadoc)
+  - [java_export](#java_export)
+  - [maven_install](#maven_install)
+- [Maven specification functions](#maven-specification-functions)
+  - [maven.repository](#mavenrepository)
+  - [maven.artifact](#mavenartifact)
+  - [maven.exclusion](#mavenexclusion)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Basic functions
 
 These are the basic functions to get started.

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,9 +115,9 @@ Generated rules:
 maven_install(<a href="#maven_install-name">name</a>, <a href="#maven_install-repositories">repositories</a>, <a href="#maven_install-artifacts">artifacts</a>, <a href="#maven_install-fail_on_missing_checksum">fail_on_missing_checksum</a>, <a href="#maven_install-fetch_sources">fetch_sources</a>, <a href="#maven_install-fetch_javadoc">fetch_javadoc</a>,
               <a href="#maven_install-use_unsafe_shared_cache">use_unsafe_shared_cache</a>, <a href="#maven_install-excluded_artifacts">excluded_artifacts</a>, <a href="#maven_install-generate_compat_repositories">generate_compat_repositories</a>,
               <a href="#maven_install-version_conflict_policy">version_conflict_policy</a>, <a href="#maven_install-maven_install_json">maven_install_json</a>, <a href="#maven_install-override_targets">override_targets</a>, <a href="#maven_install-strict_visibility">strict_visibility</a>,
-              <a href="#maven_install-resolve_timeout">resolve_timeout</a>, <a href="#maven_install-jetify">jetify</a>, <a href="#maven_install-jetify_include_list">jetify_include_list</a>, <a href="#maven_install-additional_netrc_lines">additional_netrc_lines</a>,
-              <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>, <a href="#maven_install-use_starlark_android_rules">use_starlark_android_rules</a>, <a href="#maven_install-aar_import_bzl_label">aar_import_bzl_label</a>,
-              <a href="#maven_install-duplicate_version_warning">duplicate_version_warning</a>)
+              <a href="#maven_install-strict_visibility_value">strict_visibility_value</a>, <a href="#maven_install-resolve_timeout">resolve_timeout</a>, <a href="#maven_install-jetify">jetify</a>, <a href="#maven_install-jetify_include_list">jetify_include_list</a>,
+              <a href="#maven_install-additional_netrc_lines">additional_netrc_lines</a>, <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>, <a href="#maven_install-use_starlark_android_rules">use_starlark_android_rules</a>,
+              <a href="#maven_install-aar_import_bzl_label">aar_import_bzl_label</a>, <a href="#maven_install-duplicate_version_warning">duplicate_version_warning</a>)
 </pre>
 
 Resolves and fetches artifacts transitively from Maven repositories.
@@ -144,6 +144,7 @@ and fetch Maven artifacts transitively.
 | maven_install_json |  A label to a <code>maven_install.json</code> file to use pinned artifacts for generating   build targets. e.g <code>//:maven_install.json</code>.   |  <code>None</code> |
 | override_targets |  A mapping of <code>group:artifact</code> to Bazel target labels. All occurrences of the   target label for <code>group:artifact</code> will be an alias to the specified label, therefore overriding   the original generated <code>jvm_import</code> or <code>aar_import</code> target.   |  <code>{}</code> |
 | strict_visibility |  Controls visibility of transitive dependencies. If <code>True</code>, transitive dependencies   are private and invisible to user's rules. If <code>False</code>, transitive dependencies are public and   visible to user's rules.   |  <code>False</code> |
+| strict_visibility_value |  Allows changing transitive dependencies strict visibility scope from private   to specified scopes list.   |  <code>["//visibility:private"]</code> |
 | resolve_timeout |  The execution timeout of resolving and fetching artifacts.   |  <code>600</code> |
 | jetify |  Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.   |  <code>False</code> |
 | jetify_include_list |  List of artifacts that need to be jetified in <code>groupId:artifactId</code> format. By default all artifacts are jetified if <code>jetify</code> is set to True.   |  <code>["*"]</code> |

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -375,6 +375,9 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             if repository_ctx.attr.strict_visibility and explicit_artifacts.get(simple_coord):
                 target_import_string.append("\tvisibility = [\"//visibility:public\"],")
                 alias_visibility = "\tvisibility = [\"//visibility:public\"],\n"
+            else:
+                target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % v for v in default_visibilities])))
+                alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % v for v in default_visibilities]))
 
             target_import_string.append(")")
 

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -21,7 +21,7 @@ load("//private:coursier_utilities.bzl", "escape", "get_classifier", "get_packag
 
 JETIFY_INCLUDE_LIST_JETIFY_ALL = ["*"]
 
-def _genrule_copy_artifact_from_http_file(artifact):
+def _genrule_copy_artifact_from_http_file(artifact, visibilities):
     http_file_repository = escape(artifact["coord"])
     return "\n".join([
         "genrule(",
@@ -29,6 +29,7 @@ def _genrule_copy_artifact_from_http_file(artifact):
         "     srcs = [\"@%s//file\"]," % http_file_repository,
         "     outs = [\"%s\"]," % artifact["file"],
         "     cmd = \"cp $< $@\",",
+        "     visibility = [%s]" % (",".join(["\"%s\"" % v for v in visibilities])),
         ")",
     ])
 
@@ -65,6 +66,8 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
     for coord in override_targets:
         labels_to_override.update({escape(coord): override_targets.get(coord)})
 
+    default_visibilities = repository_ctx.attr.strict_visibility_value if repository_ctx.attr.strict_visibility else ["//visibility:public"]
+
     # First collect a map of target_label to their srcjar relative paths, and symlink the srcjars if needed.
     # We will use this map later while generating target declaration strings with the "srcjar" attr.
     srcjar_paths = None
@@ -78,7 +81,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
                     target_label = escape(strip_packaging_and_classifier_and_version(artifact["coord"]))
                     srcjar_paths[target_label] = artifact_path
                     if repository_ctx.attr.maven_install_json:
-                        all_imports.append(_genrule_copy_artifact_from_http_file(artifact))
+                        all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
 
     jetify_all = repository_ctx.attr.jetify and repository_ctx.attr.jetify_include_list == JETIFY_INCLUDE_LIST_JETIFY_ALL
 
@@ -112,7 +115,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
                 "alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n\tvisibility = [\"//visibility:public\"],\n)" % (target_label, versioned_target_alias_label),
             )
             if repository_ctx.attr.maven_install_json:
-                all_imports.append(_genrule_copy_artifact_from_http_file(artifact))
+                all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
         elif target_label in labels_to_override:
             # Override target labels with the user provided mapping, instead of generating
             # a jvm_import/aar_import based on information in dep_tree.
@@ -122,7 +125,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             )
             if repository_ctx.attr.maven_install_json:
                 # Provide the downloaded artifact as a file target.
-                all_imports.append(_genrule_copy_artifact_from_http_file(artifact))
+                all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
         elif artifact_path != None:
             seen_imports[target_label] = True
 
@@ -287,6 +290,9 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             if repository_ctx.attr.strict_visibility and explicit_artifacts.get(simple_coord):
                 target_import_string.append("\tvisibility = [\"//visibility:public\"],")
                 alias_visibility = "\tvisibility = [\"//visibility:public\"],\n"
+            else:
+                target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % v for v in default_visibilities])))
+                alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % v for v in default_visibilities]))
 
             # 9. Finish the java_import rule.
             #
@@ -328,7 +334,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             #     cmd = "cp $< $@",
             # )
             if repository_ctx.attr.maven_install_json:
-                all_imports.append(_genrule_copy_artifact_from_http_file(artifact))
+                all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
 
         else:  # artifact_path == None:
             # Special case for certain artifacts that only come with a POM file.

--- a/private/rules/jetifier.bzl
+++ b/private/rules/jetifier.bzl
@@ -37,10 +37,11 @@ jetify = rule(
     implementation = _jetify_impl,
 )
 
-def jetify_aar_import(name, aar, _aar_import=None, **kwargs):
+def jetify_aar_import(name, aar, _aar_import=None, visibility=None, **kwargs):
     jetify(
         name = "jetified_" + name,
         srcs = [aar],
+        visibility = visibility,
     )
 
     if not _aar_import:
@@ -49,18 +50,21 @@ def jetify_aar_import(name, aar, _aar_import=None, **kwargs):
     _aar_import(
         name = name,
         aar = ":jetified_" + name,
+        visibility = visibility,
         **kwargs
     )
 
-def jetify_jvm_import(name, jars, **kwargs):
+def jetify_jvm_import(name, jars, visibility=None, **kwargs):
     jetify(
         name = "jetified_" + name,
         srcs = jars,
+        visibility = visibility,
     )
 
     jvm_import(
         name = name,
         jars = [":jetified_" + name],
+        visibility = visibility,
         **kwargs
     )
 

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -17,6 +17,7 @@ def maven_install(
         maven_install_json = None,
         override_targets = {},
         strict_visibility = False,
+        strict_visibility_value = ["//visibility:private"],
         resolve_timeout = 600,
         jetify = False,
         jetify_include_list = JETIFY_INCLUDE_LIST_JETIFY_ALL,
@@ -56,6 +57,8 @@ def maven_install(
       strict_visibility: Controls visibility of transitive dependencies. If `True`, transitive dependencies
         are private and invisible to user's rules. If `False`, transitive dependencies are public and
         visible to user's rules.
+      strict_visibility_value: Allows changing transitive dependencies strict visibility scope from private
+        to specified scopes list.
       resolve_timeout: The execution timeout of resolving and fetching artifacts.
       jetify: Runs the AndroidX [Jetifier](https://developer.android.com/studio/command-line/jetifier) tool on artifacts specified in jetify_include_list. If jetify_include_list is not specified, run Jetifier on all artifacts.
       jetify_include_list: List of artifacts that need to be jetified in `groupId:artifactId` format. By default all artifacts are jetified if `jetify` is set to True.
@@ -115,6 +118,7 @@ def maven_install(
         version_conflict_policy = version_conflict_policy,
         override_targets = override_targets,
         strict_visibility = strict_visibility,
+        strict_visibility_value = strict_visibility_value,
         maven_install_json = maven_install_json,
         resolve_timeout = resolve_timeout,
         jetify = jetify,
@@ -136,6 +140,7 @@ def maven_install(
             generate_compat_repositories = generate_compat_repositories,
             override_targets = override_targets,
             strict_visibility = strict_visibility,
+            strict_visibility_value = strict_visibility_value,
             jetify = jetify,
             jetify_include_list = jetify_include_list,
             additional_netrc_lines = additional_netrc_lines,


### PR DESCRIPTION
Note that using package default_visibility doesn't always work so explicit visiblity attributes are needed
https://github.com/bazelbuild/bazel/issues/13681

Somewhat related to https://github.com/bazelbuild/rules_jvm_external/pull/648

In combination this for example allows to create a class_name -> maven artifact resolver for
transitive dependency classes while still keeping strict visibility (making transitive dependencies
visible only to the resolve cli tool)