### PR TITLE
Merge jar files without unpacking them

### DIFF
--- a/private/tools/java/rules/jvm/external/jar/DuplicateEntryStrategy.java
+++ b/private/tools/java/rules/jvm/external/jar/DuplicateEntryStrategy.java
@@ -1,45 +1,36 @@
 package rules.jvm.external.jar;
 
-import rules.jvm.external.ByteStreams;
-
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.util.stream.Collectors.joining;
 
 enum DuplicateEntryStrategy {
 
   LAST_IN_WINS("last-wins") {
     @Override
-    public void resolve(Path current, InputStream inputStreamForDuplicate) throws IOException {
-      try (OutputStream os = Files.newOutputStream(current, TRUNCATE_EXISTING)) {
-        ByteStreams.copy(inputStreamForDuplicate, os);
-      }
+    public boolean isReplacingCurrent(String name, byte[] originalHash, byte[] newHash) {
+      return true;
     }
   },
   FIRST_IN_WINS("first-wins") {
     @Override
-    public void resolve(Path current, InputStream inputStreamForDuplicate) {
-      // No need to do anything.
+    public boolean isReplacingCurrent(String name, byte[] originalHash, byte[] newHash) {
+      return originalHash == null;
     }
   },
   IS_ERROR("are-errors") {
     @Override
-    public void resolve(Path current, InputStream inputStreamForDuplicate) throws IOException {
-      byte[] first = hash(Files.readAllBytes(current));
-      byte[] second = hash(ByteStreams.toByteArray(inputStreamForDuplicate));
-
-      if (Arrays.equals(first, second)) {
-        return;
+    public boolean isReplacingCurrent(String name, byte[] originalHash, byte[] newHash) throws IOException {
+      if (originalHash == null) {
+        return true;
       }
-      throw new IOException("Attempt to write different duplicate file for: " + current);
+
+      if (Arrays.equals(originalHash, newHash)) {
+        return false;
+      }
+
+      throw new IOException("Attempt to write different duplicate file for: " + name);
     }
   };
 
@@ -65,15 +56,13 @@ enum DuplicateEntryStrategy {
     return shortName;
   }
 
-  public abstract void resolve(Path current, InputStream inputStreamForDuplicate) throws IOException;
-
-  protected byte[] hash(byte[] bytes) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-1");
-      digest.update(bytes);
-      return digest.digest();
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException(e);
-    }
-  }
+  /**
+   * Whether the current version of {@code name} (as identified by {@code originalHash}) should be
+   * replaced by the version identified by {@code newHash}. Both hashes should be generated using
+   * a {@link java.security.MessageDigest}, and the algorithm used for both should be the same.
+   *
+   * @param originalHash Generated hash, which may be null.
+   * @param newHash Generated hash, which must not be null.
+   */
+  public abstract boolean isReplacingCurrent(String name, byte[] originalHash, byte[] newHash) throws IOException;
 }

--- a/tests/com/jvm/external/jar/MergeJarsTest.java
+++ b/tests/com/jvm/external/jar/MergeJarsTest.java
@@ -232,6 +232,28 @@ public class MergeJarsTest {
     assertEquals("Hello, World!", contents.get("META-INF/foo"));
   }
 
+  @Test
+  public void canMergeJarsWhereADirectoryAndFileShareTheSamePath() throws IOException {
+    Path inputOne = temp.newFile("one.jar").toPath();
+    createJar(inputOne, ImmutableMap.of("example/file.txt", "Yellow!"));
+
+    Path inputTwo = temp.newFile("two.jar").toPath();
+    createJar(inputTwo, ImmutableMap.of("example", "Purple!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[]{
+            "--output", outputJar.toAbsolutePath().toString(),
+            "--sources", inputOne.toAbsolutePath().toString(),
+            "--sources", inputTwo.toAbsolutePath().toString()});
+
+    Map<String, String> contents = readJar(outputJar);
+
+    // One entry for the manifest, one for the file "example", and one for "example/file.txt"
+    assertEquals("Yellow!", contents.get("example/file.txt"));
+    assertEquals("Purple!", contents.get("example"));
+  }
+
   private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
     try (OutputStream os = Files.newOutputStream(outputTo);
          ZipOutputStream zos = new ZipOutputStream(os)) {


### PR DESCRIPTION
It's possible to create jar files that do not unpack cleanly on
a file system. For example, they can include a _file_ named
`foo/bar` and another file called `foo`. Attempting to merge
jars by unpacking to disk and then repacking them will fail
because it's not possible to unpack cleanly.

This change does everything in-memory, without needing to create
intermediate temporary files.