### PR TITLE
pin.sh: also sort dependencies by coordinate

### DIFF
--- a/private/pin.sh
+++ b/private/pin.sh
@@ -8,7 +8,7 @@ readonly maven_install_json_loc={maven_install_location}
 # So replace leading external/ with ../
 readonly jq=${1/#external\//..\/}
 readonly maven_unsorted_file="$2"
-"$jq" --sort-keys --indent 4 '.dependency_tree.dependencies[].dependencies|=sort_by(.) | .dependency_tree.dependencies[].directDependencies|=sort_by(.)' < "$maven_unsorted_file" > $maven_install_json_loc
+"$jq" --sort-keys --indent 4 '.dependency_tree.dependencies|=sort_by(.coord) | .dependency_tree.dependencies[].dependencies|=sort_by(.) | .dependency_tree.dependencies[].directDependencies|=sort_by(.)' < "$maven_unsorted_file" > $maven_install_json_loc
 if [ "{predefined_maven_install}" = "True" ]; then
     echo "Successfully pinned resolved artifacts for @{repository_name}, $maven_install_json_loc is now up-to-date."
 else

--- a/tests/custom_maven_install/json_artifacts_testing_install.json
+++ b/tests/custom_maven_install/json_artifacts_testing_install.json
@@ -6,21 +6,6 @@
         "conflict_resolution": {},
         "dependencies": [
             {
-                "coord": "aopalliance:aopalliance:jar:sources:1.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
-                ],
-                "sha256": "e6ef91d439ada9045f419c77543ebe0416c3cdfc5b063448343417a3e4a72123",
-                "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
-            },
-            {
                 "coord": "aopalliance:aopalliance:1.0",
                 "dependencies": [],
                 "directDependencies": [],
@@ -36,16 +21,19 @@
                 "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
             },
             {
-                "coord": "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
+                "coord": "aopalliance:aopalliance:jar:sources:1.0",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar"
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "1c61bbfa809570805843aef0a91280698172ab6bd91126e76a68cf099aebdd70",
-                "url": "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
+                ],
+                "sha256": "e6ef91d439ada9045f419c77543ebe0416c3cdfc5b063448343417a3e4a72123",
+                "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
             },
             {
                 "coord": "com.eclipsesource.minimal-json:minimal-json:0.9.5",
@@ -60,16 +48,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
+                "coord": "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar"
                 ],
-                "sha256": "32362fd5b64e79143215da37f883dc7b589aea188b7d88601c1102005acc7b9f",
-                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar"
+                "sha256": "1c61bbfa809570805843aef0a91280698172ab6bd91126e76a68cf099aebdd70",
+                "url": "https://repo.maven.apache.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5-sources.jar"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
@@ -84,16 +72,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
+                "coord": "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar"
                 ],
-                "sha256": "68c6cea3770d2a7660e4ec0ceac41fd0e95b9e0595f50db8471b2030d76213c7",
-                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar"
+                "sha256": "32362fd5b64e79143215da37f883dc7b589aea188b7d88601c1102005acc7b9f",
+                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10-sources.jar"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-core:2.9.10",
@@ -108,22 +96,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10.jar"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
-                "dependencies": [
-                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10"
-                ],
-                "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar",
+                "coord": "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar"
                 ],
-                "sha256": "722eeb286133e7e54e5612c7557571e68e9d53b4e706b0df3017b2ae3ca41a50",
-                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar"
+                "sha256": "68c6cea3770d2a7660e4ec0ceac41fd0e95b9e0595f50db8471b2030d76213c7",
+                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.10/jackson-core-2.9.10-sources.jar"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-databind:2.9.10.1",
@@ -144,19 +126,22 @@
                 "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1.jar"
             },
             {
-                "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "javax.inject:javax.inject"
+                "coord": "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                "dependencies": [
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar"
                 ],
-                "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
-                "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+                "sha256": "722eeb286133e7e54e5612c7557571e68e9d53b4e706b0df3017b2ae3ca41a50",
+                "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.1/jackson-databind-2.9.10.1-sources.jar"
             },
             {
                 "coord": "com.google.code.findbugs:jsr305:3.0.2",
@@ -172,6 +157,21 @@
                 ],
                 "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
                 "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+            },
+            {
+                "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+                ],
+                "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
+                "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
             },
             {
                 "coord": "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
@@ -206,21 +206,6 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/code/google-collections/google-collect/snapshot-20080530/google-collect-snapshot-20080530.jar"
             },
             {
-                "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
-                ],
-                "sha256": "626adccd4894bee72c3f9a0384812240dcc1282fb37a87a3f6cb94924a089496",
-                "url": "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
-            },
-            {
                 "coord": "com.google.errorprone:error_prone_annotations:2.2.0",
                 "dependencies": [],
                 "directDependencies": [],
@@ -236,19 +221,19 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
             },
             {
-                "coord": "com.google.guava:failureaccess:jar:sources:1.0.1",
+                "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
                     "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
                 ],
-                "sha256": "092346eebbb1657b51aa7485a246bf602bb464cc0b0e2e1c7e7201fadce1e98f",
-                "url": "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
+                "sha256": "626adccd4894bee72c3f9a0384812240dcc1282fb37a87a3f6cb94924a089496",
+                "url": "https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
             },
             {
                 "coord": "com.google.guava:failureaccess:1.0.1",
@@ -263,32 +248,19 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
             },
             {
-                "coord": "com.google.guava:guava:jar:sources:27.0.1-jre",
-                "dependencies": [
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                "coord": "com.google.guava:failureaccess:jar:sources:1.0.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.inject:javax.inject"
                 ],
-                "directDependencies": [
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
                 ],
-                "sha256": "cba2e5680186062f42998b895a5e9a9ceccbaab94644ccc9f35bb73c2b2c7d8e",
-                "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
+                "sha256": "092346eebbb1657b51aa7485a246bf602bb464cc0b0e2e1c7e7201fadce1e98f",
+                "url": "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
             },
             {
                 "coord": "com.google.guava:guava:27.0.1-jre",
@@ -322,6 +294,34 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre.jar"
             },
             {
+                "coord": "com.google.guava:guava:jar:sources:27.0.1-jre",
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                ],
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
+                ],
+                "sha256": "cba2e5680186062f42998b895a5e9a9ceccbaab94644ccc9f35bb73c2b2c7d8e",
+                "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre-sources.jar"
+            },
+            {
                 "coord": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
                 "dependencies": [],
                 "directDependencies": [],
@@ -332,6 +332,30 @@
                 ],
                 "sha256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
                 "url": "https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+            },
+            {
+                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": null
+            },
+            {
+                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": null
+            },
+            {
+                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": null
             },
             {
                 "coord": "com.google.inject:guice:jar:no_aop:4.2.0",
@@ -381,18 +405,6 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/inject/guice/4.2.0/guice-4.2.0-sources.jar"
             },
             {
-                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
-                ],
-                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f",
-                "url": "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
-            },
-            {
                 "coord": "com.google.j2objc:j2objc-annotations:1.1",
                 "dependencies": [],
                 "directDependencies": [],
@@ -408,26 +420,16 @@
                 "url": "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
             },
             {
-                "coord": "commons-cli:commons-cli:jar:sources:1.4",
+                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "commons-lang:commons-lang",
-                    "commons-logging:commons-logging",
-                    "javax.inject:javax.inject",
-                    "org.sonatype.plexus:plexus-cipher",
-                    "org.apache.maven.wagon:wagon-provider-api",
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:jsr250-api",
-                    "org.sonatype.plexus:plexus-sec-dispatcher"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
                 ],
-                "sha256": "59fd9d6ca09ade4f27bddd274fb842ea48fd92118a755d0a64cf60413cd1c3fc",
-                "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar"
+                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f",
+                "url": "https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
             },
             {
                 "coord": "commons-cli:commons-cli:1.4",
@@ -452,21 +454,26 @@
                 "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
             },
             {
-                "coord": "commons-codec:commons-codec:jar:sources:1.9",
+                "coord": "commons-cli:commons-cli:jar:sources:1.4",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
+                    "commons-lang:commons-lang",
                     "commons-logging:commons-logging",
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject",
+                    "org.sonatype.plexus:plexus-cipher",
+                    "org.apache.maven.wagon:wagon-provider-api",
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:jsr250-api",
+                    "org.sonatype.plexus:plexus-sec-dispatcher"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar",
-                    "https://repo.spring.io/plugins-release/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar"
+                    "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar"
                 ],
-                "sha256": "9b675502f73a7a78c4ba543a68a448649875203d5be2281c94eb31dbee426f2c",
-                "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar"
+                "sha256": "59fd9d6ca09ade4f27bddd274fb842ea48fd92118a755d0a64cf60413cd1c3fc",
+                "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar"
             },
             {
                 "coord": "commons-codec:commons-codec:1.9",
@@ -486,16 +493,21 @@
                 "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar"
             },
             {
-                "coord": "commons-io:commons-io:jar:sources:2.5",
+                "coord": "commons-codec:commons-codec:jar:sources:1.9",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
-                    "https://repo.spring.io/plugins-release/commons-io/commons-io/2.5/commons-io-2.5-sources.jar"
+                "exclusions": [
+                    "commons-logging:commons-logging",
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "3b69b518d9a844732e35509b79e499fca63a960ee4301b1c96dc32e87f3f60a1",
-                "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar",
+                    "https://repo.spring.io/plugins-release/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar"
+                ],
+                "sha256": "9b675502f73a7a78c4ba543a68a448649875203d5be2281c94eb31dbee426f2c",
+                "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar"
             },
             {
                 "coord": "commons-io:commons-io:2.5",
@@ -510,24 +522,16 @@
                 "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar"
             },
             {
-                "coord": "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                "dependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.34.Final"
-                ],
-                "directDependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.34.Final"
-                ],
-                "exclusions": [
-                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar",
+                "coord": "commons-io:commons-io:jar:sources:2.5",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
+                    "https://repo.spring.io/plugins-release/commons-io/commons-io/2.5/commons-io-2.5-sources.jar"
                 ],
-                "sha256": "3fec61ea984e4342ef74221afe9bc597303e3b79dc6b345a55e9dc4f401aa04b",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar"
+                "sha256": "3b69b518d9a844732e35509b79e499fca63a960ee4301b1c96dc32e87f3f60a1",
+                "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar"
             },
             {
                 "coord": "io.netty:netty-buffer:4.1.34.Final",
@@ -550,33 +554,24 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final.jar"
             },
             {
-                "coord": "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
+                "coord": "io.netty:netty-buffer:jar:sources:4.1.34.Final",
                 "dependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
+                    "io.netty:netty-common:jar:sources:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
+                    "io.netty:netty-common:jar:sources:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "6a0f59f867fdbf4495d1659dde883504df0c5c84f625cb4030870ecb0e19a9b2",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar"
+                "sha256": "3fec61ea984e4342ef74221afe9bc597303e3b79dc6b345a55e9dc4f401aa04b",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.34.Final/netty-buffer-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.netty:netty-codec-http:4.1.34.Final",
@@ -608,29 +603,33 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final.jar"
             },
             {
-                "coord": "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                "coord": "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
                 "dependencies": [
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
                     "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
                     "io.netty:netty-resolver:jar:sources:4.1.34.Final",
                     "io.netty:netty-transport:jar:sources:4.1.34.Final"
                 ],
                 "directDependencies": [
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
                     "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
                     "io.netty:netty-transport:jar:sources:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "e28e65623bdb8469007992adb40dce76931554c4786f9d9a22f6a10017362f68",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar"
+                "sha256": "6a0f59f867fdbf4495d1659dde883504df0c5c84f625cb4030870ecb0e19a9b2",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.34.Final/netty-codec-http-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.netty:netty-codec:4.1.34.Final",
@@ -658,20 +657,29 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final.jar"
             },
             {
-                "coord": "io.netty:netty-common:jar:sources:4.1.34.Final",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                "dependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
+                ],
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
+                ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "0944a5875f7c6852433e265310cc5227dae14e7238ac3d2ba86f2f4405dda542",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar"
+                "sha256": "e28e65623bdb8469007992adb40dce76931554c4786f9d9a22f6a10017362f68",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.34.Final/netty-codec-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.netty:netty-common:4.1.34.Final",
@@ -690,31 +698,20 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final.jar"
             },
             {
-                "coord": "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                "dependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
-                ],
-                "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
-                ],
+                "coord": "io.netty:netty-common:jar:sources:4.1.34.Final",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "135fec6fa77276aa63e1b7dca0e57beec2460c83fa255cad4a54ac48f6ed3f52",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar"
+                "sha256": "0944a5875f7c6852433e265310cc5227dae14e7238ac3d2ba86f2f4405dda542",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.34.Final/netty-common-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.netty:netty-handler:4.1.34.Final",
@@ -744,24 +741,31 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final.jar"
             },
             {
-                "coord": "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                "coord": "io.netty:netty-handler:jar:sources:4.1.34.Final",
                 "dependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.34.Final"
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-common:jar:sources:4.1.34.Final"
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "18a187179cccd3edbb3489c680699467cee8cd2acd0b8e14f9c304e5b2df9290",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar"
+                "sha256": "135fec6fa77276aa63e1b7dca0e57beec2460c83fa255cad4a54ac48f6ed3f52",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.34.Final/netty-handler-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.netty:netty-resolver:4.1.34.Final",
@@ -784,28 +788,24 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final.jar"
             },
             {
-                "coord": "io.netty:netty-transport:jar:sources:4.1.34.Final",
+                "coord": "io.netty:netty-resolver:jar:sources:4.1.34.Final",
                 "dependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final"
+                    "io.netty:netty-common:jar:sources:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final"
+                    "io.netty:netty-common:jar:sources:4.1.34.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "99f390a5767cb3eabc5e7519d7b50c7dba434a9d77f3fe670ee4fac6f3c38b86",
-                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar"
+                "sha256": "18a187179cccd3edbb3489c680699467cee8cd2acd0b8e14f9c304e5b2df9290",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.34.Final/netty-resolver-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.netty:netty-transport:4.1.34.Final",
@@ -832,26 +832,28 @@
                 "url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final.jar"
             },
             {
-                "coord": "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
+                "coord": "io.netty:netty-transport:jar:sources:4.1.34.Final",
                 "dependencies": [
-                    "org.jboss:jandex:jar:sources:2.1.2.Final",
-                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
-                    "org.ow2.asm:asm-tree:jar:sources:7.1",
-                    "org.ow2.asm:asm-util:jar:sources:7.1",
-                    "org.ow2.asm:asm:jar:sources:7.1"
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final"
                 ],
                 "directDependencies": [
-                    "org.jboss:jandex:jar:sources:2.1.2.Final",
-                    "org.ow2.asm:asm-util:jar:sources:7.1",
-                    "org.ow2.asm:asm:jar:sources:7.1"
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar",
+                "exclusions": [
+                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar"
                 ],
-                "sha256": "76c5ce46505e293d9b82ec21cb50a100869b3cc2e945cabfef9a25215e643932",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar"
+                "sha256": "99f390a5767cb3eabc5e7519d7b50c7dba434a9d77f3fe670ee4fac6f3c38b86",
+                "url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.34.Final/netty-transport-4.1.34.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus.gizmo:gizmo:1.0.0.Final",
@@ -876,34 +878,26 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
+                "coord": "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
                 "dependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
+                    "org.jboss:jandex:jar:sources:2.1.2.Final",
+                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
+                    "org.ow2.asm:asm-tree:jar:sources:7.1",
+                    "org.ow2.asm:asm-util:jar:sources:7.1",
+                    "org.ow2.asm:asm:jar:sources:7.1"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
+                    "org.jboss:jandex:jar:sources:2.1.2.Final",
+                    "org.ow2.asm:asm-util:jar:sources:7.1",
+                    "org.ow2.asm:asm:jar:sources:7.1"
                 ],
-                "exclusions": [
-                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar"
                 ],
-                "sha256": "d708e9a0ac36e14fa84d024c281e0b97ea8177780e566d59d727239f95650457",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar"
+                "sha256": "76c5ce46505e293d9b82ec21cb50a100869b3cc2e945cabfef9a25215e643932",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/gizmo/gizmo/1.0.0.Final/gizmo-1.0.0.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-core:3.0.0.Beta1",
@@ -936,27 +930,34 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
+                "coord": "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
                 "dependencies": [
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
                     "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
                 ],
                 "directDependencies": [
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar"
                 ],
-                "sha256": "9cd637f426281a11e2bb3851ff8253873c2d502a3eb4e67e50670df40890c38d",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar"
+                "sha256": "d708e9a0ac36e14fa84d024c281e0b97ea8177780e566d59d727239f95650457",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-core/3.0.0.Beta1/quarkus-http-core-3.0.0.Beta1-sources.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-http-core:3.0.0.Beta1",
@@ -982,35 +983,27 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
+                "coord": "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
                 "dependencies": [
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
                     "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final"
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final"
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar"
                 ],
-                "sha256": "583e3340b92e480bca80786c2a20d945b1f6c44ab4aa65fb5e047eb3d2618dfe",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar"
+                "sha256": "9cd637f426281a11e2bb3851ff8253873c2d502a3eb4e67e50670df40890c38d",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-http-core/3.0.0.Beta1/quarkus-http-http-core-3.0.0.Beta1-sources.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
@@ -1044,7 +1037,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1.jar"
             },
             {
-                "coord": "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
+                "coord": "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
                 "dependencies": [
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
                     "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
@@ -1055,25 +1048,24 @@
                     "io.netty:netty-transport:jar:sources:4.1.34.Final",
                     "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
                     "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final"
                 ],
                 "directDependencies": [
                     "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1"
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final"
                 ],
                 "exclusions": [
                     "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
                     "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar"
                 ],
-                "sha256": "a169489122bf54069d9a8a6ea0881ad1c94a7154b64e32e65c787c6efd9c3c37",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar"
+                "sha256": "583e3340b92e480bca80786c2a20d945b1f6c44ab4aa65fb5e047eb3d2618dfe",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-servlet/3.0.0.Beta1/quarkus-http-servlet-3.0.0.Beta1-sources.jar"
             },
             {
                 "coord": "io.quarkus.http:quarkus-http-websockets-jsr:3.0.0.Beta1",
@@ -1108,6 +1100,50 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1.jar"
             },
             {
+                "coord": "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
+                "dependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final"
+                ],
+                "directDependencies": [
+                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1"
+                ],
+                "exclusions": [
+                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar"
+                ],
+                "sha256": "a169489122bf54069d9a8a6ea0881ad1c94a7154b64e32e65c787c6efd9c3c37",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/http/quarkus-http-websockets-jsr/3.0.0.Beta1/quarkus-http-websockets-jsr-3.0.0.Beta1-sources.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-bom-descriptor-json:1.0.1.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": null
+            },
+            {
+                "coord": "io.quarkus:quarkus-bom-descriptor-json:jar:sources:1.0.1.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": null
+            },
+            {
                 "coord": "io.quarkus:quarkus-bom-descriptor-json:json:1.0.1.Final",
                 "dependencies": [],
                 "directDependencies": [],
@@ -1120,89 +1156,10 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bom-descriptor-json/1.0.1.Final/quarkus-bom-descriptor-json-1.0.1.Final.json"
             },
             {
-                "coord": "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                "dependencies": [
-                    "aopalliance:aopalliance:jar:sources:1.0",
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
-                    "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.inject:guice:jar:sources:4.2.0",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "commons-cli:commons-cli:jar:sources:1.4",
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
-                ],
-                "directDependencies": [
-                    "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
-                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
-                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
-                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar"
-                ],
-                "sha256": "3a77f05f10dcfb69ebeced7f934cdc5ec67e3b3cc6a932cff412942b2fb5793d",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar"
+                "coord": "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": null
             },
             {
                 "coord": "io.quarkus:quarkus-bootstrap-core:1.0.1.Final",
@@ -1290,47 +1247,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
-                ],
-                "sha256": "39f64e99da753c96f498516c22be51db997b869efbfb15413898438d58dde6ca",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-builder:1.0.1.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
-                ],
-                "sha256": "d2a712894dad4b5217c0d05609e6e29a0715addc8df4c9286d11482589043c41",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
@@ -1343,11 +1260,6 @@
                     "commons-cli:commons-cli:jar:sources:1.4",
                     "commons-codec:commons-codec:jar:sources:1.9",
                     "commons-io:commons-io:jar:sources:2.5",
-                    "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
-                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
-                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
                     "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
                     "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
@@ -1386,44 +1298,78 @@
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
                     "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.jboss:jandex:jar:sources:2.1.2.Final",
                     "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
-                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
-                    "org.ow2.asm:asm-tree:jar:sources:7.1",
-                    "org.ow2.asm:asm-util:jar:sources:7.1",
-                    "org.ow2.asm:asm:jar:sources:7.1",
                     "org.slf4j:slf4j-api:jar:sources:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                ],
+                "directDependencies": [
+                    "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
+                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
+                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar"
+                ],
+                "sha256": "3a77f05f10dcfb69ebeced7f934cdc5ec67e3b3cc6a932cff412942b2fb5793d",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-bootstrap-core/1.0.1.Final/quarkus-bootstrap-core-1.0.1.Final-sources.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-builder:1.0.1.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
+                ],
+                "sha256": "d2a712894dad4b5217c0d05609e6e29a0715addc8df4c9286d11482589043c41",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
                     "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
-                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
-                    "org.jboss:jandex:jar:sources:2.1.2.Final",
-                    "org.ow2.asm:asm:jar:sources:7.1",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
                     "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "aecadf1b6ab8da026e299a7cbace89dd0fd04c0376c8e4ea65742d18cabbca37",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar"
+                "sha256": "39f64e99da753c96f498516c22be51db997b869efbfb15413898438d58dde6ca",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/1.0.1.Final/quarkus-builder-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-core-deployment:1.0.1.Final",
@@ -1522,95 +1468,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
-                "dependencies": [
-                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
-                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
-                ],
-                "sha256": "7a06ddd062aad6e7b781d898336659bfcf66c7448cb8f31944e0d92128b28831",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-core:1.0.1.Final",
-                "dependencies": [
-                    "io.smallrye:smallrye-config:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
-                    "jakarta.el:jakarta.el-api:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
-                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "io.smallrye:smallrye-config:1.3.9",
-                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:1.0",
-                    "org.graalvm.sdk:graal-sdk:19.2.1",
-                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
-                    "org.jboss.logging:jboss-logging:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
-                    "org.jboss.threads:jboss-threads:3.0.0.Final",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.wildfly.common:wildfly-common:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
-                ],
-                "sha256": "6b046557b9680bb04522e15f2d45a720c9d0207fc10d804aa916c5f5dd45f9ed",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
-            },
-            {
-                "coord": "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
@@ -1626,7 +1484,6 @@
                     "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
                     "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
                     "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
                     "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
                     "io.smallrye:smallrye-config:jar:sources:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
@@ -1689,15 +1546,110 @@
                     "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final"
+                    "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
+                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss:jandex:jar:sources:2.1.2.Final",
+                    "org.ow2.asm:asm:jar:sources:7.1",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "ed851b32ae87803eb4e9471373d4fe5052112fbba87707d10a5a9998f11d5435",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar"
+                "sha256": "aecadf1b6ab8da026e299a7cbace89dd0fd04c0376c8e4ea65742d18cabbca37",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core-deployment/1.0.1.Final/quarkus-core-deployment-1.0.1.Final-sources.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-core:1.0.1.Final",
+                "dependencies": [
+                    "io.smallrye:smallrye-config:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:3.2.6",
+                    "jakarta.el:jakarta.el-api:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
+                    "jakarta.transaction:jakarta.transaction-api:1.3.2",
+                    "org.eclipse.microprofile.config:microprofile-config-api:1.3",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.osgi:org.osgi.annotation.versioning:1.0.0",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "io.smallrye:smallrye-config:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:1.3.5",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:1.0",
+                    "org.graalvm.sdk:graal-sdk:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:3.0.0.Final",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.wildfly.common:wildfly-common:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
+                ],
+                "sha256": "6b046557b9680bb04522e15f2d45a720c9d0207fc10d804aa916c5f5dd45f9ed",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final.jar"
+            },
+            {
+                "coord": "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
+                "dependencies": [
+                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
+                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
+                ],
+                "sha256": "7a06ddd062aad6e7b781d898336659bfcf66c7448cb8f31944e0d92128b28831",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-core/1.0.1.Final/quarkus-core-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-creator:1.0.1.Final",
@@ -1790,7 +1742,7 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
@@ -1869,16 +1821,15 @@
                     "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4"
+                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "12580ce3ee3627641ca6eabbdf2dd2dcd3637e9bb75203f940eadfa6a78bfd3f",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar"
+                "sha256": "ed851b32ae87803eb4e9471373d4fe5052112fbba87707d10a5a9998f11d5435",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-creator/1.0.1.Final/quarkus-creator-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-development-mode:1.0.1.Final",
@@ -1972,45 +1923,50 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.inject:guice:jar:sources:4.2.0",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "commons-cli:commons-cli:jar:sources:1.4",
+                    "commons-codec:commons-codec:jar:sources:1.9",
                     "commons-io:commons-io:jar:sources:2.5",
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
-                    "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
+                    "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
+                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
+                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
                     "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
                     "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
                     "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
                     "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
                     "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                    "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
                     "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
-                    "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
                     "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
                     "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
                     "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
                     "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
                     "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
@@ -2018,34 +1974,44 @@
                     "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
                     "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
+                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.jboss:jandex:jar:sources:2.1.2.Final",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
+                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
+                    "org.ow2.asm:asm-tree:jar:sources:7.1",
+                    "org.ow2.asm:asm-util:jar:sources:7.1",
+                    "org.ow2.asm:asm:jar:sources:7.1",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
-                    "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
-                    "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
-                    "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4"
+                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "109f6ac934b62abad1f3a61c0b5e5e7795fe4252a837868ab3ce2b5d0e168806",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar"
+                "sha256": "12580ce3ee3627641ca6eabbdf2dd2dcd3637e9bb75203f940eadfa6a78bfd3f",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-development-mode/1.0.1.Final/quarkus-development-mode-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-devtools-common:1.0.1.Final",
@@ -2124,23 +2090,12 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-maven-plugin:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
-                    "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
-                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.inject:guice:jar:sources:4.2.0",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "commons-cli:commons-cli:jar:sources:1.4",
-                    "commons-codec:commons-codec:jar:sources:1.9",
                     "commons-io:commons-io:jar:sources:2.5",
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
                     "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
@@ -2149,23 +2104,11 @@
                     "io.netty:netty-handler:jar:sources:4.1.34.Final",
                     "io.netty:netty-resolver:jar:sources:4.1.34.Final",
                     "io.netty:netty-transport:jar:sources:4.1.34.Final",
-                    "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
                     "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
-                    "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
                     "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
-                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
                     "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
                     "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
                     "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
@@ -2177,30 +2120,15 @@
                     "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
                     "javax.annotation:jsr250-api:jar:sources:1.0",
                     "javax.enterprise:cdi-api:jar:sources:1.0",
-                    "jline:jline:jar:sources:2.14.6",
-                    "junit:junit:jar:sources:3.8.2",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
                     "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
-                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                    "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
                     "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
                     "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
                     "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
                     "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
@@ -2208,71 +2136,34 @@
                     "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
-                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
                     "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
                     "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
                     "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.freemarker:freemarker:jar:sources:2.3.28",
-                    "org.glassfish:jakarta.json:jar:sources:1.1.6",
-                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
-                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
                     "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
-                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                    "org.jboss:jandex:jar:sources:2.1.2.Final",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
-                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
-                    "org.ow2.asm:asm-tree:jar:sources:7.1",
-                    "org.ow2.asm:asm-util:jar:sources:7.1",
-                    "org.ow2.asm:asm:jar:sources:7.1",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2",
-                    "org.twdata.maven:mojo-executor:jar:sources:2.3.0",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
                 ],
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
-                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
+                    "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
+                    "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
                     "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jline:jline:jar:sources:2.14.6",
-                    "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
-                    "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
+                    "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
+                    "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
                     "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
-                    "org.freemarker:freemarker:jar:sources:2.3.28",
-                    "org.glassfish:jakarta.json:jar:sources:1.1.6",
-                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
-                    "org.twdata.maven:mojo-executor:jar:sources:2.3.0"
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "fb3c2c27d7dfeb6e820f9f1aadb30d4f136bdedc4773a000db5002d863a0ceb0",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar"
+                "sha256": "109f6ac934b62abad1f3a61c0b5e5e7795fe4252a837868ab3ce2b5d0e168806",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devtools-common/1.0.1.Final/quarkus-devtools-common-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-maven-plugin:1.0.1.Final",
@@ -2426,22 +2317,155 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-maven-plugin:jar:sources:1.0.1.Final",
                 "dependencies": [
+                    "aopalliance:aopalliance:jar:sources:1.0",
+                    "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
+                    "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.inject:guice:jar:sources:4.2.0",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "commons-cli:commons-cli:jar:sources:1.4",
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
+                    "io.quarkus.gizmo:gizmo:jar:sources:1.0.0.Final",
+                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
+                    "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-builder:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-core-deployment:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-core:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
+                    "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
+                    "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
+                    "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "jline:jline:jar:sources:2.14.6",
+                    "junit:junit:jar:sources:3.8.2",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                    "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
+                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                    "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
+                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                    "org.freemarker:freemarker:jar:sources:2.3.28",
+                    "org.glassfish:jakarta.json:jar:sources:1.1.6",
+                    "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
+                    "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
+                    "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                    "org.jboss:jandex:jar:sources:2.1.2.Final",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
+                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
+                    "org.ow2.asm:asm-tree:jar:sources:7.1",
+                    "org.ow2.asm:asm-util:jar:sources:7.1",
+                    "org.ow2.asm:asm:jar:sources:7.1",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2",
+                    "org.twdata.maven:mojo-executor:jar:sources:2.3.0",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-model:jar:sources:3.5.4"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-creator:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-development-mode:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jline:jline:jar:sources:2.14.6",
+                    "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
+                    "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
+                    "org.freemarker:freemarker:jar:sources:2.3.28",
+                    "org.glassfish:jakarta.json:jar:sources:1.1.6",
+                    "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                    "org.twdata.maven:mojo-executor:jar:sources:2.3.0"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "df4cca0675bf9a36bb6bfcd83ce0b4be04d1d0d381b10bb754b50705978fe4d9",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar"
+                "sha256": "fb3c2c27d7dfeb6e820f9f1aadb30d4f136bdedc4773a000db5002d863a0ceb0",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-maven-plugin/1.0.1.Final/quarkus-maven-plugin-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-platform-descriptor-api:1.0.1.Final",
@@ -2462,102 +2486,22 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
                 "dependencies": [
-                    "aopalliance:aopalliance:jar:sources:1.0",
-                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0.1",
-                    "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.inject:guice:jar:sources:4.2.0",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "commons-cli:commons-cli:jar:sources:1.4",
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
-                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
-                    "io.netty:netty-common:jar:sources:4.1.34.Final",
-                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
-                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
-                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
-                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
-                    "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
-                    "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                    "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
-                    "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
                 "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
-                    "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
-                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final"
+                    "org.apache.maven:maven-model:jar:sources:3.5.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "333c105654ba2086a31c43dd43389a96b4be8d10326098a4b245a33de5bed322",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar"
+                "sha256": "df4cca0675bf9a36bb6bfcd83ce0b4be04d1d0d381b10bb754b50705978fe4d9",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-api/1.0.1.Final/quarkus-platform-descriptor-api-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-platform-descriptor-json:1.0.1.Final",
@@ -2658,13 +2602,21 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final.jar"
             },
             {
-                "coord": "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
+                "coord": "io.quarkus:quarkus-platform-descriptor-json:jar:sources:1.0.1.Final",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
-                    "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0.1",
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.inject:guice:jar:sources:4.2.0",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "commons-cli:commons-cli:jar:sources:1.4",
+                    "commons-codec:commons-codec:jar:sources:1.9",
                     "commons-io:commons-io:jar:sources:2.5",
                     "io.netty:netty-buffer:jar:sources:4.1.34.Final",
                     "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
@@ -2677,6 +2629,8 @@
                     "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
                     "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
+                    "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
                     "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
                     "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
                     "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
@@ -2691,14 +2645,23 @@
                     "javax.annotation:jsr250-api:jar:sources:1.0",
                     "javax.enterprise:cdi-api:jar:sources:1.0",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
                     "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
                     "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
                     "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
                     "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-embedder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
                     "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
@@ -2706,29 +2669,35 @@
                     "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
                     "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
                     "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                    "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
                     "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
                     "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
                     "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
                 ],
                 "directDependencies": [
-                    "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
-                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                    "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-bootstrap-core:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "02d662cc0b1ac2586ca0e993128bbc87135846326de6ad6efa994dd8297fe5dd",
-                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar"
+                "sha256": "333c105654ba2086a31c43dd43389a96b4be8d10326098a4b245a33de5bed322",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-json/1.0.1.Final/quarkus-platform-descriptor-json-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.quarkus:quarkus-platform-descriptor-resolver-json:1.0.1.Final",
@@ -2804,27 +2773,77 @@
                 "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final.jar"
             },
             {
-                "coord": "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                "coord": "io.quarkus:quarkus-platform-descriptor-resolver-json:jar:sources:1.0.1.Final",
                 "dependencies": [
-                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "aopalliance:aopalliance:jar:sources:1.0",
+                    "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.1",
+                    "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "com.google.inject:guice:jar:sources:4.2.0",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "io.netty:netty-buffer:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.34.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.34.Final",
+                    "io.netty:netty-common:jar:sources:4.1.34.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.34.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.34.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.34.Final",
+                    "io.quarkus.http:quarkus-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-http-core:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-servlet:jar:sources:3.0.0.Beta1",
+                    "io.quarkus.http:quarkus-http-websockets-jsr:jar:sources:3.0.0.Beta1",
+                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
+                    "io.quarkus:quarkus-platform-descriptor-api:jar:sources:1.0.1.Final",
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                    "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
+                    "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
+                    "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0"
+                    "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
                 ],
                 "directDependencies": [
-                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "com.eclipsesource.minimal-json:minimal-json:jar:sources:0.9.5",
+                    "io.quarkus:quarkus-devtools-common:jar:sources:1.0.1.Final",
                     "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
                 ],
-                "exclusions": [
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:javax.annotation-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar",
-                    "https://repo.spring.io/plugins-release/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar"
+                    "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar"
                 ],
-                "sha256": "880fa5c82efd82623e5b5eeb15e7711980b668558d70db22b88bcd9568155ba7",
-                "url": "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar"
+                "sha256": "02d662cc0b1ac2586ca0e993128bbc87135846326de6ad6efa994dd8297fe5dd",
+                "url": "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-platform-descriptor-resolver-json/1.0.1.Final/quarkus-platform-descriptor-resolver-json-1.0.1.Final-sources.jar"
             },
             {
                 "coord": "io.smallrye:smallrye-config:1.3.9",
@@ -2850,16 +2869,27 @@
                 "url": "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar"
             },
             {
-                "coord": "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
+                "coord": "io.smallrye:smallrye-config:jar:sources:1.3.9",
+                "dependencies": [
+                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0"
                 ],
-                "sha256": "aa27e9291dce4ddbb0aea52a1cbef41c6330b96b0ae387a995ed412b68a3af7c",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
+                "directDependencies": [
+                    "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
+                ],
+                "exclusions": [
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:javax.annotation-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar",
+                    "https://repo.spring.io/plugins-release/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar"
+                ],
+                "sha256": "880fa5c82efd82623e5b5eeb15e7711980b668558d70db22b88bcd9568155ba7",
+                "url": "https://repo.maven.apache.org/maven2/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9-sources.jar"
             },
             {
                 "coord": "jakarta.annotation:jakarta.annotation-api:1.3.5",
@@ -2874,20 +2904,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
             },
             {
-                "coord": "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                "dependencies": [
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
-                ],
-                "directDependencies": [
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar",
+                "coord": "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
                 ],
-                "sha256": "e2256d3df53bc3fe1a9e726469d25f347e91f56920b8e267de594a239d4c1605",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar"
+                "sha256": "aa27e9291dce4ddbb0aea52a1cbef41c6330b96b0ae387a995ed412b68a3af7c",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
             },
             {
                 "coord": "jakarta.ejb:jakarta.ejb-api:3.2.6",
@@ -2906,16 +2932,20 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar"
             },
             {
-                "coord": "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar"
+                "coord": "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                "dependencies": [
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
                 ],
-                "sha256": "ee72302151cef144fe5fae6b2adb6fa5a4616e50ac5b9d6d6836a621fb82c82d",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar"
+                "directDependencies": [
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar"
+                ],
+                "sha256": "e2256d3df53bc3fe1a9e726469d25f347e91f56920b8e267de594a239d4c1605",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6-sources.jar"
             },
             {
                 "coord": "jakarta.el:jakarta.el-api:3.0.3",
@@ -2930,27 +2960,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar"
             },
             {
-                "coord": "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
-                "dependencies": [
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
-                ],
-                "directDependencies": [
-                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
-                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar",
+                "coord": "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar"
                 ],
-                "sha256": "d993e2dde6b473ebf5188b0e9be65ab216842a3ba66b252f08bc4a45dc82fd58",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar"
+                "sha256": "ee72302151cef144fe5fae6b2adb6fa5a4616e50ac5b9d6d6836a621fb82c82d",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3-sources.jar"
             },
             {
                 "coord": "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2",
@@ -2976,16 +2995,27 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar"
             },
             {
-                "coord": "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar"
+                "coord": "jakarta.enterprise:jakarta.enterprise.cdi-api:jar:sources:2.0.2",
+                "dependencies": [
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
                 ],
-                "sha256": "205e0bf93c0db3dc774b79c720d082e5ee02a2b38bb1b42a0336ef1a9897cb3a",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar"
+                "directDependencies": [
+                    "jakarta.el:jakarta.el-api:jar:sources:3.0.3",
+                    "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                    "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar"
+                ],
+                "sha256": "d993e2dde6b473ebf5188b0e9be65ab216842a3ba66b252f08bc4a45dc82fd58",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2-sources.jar"
             },
             {
                 "coord": "jakarta.inject:jakarta.inject-api:1.0",
@@ -3000,23 +3030,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar"
             },
             {
-                "coord": "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
-                "dependencies": [
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
-                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
-                ],
-                "directDependencies": [
-                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
-                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar",
+                "coord": "jakarta.inject:jakarta.inject-api:jar:sources:1.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar"
                 ],
-                "sha256": "4a9dd38a6590ba63370ed1854a01893f94e73d9c666f3ecaddcb716f6e8de5f5",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar"
+                "sha256": "205e0bf93c0db3dc774b79c720d082e5ee02a2b38bb1b42a0336ef1a9897cb3a",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0-sources.jar"
             },
             {
                 "coord": "jakarta.interceptor:jakarta.interceptor-api:1.2.5",
@@ -3038,16 +3061,23 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar"
             },
             {
-                "coord": "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar"
+                "coord": "jakarta.interceptor:jakarta.interceptor-api:jar:sources:1.2.5",
+                "dependencies": [
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6",
+                    "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2"
                 ],
-                "sha256": "8643aae750a34a7fa3f543e5e0bcdaeb7d12ae75f5267d535efacaa5bc06f7f7",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar"
+                "directDependencies": [
+                    "jakarta.annotation:jakarta.annotation-api:jar:sources:1.3.5",
+                    "jakarta.ejb:jakarta.ejb-api:jar:sources:3.2.6"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar"
+                ],
+                "sha256": "4a9dd38a6590ba63370ed1854a01893f94e73d9c666f3ecaddcb716f6e8de5f5",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5-sources.jar"
             },
             {
                 "coord": "jakarta.servlet:jakarta.servlet-api:4.0.3",
@@ -3062,16 +3092,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar"
             },
             {
-                "coord": "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
+                "coord": "jakarta.servlet:jakarta.servlet-api:jar:sources:4.0.3",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar"
                 ],
-                "sha256": "316e0ae1242a3826cc1e2d75ebd343553ffc7a98bee087ac9d8da32bf9fe7fc8",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar"
+                "sha256": "8643aae750a34a7fa3f543e5e0bcdaeb7d12ae75f5267d535efacaa5bc06f7f7",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3-sources.jar"
             },
             {
                 "coord": "jakarta.transaction:jakarta.transaction-api:1.3.2",
@@ -3086,16 +3116,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar"
             },
             {
-                "coord": "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
+                "coord": "jakarta.transaction:jakarta.transaction-api:jar:sources:1.3.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar"
                 ],
-                "sha256": "c66adcb71ea4d8a1d3e75b9b21edc8ad14f90b8abf0ab1f6689564c0e8ed2fa9",
-                "url": "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar"
+                "sha256": "316e0ae1242a3826cc1e2d75ebd343553ffc7a98bee087ac9d8da32bf9fe7fc8",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2-sources.jar"
             },
             {
                 "coord": "jakarta.websocket:jakarta.websocket-api:1.1.2",
@@ -3110,23 +3140,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar"
             },
             {
-                "coord": "javax.annotation:jsr250-api:jar:sources:1.0",
+                "coord": "jakarta.websocket:jakarta.websocket-api:jar:sources:1.1.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "javax.el:el-api",
-                    "org.jboss.ejb3:jboss-ejb3-api",
-                    "org.jboss.interceptor:jboss-interceptor-api",
-                    "log4j:log4j",
-                    "commons-logging:commons-logging-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar"
                 ],
-                "sha256": "025c47d76c60199381be07012a0c5f9e74661aac5bd67f5aec847741c5b7f838",
-                "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
+                "sha256": "c66adcb71ea4d8a1d3e75b9b21edc8ad14f90b8abf0ab1f6689564c0e8ed2fa9",
+                "url": "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2-sources.jar"
             },
             {
                 "coord": "javax.annotation:jsr250-api:1.0",
@@ -3147,15 +3170,9 @@
                 "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
             },
             {
-                "coord": "javax.enterprise:cdi-api:jar:sources:1.0",
-                "dependencies": [
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.inject:javax.inject:jar:sources:1"
-                ],
-                "directDependencies": [
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.inject:javax.inject:jar:sources:1"
-                ],
+                "coord": "javax.annotation:jsr250-api:jar:sources:1.0",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
                     "javax.el:el-api",
                     "org.jboss.ejb3:jboss-ejb3-api",
@@ -3163,13 +3180,13 @@
                     "log4j:log4j",
                     "commons-logging:commons-logging-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
                 ],
-                "sha256": "0e7c351dfe05759f84dc3eddaac1da4ef72578b494b53338829d34b12271374f",
-                "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
+                "sha256": "025c47d76c60199381be07012a0c5f9e74661aac5bd67f5aec847741c5b7f838",
+                "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0-sources.jar"
             },
             {
                 "coord": "javax.enterprise:cdi-api:1.0",
@@ -3200,19 +3217,29 @@
                 "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
             },
             {
-                "coord": "javax.inject:javax.inject:jar:sources:1",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "javax.enterprise:cdi-api:jar:sources:1.0",
+                "dependencies": [
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.inject:javax.inject:jar:sources:1"
+                ],
+                "directDependencies": [
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.inject:javax.inject:jar:sources:1"
+                ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "javax.el:el-api",
+                    "org.jboss.ejb3:jboss-ejb3-api",
+                    "org.jboss.interceptor:jboss-interceptor-api",
+                    "log4j:log4j",
+                    "commons-logging:commons-logging-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
-                    "https://repo.spring.io/plugins-release/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
                 ],
-                "sha256": "c4b87ee2911c139c3daf498a781967f1eb2e75bc1a8529a2e7b328a15d0e433e",
-                "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
+                "sha256": "0e7c351dfe05759f84dc3eddaac1da4ef72578b494b53338829d34b12271374f",
+                "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0-sources.jar"
             },
             {
                 "coord": "javax.inject:javax.inject:1",
@@ -3234,16 +3261,19 @@
                 "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar"
             },
             {
-                "coord": "jline:jline:jar:sources:2.14.6",
+                "coord": "javax.inject:javax.inject:jar:sources:1",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar",
-                    "https://repo.spring.io/plugins-release/jline/jline/2.14.6/jline-2.14.6-sources.jar"
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
                 ],
-                "sha256": "319a840705e1e46abe579dd3d079b508558791e0236bc78da01911748e06af93",
-                "url": "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar",
+                    "https://repo.spring.io/plugins-release/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
+                ],
+                "sha256": "c4b87ee2911c139c3daf498a781967f1eb2e75bc1a8529a2e7b328a15d0e433e",
+                "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
             },
             {
                 "coord": "jline:jline:2.14.6",
@@ -3258,20 +3288,16 @@
                 "url": "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar"
             },
             {
-                "coord": "junit:junit:jar:sources:3.8.2",
+                "coord": "jline:jline:jar:sources:2.14.6",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/junit/junit/3.8.2/junit-3.8.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar",
+                    "https://repo.spring.io/plugins-release/jline/jline/2.14.6/jline-2.14.6-sources.jar"
                 ],
-                "sha256": "79048799144171122d10f8f57bbaf542389e5452a7210c2636000548e984078a",
-                "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar"
+                "sha256": "319a840705e1e46abe579dd3d079b508558791e0236bc78da01911748e06af93",
+                "url": "https://repo.maven.apache.org/maven2/jline/jline/2.14.6/jline-2.14.6-sources.jar"
             },
             {
                 "coord": "junit:junit:3.8.2",
@@ -3290,19 +3316,20 @@
                 "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar"
             },
             {
-                "coord": "org.apache.commons:commons-lang3:jar:sources:3.9",
+                "coord": "junit:junit:jar:sources:3.8.2",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "javax.inject:javax.inject"
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar"
+                    "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/junit/junit/3.8.2/junit-3.8.2-sources.jar"
                 ],
-                "sha256": "d97341ce0a7554028db3403e407bb51f4d902bf3287f64f709d7a8156eaf1910",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar"
+                "sha256": "79048799144171122d10f8f57bbaf542389e5452a7210c2636000548e984078a",
+                "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2-sources.jar"
             },
             {
                 "coord": "org.apache.commons:commons-lang3:3.9",
@@ -3320,27 +3347,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
             },
             {
-                "coord": "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6"
-                ],
-                "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6"
-                ],
+                "coord": "org.apache.commons:commons-lang3:jar:sources:3.9",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "commons-logging:commons-logging",
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar"
                 ],
-                "sha256": "6475ea5ce5bce787f88f449c4d29dc8cafbeba9f172683fcad15c2e4b5e2ed84",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar"
+                "sha256": "d97341ce0a7554028db3403e407bb51f4d902bf3287f64f709d7a8156eaf1910",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar"
             },
             {
                 "coord": "org.apache.httpcomponents:httpclient:4.5.3",
@@ -3366,21 +3385,27 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar"
             },
             {
-                "coord": "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6"
+                ],
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6"
+                ],
                 "exclusions": [
+                    "commons-logging:commons-logging",
                     "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar"
                 ],
-                "sha256": "292895822468716a4b8c65b07f9e45c8a9ff9946aa5407c883f5f455d09cdf9e",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar"
+                "sha256": "6475ea5ce5bce787f88f449c4d29dc8cafbeba9f172683fcad15c2e4b5e2ed84",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar"
             },
             {
                 "coord": "org.apache.httpcomponents:httpcore:4.4.6",
@@ -3398,6 +3423,701 @@
                 ],
                 "sha256": "d7f853dee87680b07293d30855b39b9eb56c1297bd16ff1cd6f19ddb8fa745fb",
                 "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar"
+            },
+            {
+                "coord": "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar"
+                ],
+                "sha256": "292895822468716a4b8c65b07f9e45c8a9ff9946aa5407c883f5f455d09cdf9e",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
+                ],
+                "sha256": "a4ce03467f0c47615c53533ad1682fe00b8170f760e7ed0c57f5afc3035fe38b",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
+                ],
+                "sha256": "d6f618875c02e12f4b64e173c2a3897306694b0c4f613567907be2d0e906c7fa",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
+                ],
+                "sha256": "5efa36fa5e8f14be6013301fcba012aa8dc651fea886ab9f902a4122a7debb93",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
+                ],
+                "sha256": "bb8ecdb9ac7715873b0a316351adf96d31641647ef42f26feefd211177426756",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
+                ],
+                "sha256": "6c8adfb6415b46e31f399132e5d8d0faee3443b7493ba709746ce2614d2acf97",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
+                ],
+                "sha256": "6dd833726534cae3b0ba6ddae2b6899917b77ddd8cacd1dd0cda0d24755cd19d",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
+                ],
+                "sha256": "8b686318f0675719afd6a97d6856d498ea554bd7da6522b6798d94d235e74c16",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
+                ],
+                "sha256": "4efe32a8c8517bace826a5d91fa2b65d8ca35d90f8ecb92981c1ad37806fe680",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
+                ],
+                "sha256": "c45247527daa9536f5fb31b3063dd456d41543d06490fec040fc37da5c88a4af",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
+                ],
+                "sha256": "6a0c64f62be47314bba1f0aa3dd49cb26f8debe730642bce2f2cb5f29fef8944",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-util:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
+                ],
+                "sha256": "040e6bb13a34bc3fd721e9256784e996d2700a518476c6f9801c112699320208",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                "dependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
+                ],
+                "sha256": "db5556b7023f3c4dc8a26c6c0700defd9b9da64a9b8ae2b113b7bdf54adc4de8",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
+                "dependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
+                ],
+                "sha256": "6f919f97c9272263fa910cfe7fa88595982a0451e7d7b121cca8ac85f6162882",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
+                "dependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
+                ],
+                "sha256": "ee55923f7ca080f751e49b0a9751c32c1d36068467a6bad7ccfe5db7719348ae",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
+                "dependencies": [
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven:maven-core:3.5.4",
+                    "org.apache.maven:maven-plugin-api:3.5.4",
+                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
+                ],
+                "sha256": "b291bd2d46ecd42ba26938a78ec053eedb240e5a3eef3ffc82c46ecafa95c306",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
+                "dependencies": [
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
+                ],
+                "directDependencies": [
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
+                ],
+                "exclusions": [
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
+                ],
+                "sha256": "562a67e2888d6f70379d89f7c78b3226dd26c5b5e77c8554c6854f9001dc8d18",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-invoker:3.0.1",
+                "dependencies": [
+                    "commons-io:commons-io:2.5",
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
+                ],
+                "sha256": "d20e5d26c19c04199c73fd4f0b6caebf4bbdc6b872a4504c5e71a192751d9464",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
+                "dependencies": [
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
+                ],
+                "sha256": "94b766c063bf6345faa571ada4bd19fd4804ff2354ea6779d5894b3e37c7afa7",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-shared-utils:3.2.1",
+                "dependencies": [
+                    "commons-io:commons-io:2.5"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:2.5"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+                ],
+                "sha256": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+            },
+            {
+                "coord": "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                "dependencies": [
+                    "commons-io:commons-io:jar:sources:2.5"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:jar:sources:2.5"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
+                ],
+                "sha256": "25064c72c178a98335048d0f7c3e08839e949426bc92bf905ea964146235f388",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-file:3.0.0",
+                "dependencies": [
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
+                ],
+                "sha256": "63324036899559f94154e6f845e62453a1f202c1b21b80060f2d88a05a05a272",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
+                ],
+                "sha256": "4481a2ab7ceca66e57401d3d3528c095dac22dc7ce7e67124a19cc172da30d74",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:1.9",
+                    "commons-io:commons-io:2.5",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:2.5",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
+                ],
+                "sha256": "40c51265b3ed90b6919c08dcdf3620dc614894ef60bacdf4c34bdbe295b44c49",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "directDependencies": [
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
+                ],
+                "sha256": "399e420f09b69e34b53897affd2723c06a133f6e9dbff68d74b3e55498c7a83a",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:1.9",
+                    "commons-io:commons-io:2.5",
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.jsoup:jsoup:1.7.2",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.apache.httpcomponents:httpclient:4.5.3",
+                    "org.apache.httpcomponents:httpcore:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
+                ],
+                "sha256": "9f68fed6684c2245a62d5d3c8b4954b882562797e96b15ce0f18514c543fb999",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.9",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.jsoup:jsoup:jar:sources:1.7.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple",
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
+                ],
+                "sha256": "1b16a3eb55393e2c96184f0222d644675d5b439d0ed00ea4100bebbd8f8eaa22",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-provider-api:3.0.0",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
+                ],
+                "sha256": "04de4d2f39178998ef3ce5f6d91a358363ad3f5270e897d5547321ea69fa2992",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
+            },
+            {
+                "coord": "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
+                ],
+                "sha256": "c356c99bad5f0e8e99203e2e5b3c83ab5eafe0bd80e3346f7dfbe1fce94c9bb6",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven:maven-artifact:3.5.4",
+                "dependencies": [
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
+                ],
+                "sha256": "6fbf25de86cce3afbaf5c502dff57df6d7c90cf9bec0ae0ffe5ab2467243c35b",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-artifact:jar:sources:3.5.4",
@@ -3423,25 +4143,23 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-artifact:3.5.4",
+                "coord": "org.apache.maven:maven-builder-support:3.5.4",
                 "dependencies": [
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.commons:commons-lang3:3.9"
                 ],
                 "directDependencies": [
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.commons:commons-lang3:3.9"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
                 ],
-                "sha256": "6fbf25de86cce3afbaf5c502dff57df6d7c90cf9bec0ae0ffe5ab2467243c35b",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.5.4/maven-artifact-3.5.4.jar"
+                "sha256": "43855ce29fc8001ef663a5bb2bb0473481b1f8f80cea7b3cc1d426af996960b2",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
@@ -3462,56 +4180,6 @@
                 ],
                 "sha256": "3d283bcfc1f73430e787c9d69caa94b848b874209eed2f07c5900c3af0de1a71",
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-builder-support:3.5.4",
-                "dependencies": [
-                    "org.apache.commons:commons-lang3:3.9"
-                ],
-                "directDependencies": [
-                    "org.apache.commons:commons-lang3:3.9"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
-                ],
-                "sha256": "43855ce29fc8001ef663a5bb2bb0473481b1f8f80cea7b3cc1d426af996960b2",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.5.4/maven-builder-support-3.5.4.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
-                "dependencies": [
-                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
-                    "junit:junit:jar:sources:3.8.2",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar"
-                ],
-                "sha256": "d46ed2dbf42dcc12108e9510b84a5ba1dde2c43aa99be44b1b558a73dd22d7b9",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-compat:3.0-alpha-2",
@@ -3545,74 +4213,35 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2.jar"
             },
             {
-                "coord": "org.apache.maven:maven-core:jar:sources:3.5.4",
+                "coord": "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
                 "dependencies": [
-                    "aopalliance:aopalliance:jar:sources:1.0",
-                    "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "com.google.inject:guice:jar:sources:4.2.0",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
-                    "javax.inject:javax.inject:jar:sources:1",
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
+                    "junit:junit:jar:sources:3.8.2",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
                     "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
                 "directDependencies": [
-                    "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "com.google.inject:guice:jar:sources:4.2.0",
-                    "javax.inject:javax.inject:jar:sources:1",
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
-                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3"
+                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar"
                 ],
-                "sha256": "5b80f1c7189639aec67ceacac7755d2a2c7e95a1ed896477a4efff358ebabf08",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar"
+                "sha256": "d46ed2dbf42dcc12108e9510b84a5ba1dde2c43aa99be44b1b558a73dd22d7b9",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0-alpha-2/maven-compat-3.0-alpha-2-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-core:3.5.4",
@@ -3685,13 +4314,15 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4.jar"
             },
             {
-                "coord": "org.apache.maven:maven-embedder:jar:sources:3.5.4",
+                "coord": "org.apache.maven:maven-core:jar:sources:3.5.4",
                 "dependencies": [
                     "aopalliance:aopalliance:jar:sources:1.0",
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
                     "com.google.inject:guice:jar:sources:4.2.0",
-                    "commons-cli:commons-cli:jar:sources:1.4",
                     "commons-io:commons-io:jar:sources:2.5",
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "javax.inject:javax.inject:jar:sources:1",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
                     "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
@@ -3700,7 +4331,6 @@
                     "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
                     "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
                     "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
                     "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
@@ -3714,44 +4344,44 @@
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
                     "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
                     "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
                 ],
                 "directDependencies": [
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
                     "com.google.inject:guice:jar:sources:4.2.0",
-                    "commons-cli:commons-cli:jar:sources:1.4",
+                    "javax.inject:javax.inject:jar:sources:1",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
                     "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
                     "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
                     "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
+                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
                     "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
                     "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-settings:jar:sources:3.5.4",
                     "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3"
                 ],
                 "exclusions": [
-                    "javax.inject:javax.inject",
-                    "org.sonatype.plexus:plexus-cipher",
-                    "org.apache.maven.wagon:wagon-provider-api",
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:jsr250-api",
-                    "org.sonatype.plexus:plexus-sec-dispatcher"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar"
                 ],
-                "sha256": "79f6eadfbc55f28f4bea2e3d76a1dfe5095e168e00014084e2ef9f22bbb6f1be",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar"
+                "sha256": "5b80f1c7189639aec67ceacac7755d2a2c7e95a1ed896477a4efff358ebabf08",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.5.4/maven-core-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-embedder:3.5.4",
@@ -3822,37 +4452,73 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4.jar"
             },
             {
-                "coord": "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                "coord": "org.apache.maven:maven-embedder:jar:sources:3.5.4",
                 "dependencies": [
+                    "aopalliance:aopalliance:jar:sources:1.0",
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "com.google.inject:guice:jar:sources:4.2.0",
+                    "commons-cli:commons-cli:jar:sources:1.4",
+                    "commons-io:commons-io:jar:sources:2.5",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
                     "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
+                    "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
                 ],
                 "directDependencies": [
                     "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "com.google.inject:guice:jar:sources:4.2.0",
+                    "commons-cli:commons-cli:jar:sources:1.4",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
                     "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "javax.inject:javax.inject",
+                    "org.sonatype.plexus:plexus-cipher",
+                    "org.apache.maven.wagon:wagon-provider-api",
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:jsr250-api",
+                    "org.sonatype.plexus:plexus-sec-dispatcher"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar"
                 ],
-                "sha256": "c54b66772a2be78bf1f280627fb374745f82ffefbdeb5d6c45ee494a22af4197",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar"
+                "sha256": "79f6eadfbc55f28f4bea2e3d76a1dfe5095e168e00014084e2ef9f22bbb6f1be",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-embedder/3.5.4/maven-embedder-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-model-builder:3.5.4",
@@ -3888,6 +4554,57 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4.jar"
             },
             {
+                "coord": "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                "dependencies": [
+                    "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "directDependencies": [
+                    "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar"
+                ],
+                "sha256": "c54b66772a2be78bf1f280627fb374745f82ffefbdeb5d6c45ee494a22af4197",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.5.4/maven-model-builder-3.5.4-sources.jar"
+            },
+            {
+                "coord": "org.apache.maven:maven-model:3.5.4",
+                "dependencies": [
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "directDependencies": [
+                    "org.apache.commons:commons-lang3:3.9",
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
+                ],
+                "sha256": "5ec1b94e9254c25480548633a48b7ae8a9ada7527e28f5c575943fe0c2ab7350",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
+            },
+            {
                 "coord": "org.apache.maven:maven-model:jar:sources:3.5.4",
                 "dependencies": [
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
@@ -3910,22 +4627,36 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-model:3.5.4",
+                "coord": "org.apache.maven:maven-plugin-api:3.5.4",
                 "dependencies": [
+                    "javax.annotation:jsr250-api:1.0",
+                    "javax.enterprise:cdi-api:1.0",
                     "org.apache.commons:commons-lang3:3.9",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
                 ],
                 "directDependencies": [
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
+                    "org.apache.maven:maven-artifact:3.5.4",
+                    "org.apache.maven:maven-model:3.5.4",
+                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
+                    "org.codehaus.plexus:plexus-utils:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
                 ],
-                "sha256": "5ec1b94e9254c25480548633a48b7ae8a9ada7527e28f5c575943fe0c2ab7350",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.5.4/maven-model-3.5.4.jar"
+                "sha256": "6ef2f5977d400f636f86dafd2321bad6e230787321238e0bd206d553eb4d2406",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
@@ -3962,36 +4693,23 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4-sources.jar"
             },
             {
-                "coord": "org.apache.maven:maven-plugin-api:3.5.4",
+                "coord": "org.apache.maven:maven-repository-metadata:3.5.4",
                 "dependencies": [
-                    "javax.annotation:jsr250-api:1.0",
-                    "javax.enterprise:cdi-api:1.0",
-                    "org.apache.commons:commons-lang3:3.9",
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-artifact:3.5.4",
-                    "org.apache.maven:maven-model:3.5.4",
-                    "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3"
+                    "org.codehaus.plexus:plexus-utils:3.1.0"
                 ],
                 "exclusions": [
                     "javax.inject:javax.inject"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
                 ],
-                "sha256": "6ef2f5977d400f636f86dafd2321bad6e230787321238e0bd206d553eb4d2406",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.5.4/maven-plugin-api-3.5.4.jar"
+                "sha256": "159d4f7ebe63c0bbc81144c865ea4bf1bd0add710b5725964ac22bea3c53b803",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
             },
             {
                 "coord": "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
@@ -4012,68 +4730,6 @@
                 ],
                 "sha256": "967eead04058fe54fce38e9b972bfbb2e83c727de17070011cc0412af8fd4ef5",
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-repository-metadata:3.5.4",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
-                ],
-                "sha256": "159d4f7ebe63c0bbc81144c865ea4bf1bd0add710b5725964ac22bea3c53b803",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.5.4/maven-repository-metadata-3.5.4.jar"
-            },
-            {
-                "coord": "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
-                "dependencies": [
-                    "com.google.guava:guava:jar:sources:27.0.1-jre",
-                    "javax.inject:javax.inject:jar:sources:1",
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "javax.inject:javax.inject:jar:sources:1",
-                    "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar"
-                ],
-                "sha256": "3174c174d35da70b92f0fc983c6fd92e1617a77feafc1cb833674f14897f792a",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-resolver-provider:3.5.4",
@@ -4119,33 +4775,47 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4.jar"
             },
             {
-                "coord": "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
+                "coord": "org.apache.maven:maven-resolver-provider:jar:sources:3.5.4",
                 "dependencies": [
+                    "com.google.guava:guava:jar:sources:27.0.1-jre",
+                    "javax.inject:javax.inject:jar:sources:1",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                    "org.apache.maven:maven-artifact:jar:sources:3.5.4",
                     "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
                     "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
                 "directDependencies": [
+                    "javax.inject:javax.inject:jar:sources:1",
                     "org.apache.commons:commons-lang3:jar:sources:3.9",
-                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
-                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
+                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
+                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
+                    "org.apache.maven:maven-model-builder:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-repository-metadata:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar"
                 ],
-                "sha256": "e08658d03c721221d76b5f5e7b0a7a1f0ba19a6788a83198600733f52cdcbd71",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
+                "sha256": "3174c174d35da70b92f0fc983c6fd92e1617a77feafc1cb833674f14897f792a",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-resolver-provider/3.5.4/maven-resolver-provider-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-settings-builder:3.5.4",
@@ -4180,20 +4850,33 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4.jar"
             },
             {
-                "coord": "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                "coord": "org.apache.maven:maven-settings-builder:jar:sources:3.5.4",
                 "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
                 ],
                 "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.apache.maven:maven-builder-support:jar:sources:3.5.4",
+                    "org.apache.maven:maven-settings:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
                 ],
-                "sha256": "0e27222242ee3e41763e8cdc3d1785b1bfc50f3cc842dfb3f00b45e463a4d4ff",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
+                "sha256": "e08658d03c721221d76b5f5e7b0a7a1f0ba19a6788a83198600733f52cdcbd71",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.5.4/maven-settings-builder-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-settings:3.5.4",
@@ -4219,35 +4902,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4.jar"
             },
             {
-                "coord": "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
+                "coord": "org.apache.maven:maven-settings:jar:sources:3.5.4",
                 "dependencies": [
-                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
-                    "junit:junit:jar:sources:3.8.2",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4"
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
                 ],
-                "sha256": "58c79ff3191f2e48977bc5e1ce34f1b99c21f8d147941b9b7f5ce59d25313a54",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar"
+                "sha256": "0e27222242ee3e41763e8cdc3d1785b1bfc50f3cc842dfb3f00b45e463a4d4ff",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.5.4/maven-settings-3.5.4-sources.jar"
             },
             {
                 "coord": "org.apache.maven:maven-toolchain:3.0-alpha-2",
@@ -4281,677 +4949,35 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar"
             },
             {
-                "coord": "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
-                ],
-                "sha256": "d6f618875c02e12f4b64e173c2a3897306694b0c4f613567907be2d0e906c7fa",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
-                ],
-                "sha256": "a4ce03467f0c47615c53533ad1682fe00b8170f760e7ed0c57f5afc3035fe38b",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.1.1/maven-resolver-api-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:jar:sources:1.1.1",
+                "coord": "org.apache.maven:maven-toolchain:jar:sources:3.0-alpha-2",
                 "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
-                ],
-                "sha256": "bb8ecdb9ac7715873b0a316351adf96d31641647ef42f26feefd211177426756",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-connector-basic:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
-                ],
-                "sha256": "5efa36fa5e8f14be6013301fcba012aa8dc651fea886ab9f902a4122a7debb93",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/1.1.1/maven-resolver-connector-basic-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-impl:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "javax.inject:javax.inject"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
-                ],
-                "sha256": "6dd833726534cae3b0ba6ddae2b6899917b77ddd8cacd1dd0cda0d24755cd19d",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-impl:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
-                ],
-                "sha256": "6c8adfb6415b46e31f399132e5d8d0faee3443b7493ba709746ce2614d2acf97",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-impl/1.1.1/maven-resolver-impl-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
-                ],
-                "sha256": "4efe32a8c8517bace826a5d91fa2b65d8ca35d90f8ecb92981c1ad37806fe680",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
-                ],
-                "sha256": "8b686318f0675719afd6a97d6856d498ea554bd7da6522b6798d94d235e74c16",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-spi/1.1.1/maven-resolver-spi-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:jar:sources:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
-                ],
-                "sha256": "6a0c64f62be47314bba1f0aa3dd49cb26f8debe730642bce2f2cb5f29fef8944",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-transport-wagon:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-spi:1.1.1",
-                    "org.apache.maven.resolver:maven-resolver-util:1.1.1"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
-                ],
-                "sha256": "c45247527daa9536f5fb31b3063dd456d41543d06490fec040fc37da5c88a4af",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-wagon/1.1.1/maven-resolver-transport-wagon-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-util:jar:sources:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:jar:sources:1.1.1"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
-                ],
-                "sha256": "db5556b7023f3c4dc8a26c6c0700defd9b9da64a9b8ae2b113b7bdf54adc4de8",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.resolver:maven-resolver-util:1.1.1",
-                "dependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.resolver:maven-resolver-api:1.1.1"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
-                ],
-                "sha256": "040e6bb13a34bc3fd721e9256784e996d2700a518476c6f9801c112699320208",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.1.1/maven-resolver-util-1.1.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-artifact-transfer:jar:sources:0.10.0",
-                "dependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25",
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
-                ],
-                "sha256": "ee55923f7ca080f751e49b0a9751c32c1d36068467a6bad7ccfe5db7719348ae",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-artifact-transfer:0.10.0",
-                "dependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
-                ],
-                "sha256": "6f919f97c9272263fa910cfe7fa88595982a0451e7d7b121cca8ac85f6162882",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-common-artifact-filters:jar:sources:3.0.1",
-                "dependencies": [
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
-                    "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
-                ],
-                "sha256": "562a67e2888d6f70379d89f7c78b3226dd26c5b5e77c8554c6854f9001dc8d18",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-common-artifact-filters:3.0.1",
-                "dependencies": [
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:1.4.2",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
-                ],
-                "directDependencies": [
-                    "org.apache.maven:maven-core:3.5.4",
-                    "org.apache.maven:maven-plugin-api:3.5.4",
-                    "org.sonatype.sisu:sisu-inject-plexus:1.4.2"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
-                ],
-                "sha256": "b291bd2d46ecd42ba26938a78ec053eedb240e5a3eef3ffc82c46ecafa95c306",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-invoker:jar:sources:3.0.1",
-                "dependencies": [
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
-                ],
-                "sha256": "94b766c063bf6345faa571ada4bd19fd4804ff2354ea6779d5894b3e37c7afa7",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-invoker:3.0.1",
-                "dependencies": [
-                    "commons-io:commons-io:2.5",
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                    "org.codehaus.plexus:plexus-component-annotations:1.7.1"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
-                ],
-                "sha256": "d20e5d26c19c04199c73fd4f0b6caebf4bbdc6b872a4504c5e71a192751d9464",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.0.1/maven-invoker-3.0.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-shared-utils:jar:sources:3.2.1",
-                "dependencies": [
-                    "commons-io:commons-io:jar:sources:2.5"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:jar:sources:2.5"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
-                ],
-                "sha256": "25064c72c178a98335048d0f7c3e08839e949426bc92bf905ea964146235f388",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.shared:maven-shared-utils:3.2.1",
-                "dependencies": [
-                    "commons-io:commons-io:2.5"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:2.5"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-                ],
-                "sha256": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-file:jar:sources:3.0.0",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
-                ],
-                "sha256": "4481a2ab7ceca66e57401d3d3528c095dac22dc7ce7e67124a19cc172da30d74",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-file:3.0.0",
-                "dependencies": [
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
-                ],
-                "sha256": "63324036899559f94154e6f845e62453a1f202c1b21b80060f2d88a05a05a272",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-file/3.0.0/wagon-file-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
+                    "junit:junit:jar:sources:3.8.2",
                     "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
-                ],
-                "sha256": "399e420f09b69e34b53897affd2723c06a133f6e9dbff68d74b3e55498c7a83a",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:1.9",
-                    "commons-io:commons-io:2.5",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "commons-io:commons-io:2.5",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
-                ],
-                "sha256": "40c51265b3ed90b6919c08dcdf3620dc614894ef60bacdf4c34bdbe295b44c49",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/3.0.0/wagon-http-shared-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http:jar:sources:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.9",
-                    "commons-io:commons-io:jar:sources:2.5",
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.jsoup:jsoup:jar:sources:1.7.2",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:jar:sources:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
-                ],
-                "sha256": "1b16a3eb55393e2c96184f0222d644675d5b439d0ed00ea4100bebbd8f8eaa22",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-http:3.0.0",
-                "dependencies": [
-                    "commons-codec:commons-codec:1.9",
-                    "commons-io:commons-io:2.5",
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0",
-                    "org.jsoup:jsoup:1.7.2",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.apache.httpcomponents:httpclient:4.5.3",
-                    "org.apache.httpcomponents:httpcore:4.4.6",
-                    "org.apache.maven.wagon:wagon-http-shared:3.0.0",
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple",
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
-                ],
-                "sha256": "9f68fed6684c2245a62d5d3c8b4954b882562797e96b15ce0f18514c543fb999",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http/3.0.0/wagon-http-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-provider-api:jar:sources:3.0.0",
-                "dependencies": [
+                    "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
                 "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                    "org.apache.maven:maven-compat:jar:sources:3.0-alpha-2",
+                    "org.apache.maven:maven-core:jar:sources:3.5.4"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
-                ],
-                "sha256": "c356c99bad5f0e8e99203e2e5b3c83ab5eafe0bd80e3346f7dfbe1fce94c9bb6",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0-sources.jar"
-            },
-            {
-                "coord": "org.apache.maven.wagon:wagon-provider-api:3.0.0",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:3.1.0"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
-                ],
-                "sha256": "04de4d2f39178998ef3ce5f6d91a358363ad3f5270e897d5547321ea69fa2992",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/3.0.0/wagon-provider-api-3.0.0.jar"
-            },
-            {
-                "coord": "org.apache.xbean:xbean-reflect:jar:sources:3.4",
-                "dependencies": [],
-                "directDependencies": [],
                 "exclusions": [
                     "commons-logging:commons-logging-api",
                     "log4j:log4j"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar"
                 ],
-                "sha256": "1e6f89e8c5fc05b15a2def9b1414cac7e8c01e0b3dc25feece2bef4b67ef4de1",
-                "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar"
+                "sha256": "58c79ff3191f2e48977bc5e1ce34f1b99c21f8d147941b9b7f5ce59d25313a54",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2-sources.jar"
             },
             {
                 "coord": "org.apache.xbean:xbean-reflect:3.4",
@@ -4970,6 +4996,34 @@
                 "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
             },
             {
+                "coord": "org.apache.xbean:xbean-reflect:jar:sources:3.4",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar"
+                ],
+                "sha256": "1e6f89e8c5fc05b15a2def9b1414cac7e8c01e0b3dc25feece2bef4b67ef4de1",
+                "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar"
+            },
+            {
+                "coord": "org.checkerframework:checker-qual:2.5.2",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
+                    "https://repo.spring.io/plugins-release/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                ],
+                "sha256": "64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a",
+                "url": "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+            },
+            {
                 "coord": "org.checkerframework:checker-qual:jar:sources:2.5.2",
                 "dependencies": [],
                 "directDependencies": [],
@@ -4985,16 +5039,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
             },
             {
-                "coord": "org.checkerframework:checker-qual:2.5.2",
+                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
-                    "https://repo.spring.io/plugins-release/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                "exclusions": [
+                    "javax.inject:javax.inject"
                 ],
-                "sha256": "64b02691c8b9d4e7700f8ee2e742dce7ea2c6e81e662b7522c9ee3bf568c040a",
-                "url": "https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                ],
+                "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
             },
             {
                 "coord": "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
@@ -5009,19 +5066,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
             },
             {
-                "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+                "coord": "org.codehaus.plexus:plexus-classworlds:2.5.2",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "javax.inject:javax.inject"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
                 ],
-                "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
+                "sha256": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
@@ -5040,33 +5097,6 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2-sources.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-                ],
-                "sha256": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-            },
-            {
-                "coord": "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar"
-                ],
-                "sha256": "18999359e8c1c5eb1f17a06093ceffc21f84b62b4ee0d9ab82f2e10d11049a78",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar"
-            },
-            {
                 "coord": "org.codehaus.plexus:plexus-component-annotations:1.7.1",
                 "dependencies": [],
                 "directDependencies": [],
@@ -5079,32 +5109,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
-                "dependencies": [
-                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
-                    "junit:junit:jar:sources:3.8.2",
-                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "directDependencies": [
-                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
-                    "junit:junit:jar:sources:3.8.2",
-                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
-                ],
-                "exclusions": [
-                    "commons-logging:commons-logging-api",
-                    "log4j:log4j"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar",
+                "coord": "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar"
                 ],
-                "sha256": "b6b1985b938034df4da56717305fa342b23d1f25f957f134ba0bad181d1868d6",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar"
+                "sha256": "18999359e8c1c5eb1f17a06093ceffc21f84b62b4ee0d9ab82f2e10d11049a78",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1-sources.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-container-default:1.0-beta-3.0.5",
@@ -5135,16 +5149,32 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
+                "coord": "org.codehaus.plexus:plexus-container-default:jar:sources:1.0-beta-3.0.5",
+                "dependencies": [
+                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
+                    "junit:junit:jar:sources:3.8.2",
+                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
                 ],
-                "sha256": "0b372b91236c4a2c63dc0d6b2010e10c98b993fc8491f6a02b73052a218b6644",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
+                "directDependencies": [
+                    "com.google.code.google-collections:google-collect:jar:sources:snapshot-20080530",
+                    "junit:junit:jar:sources:3.8.2",
+                    "org.apache.xbean:xbean-reflect:jar:sources:3.4",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0"
+                ],
+                "exclusions": [
+                    "commons-logging:commons-logging-api",
+                    "log4j:log4j"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar"
+                ],
+                "sha256": "b6b1985b938034df4da56717305fa342b23d1f25f957f134ba0bad181d1868d6",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-beta-3.0.5/plexus-container-default-1.0-beta-3.0.5-sources.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-interpolation:1.24",
@@ -5162,16 +5192,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.jar"
             },
             {
-                "coord": "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                "coord": "org.codehaus.plexus:plexus-interpolation:jar:sources:1.24",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
                 ],
-                "sha256": "06eb127e188a940ebbcf340c43c95537c3052298acdc943a9b2ec2146c7238d9",
-                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
+                "sha256": "0b372b91236c4a2c63dc0d6b2010e10c98b993fc8491f6a02b73052a218b6644",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24-sources.jar"
             },
             {
                 "coord": "org.codehaus.plexus:plexus-utils:3.1.0",
@@ -5189,24 +5219,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
             },
             {
-                "coord": "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
-                "dependencies": [
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0"
-                ],
-                "directDependencies": [
-                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0"
-                ],
-                "exclusions": [
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:javax.annotation-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar",
+                "coord": "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
                 ],
-                "sha256": "af9510ac7f0eb9300447022206b7a2b6f68f8a5d6a860c6c199c57d025b4f170",
-                "url": "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar"
+                "sha256": "06eb127e188a940ebbcf340c43c95537c3052298acdc943a9b2ec2146c7238d9",
+                "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0-sources.jar"
             },
             {
                 "coord": "org.eclipse.microprofile.config:microprofile-config-api:1.3",
@@ -5229,19 +5251,24 @@
                 "url": "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar"
             },
             {
-                "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
-                "dependencies": [],
-                "directDependencies": [],
+                "coord": "org.eclipse.microprofile.config:microprofile-config-api:jar:sources:1.3",
+                "dependencies": [
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0"
+                ],
+                "directDependencies": [
+                    "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0"
+                ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:javax.annotation-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar"
                 ],
-                "sha256": "1f4d2575cb004f3fbd8e687c5dfa42d7478e1cf98e0cafa6e22dd1304cdfc6d7",
-                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
+                "sha256": "af9510ac7f0eb9300447022206b7a2b6f68f8a5d6a860c6c199c57d025b4f170",
+                "url": "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3-sources.jar"
             },
             {
                 "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3",
@@ -5263,32 +5290,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
             },
             {
-                "coord": "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
-                "dependencies": [
-                    "javax.annotation:jsr250-api:jar:sources:1.0",
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
-                ],
-                "directDependencies": [
-                    "javax.enterprise:cdi-api:jar:sources:1.0",
-                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
-                ],
+                "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "javax.inject:javax.inject"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
                 ],
-                "sha256": "349dd64dca9d0007d7037862759fd8f74c7a0a5de29cfa1cec1ae2fb25eaa49b",
-                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
+                "sha256": "1f4d2575cb004f3fbd8e687c5dfa42d7478e1cf98e0cafa6e22dd1304cdfc6d7",
+                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3-sources.jar"
             },
             {
                 "coord": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3",
@@ -5322,16 +5336,32 @@
                 "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
             },
             {
-                "coord": "org.freemarker:freemarker:jar:sources:2.3.28",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
+                "coord": "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:sources:0.3.3",
+                "dependencies": [
+                    "javax.annotation:jsr250-api:jar:sources:1.0",
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
                 ],
-                "sha256": "a855ab20a0b72d1a876f708e2c377f549d9b46527e7e5845cf3cd02dc906668d",
-                "url": "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
+                "directDependencies": [
+                    "javax.enterprise:cdi-api:jar:sources:1.0",
+                    "org.codehaus.plexus:plexus-classworlds:jar:sources:2.5.2",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:sources:0.3.3"
+                ],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
+                ],
+                "sha256": "349dd64dca9d0007d7037862759fd8f74c7a0a5de29cfa1cec1ae2fb25eaa49b",
+                "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3-sources.jar"
             },
             {
                 "coord": "org.freemarker:freemarker:2.3.28",
@@ -5346,16 +5376,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28.jar"
             },
             {
-                "coord": "org.glassfish:jakarta.json:jar:sources:1.1.6",
+                "coord": "org.freemarker:freemarker:jar:sources:2.3.28",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
                 ],
-                "sha256": "1580d5a07866922912eb2cbad8304180b84b5e4f7f47ae5303fcde4618c282fa",
-                "url": "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
+                "sha256": "a855ab20a0b72d1a876f708e2c377f549d9b46527e7e5845cf3cd02dc906668d",
+                "url": "https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.28/freemarker-2.3.28-sources.jar"
             },
             {
                 "coord": "org.glassfish:jakarta.json:1.1.6",
@@ -5370,16 +5400,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6.jar"
             },
             {
-                "coord": "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
+                "coord": "org.glassfish:jakarta.json:jar:sources:1.1.6",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
                 ],
-                "sha256": "39d6c5ebbecd48c0918bdf5e1b674e5715078f6d72df319e85663dae0fbcacca",
-                "url": "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
+                "sha256": "1580d5a07866922912eb2cbad8304180b84b5e4f7f47ae5303fcde4618c282fa",
+                "url": "https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6-sources.jar"
             },
             {
                 "coord": "org.graalvm.sdk:graal-sdk:19.2.1",
@@ -5394,47 +5424,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1.jar"
             },
             {
-                "coord": "org.jboss:jandex:jar:sources:2.1.2.Final",
+                "coord": "org.graalvm.sdk:graal-sdk:jar:sources:19.2.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
                 ],
-                "sha256": "80ce8274e5b5eeeb60f37bf2fd5504a6b509874588823a9301a25ee27a935292",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
-            },
-            {
-                "coord": "org.jboss:jandex:2.1.2.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
-                ],
-                "sha256": "d7a90668526b56e5530e71c0d9d0426043cdc10c543d1c75f660eaff0af857b7",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
-            },
-            {
-                "coord": "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
-                ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
-                ],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar"
-                ],
-                "sha256": "1e855b71b5c03590dc180ad8e01e76307648cc760a57c57dd86725dee4396b53",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar"
+                "sha256": "39d6c5ebbecd48c0918bdf5e1b674e5715078f6d72df319e85663dae0fbcacca",
+                "url": "https://repo.maven.apache.org/maven2/org/graalvm/sdk/graal-sdk/19.2.1/graal-sdk-19.2.1-sources.jar"
             },
             {
                 "coord": "org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final",
@@ -5456,16 +5455,23 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar"
             },
             {
-                "coord": "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar"
+                "coord": "org.jboss.logging:commons-logging-jboss-logging:jar:sources:1.0.0.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
                 ],
-                "sha256": "3c41d85d5afced53a1a75dc641bf4f5f1d49227a7fb73c136788e333fb837d3a",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar"
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final"
+                ],
+                "exclusions": [
+                    "org.apache.maven.wagon:wagon-provider-api"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar"
+                ],
+                "sha256": "1e855b71b5c03590dc180ad8e01e76307648cc760a57c57dd86725dee4396b53",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final-sources.jar"
             },
             {
                 "coord": "org.jboss.logging:jboss-logging-annotations:2.1.0.Final",
@@ -5480,19 +5486,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final.jar"
             },
             {
-                "coord": "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                "coord": "org.jboss.logging:jboss-logging-annotations:jar:sources:2.1.0.Final",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar"
                 ],
-                "sha256": "d0ee0481be34da68dd0594461169f3636a7a244e41fbef095dcffdd3b73c011c",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar"
+                "sha256": "3c41d85d5afced53a1a75dc641bf4f5f1d49227a7fb73c136788e333fb837d3a",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging-annotations/2.1.0.Final/jboss-logging-annotations-2.1.0.Final-sources.jar"
             },
             {
                 "coord": "org.jboss.logging:jboss-logging:3.4.0.Final",
@@ -5510,25 +5513,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final.jar"
             },
             {
-                "coord": "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
-                "dependencies": [
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "directDependencies": [
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
+                "coord": "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "com.oracle.substratevm:svm",
-                    "org.jboss.modules:jboss-modules",
-                    "org.glassfish:javax.json"
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar"
                 ],
-                "sha256": "968284f7028196db1e588c3e39379cd6c602bcd560facc3e7b6f40a4b2cc82e9",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar"
+                "sha256": "d0ee0481be34da68dd0594461169f3636a7a244e41fbef095dcffdd3b73c011c",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.4.0.Final/jboss-logging-3.4.0.Final-sources.jar"
             },
             {
                 "coord": "org.jboss.logmanager:jboss-logmanager-embedded:1.0.4",
@@ -5552,22 +5549,25 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4.jar"
             },
             {
-                "coord": "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                "coord": "org.jboss.logmanager:jboss-logmanager-embedded:jar:sources:1.0.4",
                 "dependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
                 "directDependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar",
+                "exclusions": [
+                    "com.oracle.substratevm:svm",
+                    "org.jboss.modules:jboss-modules",
+                    "org.glassfish:javax.json"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar"
                 ],
-                "sha256": "d3951b5a01e03bf80f69e03c7c7933317eaf9d1fa4fd75b2a671ff6db4c6b58a",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar"
+                "sha256": "968284f7028196db1e588c3e39379cd6c602bcd560facc3e7b6f40a4b2cc82e9",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager-embedded/1.0.4/jboss-logmanager-embedded-1.0.4-sources.jar"
             },
             {
                 "coord": "org.jboss.slf4j:slf4j-jboss-logging:1.2.0.Final",
@@ -5588,20 +5588,22 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final.jar"
             },
             {
-                "coord": "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
+                "coord": "org.jboss.slf4j:slf4j-jboss-logging:jar:sources:1.2.0.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar",
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar"
                 ],
-                "sha256": "aa2e016438d6723f19a7bfd9863cb1c83b673dfb42f30d254c8444e22a655829",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar"
+                "sha256": "d3951b5a01e03bf80f69e03c7c7933317eaf9d1fa4fd75b2a671ff6db4c6b58a",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/slf4j/slf4j-jboss-logging/1.2.0.Final/slf4j-jboss-logging-1.2.0.Final-sources.jar"
             },
             {
                 "coord": "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final",
@@ -5620,22 +5622,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final.jar"
             },
             {
-                "coord": "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
-                "dependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                "coord": "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:sources:1.0.2.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+                    "org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec"
                 ],
-                "directDependencies": [
-                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
-                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar"
                 ],
-                "sha256": "faf7e8cb66e762520d97b5fa465386982fa97c797c061b579b36897250328323",
-                "url": "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar"
+                "sha256": "aa2e016438d6723f19a7bfd9863cb1c83b673dfb42f30d254c8444e22a655829",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/1.0.2.Final/jboss-annotations-api_1.2_spec-1.0.2.Final-sources.jar"
             },
             {
                 "coord": "org.jboss.threads:jboss-threads:3.0.0.Final",
@@ -5656,16 +5656,46 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final.jar"
             },
             {
-                "coord": "org.json:json:jar:sources:20190722",
+                "coord": "org.jboss.threads:jboss-threads:jar:sources:3.0.0.Final",
+                "dependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "directDependencies": [
+                    "org.jboss.logging:jboss-logging:jar:sources:3.4.0.Final",
+                    "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar"
+                ],
+                "sha256": "faf7e8cb66e762520d97b5fa465386982fa97c797c061b579b36897250328323",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/3.0.0.Final/jboss-threads-3.0.0.Final-sources.jar"
+            },
+            {
+                "coord": "org.jboss:jandex:2.1.2.Final",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/json/json/20190722/json-20190722-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
                 ],
-                "sha256": "80cc1eddb416c6ca38ed87d1995ac78927d3515c8bd5945eaf84088f37dd9322",
-                "url": "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar"
+                "sha256": "d7a90668526b56e5530e71c0d9d0426043cdc10c543d1c75f660eaff0af857b7",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final.jar"
+            },
+            {
+                "coord": "org.jboss:jandex:jar:sources:2.1.2.Final",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
+                ],
+                "sha256": "80ce8274e5b5eeeb60f37bf2fd5504a6b509874588823a9301a25ee27a935292",
+                "url": "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.1.2.Final/jandex-2.1.2.Final-sources.jar"
             },
             {
                 "coord": "org.json:json:20190722",
@@ -5680,20 +5710,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722.jar"
             },
             {
-                "coord": "org.jsoup:jsoup:jar:sources:1.7.2",
+                "coord": "org.json:json:jar:sources:20190722",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:jcl-over-slf4j",
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/json/json/20190722/json-20190722-sources.jar"
                 ],
-                "sha256": "a3b8716ba40205b03138917c39bbb6c191060990f9c730121b3e5f18f1144747",
-                "url": "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar"
+                "sha256": "80cc1eddb416c6ca38ed87d1995ac78927d3515c8bd5945eaf84088f37dd9322",
+                "url": "https://repo.maven.apache.org/maven2/org/json/json/20190722/json-20190722-sources.jar"
             },
             {
                 "coord": "org.jsoup:jsoup:1.7.2",
@@ -5712,20 +5738,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar"
             },
             {
-                "coord": "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
+                "coord": "org.jsoup:jsoup:jar:sources:1.7.2",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "javax.enterprise:cdi-api",
-                    "javax.annotation:javax.annotation-api"
+                    "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar"
                 ],
-                "sha256": "7cb84314f59f5c0f0e38d281e87c88762dd00848158f49c4bbc7b053f789600b",
-                "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar"
+                "sha256": "a3b8716ba40205b03138917c39bbb6c191060990f9c730121b3e5f18f1144747",
+                "url": "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar"
             },
             {
                 "coord": "org.osgi:org.osgi.annotation.versioning:1.0.0",
@@ -5744,21 +5770,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar"
             },
             {
-                "coord": "org.ow2.asm:asm-analysis:jar:sources:7.1",
-                "dependencies": [
-                    "org.ow2.asm:asm-tree:jar:sources:7.1",
-                    "org.ow2.asm:asm:jar:sources:7.1"
+                "coord": "org.osgi:org.osgi.annotation.versioning:jar:sources:1.0.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "javax.enterprise:cdi-api",
+                    "javax.annotation:javax.annotation-api"
                 ],
-                "directDependencies": [
-                    "org.ow2.asm:asm-tree:jar:sources:7.1"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar"
                 ],
-                "sha256": "fa6f39cac9e13165afec17d96507c087e4c904a174b1951b8bda7f1d38b74728",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar"
+                "sha256": "7cb84314f59f5c0f0e38d281e87c88762dd00848158f49c4bbc7b053f789600b",
+                "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0-sources.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-analysis:7.1",
@@ -5778,20 +5803,21 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1.jar"
             },
             {
-                "coord": "org.ow2.asm:asm-tree:jar:sources:7.1",
+                "coord": "org.ow2.asm:asm-analysis:jar:sources:7.1",
                 "dependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:7.1",
                     "org.ow2.asm:asm:jar:sources:7.1"
                 ],
                 "directDependencies": [
-                    "org.ow2.asm:asm:jar:sources:7.1"
+                    "org.ow2.asm:asm-tree:jar:sources:7.1"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar"
                 ],
-                "sha256": "5633ad585cd60358acbd2b1c1fae6f2195a3d34e0b95b80033aaf3a932a16d4d",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar"
+                "sha256": "fa6f39cac9e13165afec17d96507c087e4c904a174b1951b8bda7f1d38b74728",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.1/asm-analysis-7.1-sources.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-tree:7.1",
@@ -5810,24 +5836,20 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1.jar"
             },
             {
-                "coord": "org.ow2.asm:asm-util:jar:sources:7.1",
+                "coord": "org.ow2.asm:asm-tree:jar:sources:7.1",
                 "dependencies": [
-                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
-                    "org.ow2.asm:asm-tree:jar:sources:7.1",
                     "org.ow2.asm:asm:jar:sources:7.1"
                 ],
                 "directDependencies": [
-                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
-                    "org.ow2.asm:asm-tree:jar:sources:7.1",
                     "org.ow2.asm:asm:jar:sources:7.1"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar"
                 ],
-                "sha256": "b856a99f878bca99950abfd937d7c7b090c859fee792125b3e301593c263a8c6",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar"
+                "sha256": "5633ad585cd60358acbd2b1c1fae6f2195a3d34e0b95b80033aaf3a932a16d4d",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.1/asm-tree-7.1-sources.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-util:7.1",
@@ -5850,16 +5872,24 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1.jar"
             },
             {
-                "coord": "org.ow2.asm:asm:jar:sources:7.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm/7.1/asm-7.1-sources.jar"
+                "coord": "org.ow2.asm:asm-util:jar:sources:7.1",
+                "dependencies": [
+                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
+                    "org.ow2.asm:asm-tree:jar:sources:7.1",
+                    "org.ow2.asm:asm:jar:sources:7.1"
                 ],
-                "sha256": "c1297c6d395d40f9f7c9f03d435970e174ea8df8280cbae39efae44228bbd876",
-                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar"
+                "directDependencies": [
+                    "org.ow2.asm:asm-analysis:jar:sources:7.1",
+                    "org.ow2.asm:asm-tree:jar:sources:7.1",
+                    "org.ow2.asm:asm:jar:sources:7.1"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar"
+                ],
+                "sha256": "b856a99f878bca99950abfd937d7c7b090c859fee792125b3e301593c263a8c6",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.1/asm-util-7.1-sources.jar"
             },
             {
                 "coord": "org.ow2.asm:asm:7.1",
@@ -5874,19 +5904,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1.jar"
             },
             {
-                "coord": "org.slf4j:slf4j-api:jar:sources:1.7.25",
+                "coord": "org.ow2.asm:asm:jar:sources:7.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "exclusions": [
-                    "org.slf4j:slf4j-simple"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/ow2/asm/asm/7.1/asm-7.1-sources.jar"
                 ],
-                "sha256": "c4bc93180a4f0aceec3b057a2514abe04a79f06c174bbed910a2afb227b79366",
-                "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+                "sha256": "c1297c6d395d40f9f7c9f03d435970e174ea8df8280cbae39efae44228bbd876",
+                "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.1/asm-7.1-sources.jar"
             },
             {
                 "coord": "org.slf4j:slf4j-api:1.7.25",
@@ -5904,19 +5931,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
             },
             {
-                "coord": "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                "coord": "org.slf4j:slf4j-api:jar:sources:1.7.25",
                 "dependencies": [],
                 "directDependencies": [],
                 "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
+                    "org.slf4j:slf4j-simple"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
                 ],
-                "sha256": "35291f96baa7d430cac96e15862e288527e08689b6f30c4f39482f19962ea540",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar"
+                "sha256": "c4bc93180a4f0aceec3b057a2514abe04a79f06c174bbed910a2afb227b79366",
+                "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
             },
             {
                 "coord": "org.sonatype.plexus:plexus-cipher:1.4",
@@ -5934,25 +5961,19 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
             },
             {
-                "coord": "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
-                "dependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4"
-                ],
-                "directDependencies": [
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4"
-                ],
+                "coord": "org.sonatype.plexus:plexus-cipher:jar:sources:1.4",
+                "dependencies": [],
+                "directDependencies": [],
                 "exclusions": [
-                    "javax.inject:javax.inject"
+                    "org.apache.maven.wagon:wagon-provider-api"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar"
                 ],
-                "sha256": "2e5de23342c1f130b0244149dee6aaae7f2d4f5ff668e329265cea08830d39c2",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar"
+                "sha256": "35291f96baa7d430cac96e15862e288527e08689b6f30c4f39482f19962ea540",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4-sources.jar"
             },
             {
                 "coord": "org.sonatype.plexus:plexus-sec-dispatcher:1.4",
@@ -5974,6 +5995,27 @@
                 ],
                 "sha256": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+            },
+            {
+                "coord": "org.sonatype.plexus:plexus-sec-dispatcher:jar:sources:1.4",
+                "dependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4"
+                ],
+                "directDependencies": [
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.sonatype.plexus:plexus-cipher:jar:sources:1.4"
+                ],
+                "exclusions": [
+                    "javax.inject:javax.inject"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar"
+                ],
+                "sha256": "2e5de23342c1f130b0244149dee6aaae7f2d4f5ff668e329265cea08830d39c2",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4-sources.jar"
             },
             {
                 "coord": "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7",
@@ -6018,29 +6060,6 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-sources.jar"
             },
             {
-                "coord": "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
-                "dependencies": [
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7"
-                ],
-                "directDependencies": [
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7"
-                ],
-                "exclusions": [
-                    "org.apache.maven:maven-artifact",
-                    "commons-codec:commons-codec",
-                    "org.codehaus.plexus:plexus-classworlds",
-                    "org.apache.maven.shared:maven-shared-utils",
-                    "org.apache.maven:maven-model"
-                ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar"
-                ],
-                "sha256": "d59b973c0c0c95ae1ef83d077cffee948ae62fedf71fd97187ce948d508b9a67",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar"
-            },
-            {
                 "coord": "org.sonatype.sisu:sisu-inject-bean:1.4.2",
                 "dependencies": [
                     "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7"
@@ -6064,17 +6083,12 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
             },
             {
-                "coord": "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2",
+                "coord": "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2",
                 "dependencies": [
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2"
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7"
                 ],
                 "directDependencies": [
-                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
-                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2"
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7"
                 ],
                 "exclusions": [
                     "org.apache.maven:maven-artifact",
@@ -6083,13 +6097,13 @@
                     "org.apache.maven.shared:maven-shared-utils",
                     "org.apache.maven:maven-model"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar"
                 ],
-                "sha256": "4638d56d002365f85a255137f572c140c5c7eeb53d131fd5f0de2573dc1a0930",
-                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar"
+                "sha256": "d59b973c0c0c95ae1ef83d077cffee948ae62fedf71fd97187ce948d508b9a67",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2-sources.jar"
             },
             {
                 "coord": "org.sonatype.sisu:sisu-inject-plexus:1.4.2",
@@ -6120,31 +6134,32 @@
                 "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
             },
             {
-                "coord": "org.twdata.maven:mojo-executor:jar:sources:2.3.0",
+                "coord": "org.sonatype.sisu:sisu-inject-plexus:jar:sources:1.4.2",
                 "dependencies": [
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                    "org.sonatype.sisu:sisu-guice:jar:sources:2.1.7",
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2"
                 ],
                 "directDependencies": [
-                    "org.apache.maven:maven-core:jar:sources:3.5.4",
-                    "org.apache.maven:maven-model:jar:sources:3.5.4",
-                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-component-annotations:jar:sources:1.7.1",
                     "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
-                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                    "org.sonatype.sisu:sisu-inject-bean:jar:sources:1.4.2"
                 ],
                 "exclusions": [
-                    "org.slf4j:slf4j-simple"
+                    "org.apache.maven:maven-artifact",
+                    "commons-codec:commons-codec",
+                    "org.codehaus.plexus:plexus-classworlds",
+                    "org.apache.maven.shared:maven-shared-utils",
+                    "org.apache.maven:maven-model"
                 ],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar",
+                "file": "v1/https/repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar"
+                    "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar"
                 ],
-                "sha256": "a4ef053f390b709303f8aacbffc458b82bb9c56982540cc9b0677f759793d5c8",
-                "url": "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar"
+                "sha256": "4638d56d002365f85a255137f572c140c5c7eeb53d131fd5f0de2573dc1a0930",
+                "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2-sources.jar"
             },
             {
                 "coord": "org.twdata.maven:mojo-executor:2.3.0",
@@ -6174,16 +6189,31 @@
                 "url": "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0.jar"
             },
             {
-                "coord": "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar",
-                "mirror_urls": [
-                    "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar",
-                    "https://repo.spring.io/plugins-release/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar"
+                "coord": "org.twdata.maven:mojo-executor:jar:sources:2.3.0",
+                "dependencies": [
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
                 ],
-                "sha256": "7cef50710671842c76999e0a974aeeb7e4568a686640893e77ad6b5eba324eef",
-                "url": "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar"
+                "directDependencies": [
+                    "org.apache.maven:maven-core:jar:sources:3.5.4",
+                    "org.apache.maven:maven-model:jar:sources:3.5.4",
+                    "org.apache.maven:maven-plugin-api:jar:sources:3.5.4",
+                    "org.codehaus.plexus:plexus-utils:jar:sources:3.1.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.25"
+                ],
+                "exclusions": [
+                    "org.slf4j:slf4j-simple"
+                ],
+                "file": "v1/https/repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar"
+                ],
+                "sha256": "a4ef053f390b709303f8aacbffc458b82bb9c56982540cc9b0677f759793d5c8",
+                "url": "https://repo.maven.apache.org/maven2/org/twdata/maven/mojo-executor/2.3.0/mojo-executor-2.3.0-sources.jar"
             },
             {
                 "coord": "org.wildfly.common:wildfly-common:1.5.0.Final",
@@ -6198,46 +6228,16 @@
                 "url": "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final.jar"
             },
             {
-                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                "coord": "org.wildfly.common:wildfly-common:jar:sources:1.5.0.Final",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": null
-            },
-            {
-                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "javax.inject:javax.inject"
+                "file": "v1/https/repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar",
+                    "https://repo.spring.io/plugins-release/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar"
                 ],
-                "file": null
-            },
-            {
-                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.apache.maven.wagon:wagon-provider-api"
-                ],
-                "file": null
-            },
-            {
-                "coord": "io.quarkus:quarkus-bom-descriptor-json:1.0.1.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": null
-            },
-            {
-                "coord": "io.quarkus:quarkus-bom-descriptor-json:jar:sources:1.0.1.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": null
-            },
-            {
-                "coord": "io.quarkus:quarkus-bom-descriptor-json:json:sources:1.0.1.Final",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": null
+                "sha256": "7cef50710671842c76999e0a974aeeb7e4568a686640893e77ad6b5eba324eef",
+                "url": "https://repo.maven.apache.org/maven2/org/wildfly/common/wildfly-common/1.5.0.Final/wildfly-common-1.5.0.Final-sources.jar"
             }
         ],
         "version": "0.1.0"

--- a/tests/custom_maven_install/policy_pinned_testing_install.json
+++ b/tests/custom_maven_install/policy_pinned_testing_install.json
@@ -40,6 +40,42 @@
                 "url": "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/1.27.0/google-api-client-1.27.0.jar"
             },
             {
+                "coord": "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                "dependencies": [
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
+                    "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
+                ],
+                "sha256": "d94b529c39f94765fdb81f1835ee9c006de2707c0ef4a49445999d00cb99eec2",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
+            },
+            {
+                "coord": "com.google.api.grpc:proto-google-iam-v1:0.12.0",
+                "dependencies": [
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                    "com.google.api:api-common:1.7.0",
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "directDependencies": [
+                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
+                    "com.google.api:api-common:1.7.0",
+                    "com.google.protobuf:protobuf-java:3.6.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
+                    "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
+                ],
+                "sha256": "ddabb48fe072ada50484c98f00893a3e1356b4f05d2d0bf0045bc830145d1e0c",
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
+            },
+            {
                 "coord": "com.google.api:api-common:1.7.0",
                 "dependencies": [
                     "com.google.code.findbugs:jsr305:3.0.2",
@@ -127,42 +163,6 @@
                 ],
                 "sha256": "9c8540678f209092191e19c59b6ca3092bd75b782f30823bdadf5567e2a1515a",
                 "url": "https://repo1.maven.org/maven2/com/google/api/gax/1.42.0/gax-1.42.0.jar"
-            },
-            {
-                "coord": "com.google.api.grpc:proto-google-common-protos:1.14.0",
-                "dependencies": [
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "directDependencies": [
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar",
-                    "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
-                ],
-                "sha256": "d94b529c39f94765fdb81f1835ee9c006de2707c0ef4a49445999d00cb99eec2",
-                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.14.0/proto-google-common-protos-1.14.0.jar"
-            },
-            {
-                "coord": "com.google.api.grpc:proto-google-iam-v1:0.12.0",
-                "dependencies": [
-                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
-                    "com.google.api:api-common:1.7.0",
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "directDependencies": [
-                    "com.google.api.grpc:proto-google-common-protos:1.14.0",
-                    "com.google.api:api-common:1.7.0",
-                    "com.google.protobuf:protobuf-java:3.6.1"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar",
-                    "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
-                ],
-                "sha256": "ddabb48fe072ada50484c98f00893a3e1356b4f05d2d0bf0045bc830145d1e0c",
-                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/0.12.0/proto-google-iam-v1-0.12.0.jar"
             },
             {
                 "coord": "com.google.apis:google-api-services-storage:v1-rev20181109-1.27.0",

--- a/tests/custom_maven_install/regression_testing_install.json
+++ b/tests/custom_maven_install/regression_testing_install.json
@@ -142,6 +142,51 @@
                 "url": "https://maven.google.com/android/arch/lifecycle/viewmodel/1.1.1/viewmodel-1.1.1.aar"
             },
             {
+                "coord": "ch.epfl.scala:compiler-interface:1.3.0-M4+20-c8a2f9bd",
+                "dependencies": [
+                    "com.google.protobuf:protobuf-java:3.7.0",
+                    "org.scala-sbt:util-interface:1.3.0-M4"
+                ],
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:3.7.0",
+                    "org.scala-sbt:util-interface:1.3.0-M4"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
+                    "https://maven.google.com/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
+                    "https://packages.confluent.io/maven/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
+                ],
+                "sha256": "b5080bbfd4dc2beef489e4a7153b1b6099724ae7860b720e64d2b3b3b96570a5",
+                "url": "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
+            },
+            {
+                "coord": "com.101tec:zkclient:0.11",
+                "dependencies": [
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "exclusions": [
+                    "*:jline",
+                    "*:jmxtools",
+                    "*:jms",
+                    "*:mail",
+                    "*:javax",
+                    "*:jmxri",
+                    "*:zookeeper"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
+                    "https://maven.google.com/com/101tec/zkclient/0.11/zkclient-0.11.jar",
+                    "https://packages.confluent.io/maven/com/101tec/zkclient/0.11/zkclient-0.11.jar"
+                ],
+                "sha256": "72e05e5031508115cafa6092cd53af306c5584957a34012511a20aac5e6c45e5",
+                "url": "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar"
+            },
+            {
                 "coord": "com.android.support:animated-vector-drawable:aar:28.0.0",
                 "dependencies": [
                     "android.arch.core:common:1.1.1",
@@ -809,340 +854,6 @@
                 "url": "https://maven.google.com/com/android/support/viewpager/28.0.0/viewpager-28.0.0.aar"
             },
             {
-                "coord": "com.google.android.gms:play-services-base:16.1.0",
-                "dependencies": [
-                    "com.android.support:support-annotations:28.0.0",
-                    "com.android.support:support-compat:28.0.0",
-                    "com.android.support:support-core-ui:28.0.0",
-                    "com.android.support:support-core-utils:28.0.0",
-                    "com.android.support:support-fragment:28.0.0",
-                    "com.android.support:support-media-compat:26.1.0",
-                    "com.android.support:support-v4:aar:26.1.0",
-                    "com.google.android.gms:play-services-basement:aar:16.2.0",
-                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
-                ],
-                "directDependencies": [
-                    "com.google.android.gms:play-services-basement:aar:16.2.0",
-                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
-                ],
-                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
-                    "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
-                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
-                ],
-                "sha256": "3a543b05dfa09ca84fb47ed5e166ec7fbd7715ce630bbde44c10ffa5fb81daa4",
-                "url": "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
-            },
-            {
-                "coord": "com.google.android.gms:play-services-basement:aar:16.2.0",
-                "dependencies": [
-                    "com.android.support:support-annotations:28.0.0",
-                    "com.android.support:support-compat:28.0.0",
-                    "com.android.support:support-core-ui:28.0.0",
-                    "com.android.support:support-core-utils:28.0.0",
-                    "com.android.support:support-fragment:28.0.0",
-                    "com.android.support:support-media-compat:26.1.0",
-                    "com.android.support:support-v4:aar:26.1.0"
-                ],
-                "directDependencies": [
-                    "com.android.support:support-v4:aar:26.1.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
-                    "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
-                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
-                ],
-                "sha256": "5ccead5a05a632f93df0a807752a034adcd0cd62fcf30da287c6dd5b05bd3d5a",
-                "url": "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
-            },
-            {
-                "coord": "com.google.android.gms:play-services-tasks:aar:16.0.1",
-                "dependencies": [
-                    "com.google.android.gms:play-services-basement:aar:16.2.0"
-                ],
-                "directDependencies": [
-                    "com.google.android.gms:play-services-basement:aar:16.2.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
-                    "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
-                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
-                ],
-                "sha256": "b31c18d8d1cc8d9814f295ee7435471333f370ba5bd904ca14f8f2bec4f35c35",
-                "url": "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
-            },
-            {
-                "coord": "com.google.ar:core:aar:1.10.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/core/1.10.0/core-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/core/1.10.0/core-1.10.0.aar"
-                ],
-                "sha256": "6624df5075cb9db0887abd6c84eb0889d1d7ba11bfd930b4e06a56eaffab820a",
-                "url": "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:core:aar:1.10.0",
-                "dependencies": [
-                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                    "com.google.ar.sceneform:rendering:aar:1.10.0",
-                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "directDependencies": [
-                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                    "com.google.ar.sceneform:rendering:aar:1.10.0",
-                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
-                ],
-                "sha256": "0652b7feb93b5c19ab314b79977aa739ec58c48a1bd727a4f8c31e61fe105e09",
-                "url": "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
-                ],
-                "sha256": "24751cbda2bfa49d5ab0d53f36efa7ac4f0b1ba6c7356c8bf418cb5a61dd067f",
-                "url": "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:rendering:aar:1.10.0",
-                "dependencies": [
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "directDependencies": [
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
-                ],
-                "sha256": "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
-                "url": "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
-                ],
-                "sha256": "fe2191f8a0b622bf35c91cdbe83074ff025f1641b6fe25ea0b554f208a62daff",
-                "url": "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
-            },
-            {
-                "coord": "com.google.ar.sceneform.ux:sceneform-ux:1.10.0",
-                "dependencies": [
-                    "com.android.support:support-fragment:aar:28.0.0",
-                    "com.google.ar.sceneform:core:aar:1.10.0",
-                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
-                    "com.google.ar.sceneform:rendering:aar:1.10.0",
-                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
-                    "com.google.ar:core:aar:1.10.0"
-                ],
-                "directDependencies": [
-                    "com.android.support:support-fragment:aar:28.0.0",
-                    "com.google.ar.sceneform:core:aar:1.10.0"
-                ],
-                "file": "v1/https/maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
-                    "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
-                    "https://packages.confluent.io/maven/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
-                ],
-                "sha256": "f37d622f5f44facf953e23bcc01175c4f2df5f7234f71cd8855ca669d7c179fc",
-                "url": "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
-            },
-            {
-                "coord": "io.confluent:common-config:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "io.confluent:common-utils:5.0.1",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
-                ],
-                "sha256": "d4375cdff2296888f598af6764697dc6215ceb61c023eeb0c7d5ab60583122ed",
-                "url": "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
-            },
-            {
-                "coord": "io.confluent:common-utils:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
-                ],
-                "sha256": "fec75e2c7da2db6f4a1b2d288576b96cb72fa06029bcf5adfd444573e57f2a7f",
-                "url": "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
-            },
-            {
-                "coord": "io.confluent:kafka-avro-serializer:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "com.thoughtworks.paranamer:paranamer:2.7",
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.confluent:kafka-schema-registry-client:5.0.1",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.avro:avro:1.8.1",
-                    "org.apache.commons:commons-compress:1.18",
-                    "org.apache.kafka:kafka-clients:2.1.1",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
-                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.tukaani:xz:1.5",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "directDependencies": [
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.confluent:kafka-schema-registry-client:5.0.1",
-                    "org.apache.avro:avro:1.8.1"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
-                ],
-                "sha256": "2372bb93a753ce754d0c10514cf4c61501e2c3d8960873541f72377689cb1a48",
-                "url": "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
-            },
-            {
-                "coord": "io.confluent:kafka-schema-registry-client:5.0.1",
-                "dependencies": [
-                    "com.101tec:zkclient:0.11",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "com.thoughtworks.paranamer:paranamer:2.7",
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "io.netty:netty:3.10.6.Final",
-                    "jline:jline:0.9.94",
-                    "org.apache.avro:avro:1.8.1",
-                    "org.apache.commons:commons-compress:1.18",
-                    "org.apache.kafka:kafka-clients:2.1.1",
-                    "org.apache.yetus:audience-annotations:0.5.0",
-                    "org.apache.zookeeper:zookeeper:3.4.13",
-                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
-                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.tukaani:xz:1.5",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "directDependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "io.confluent:common-config:5.0.1",
-                    "io.confluent:common-utils:5.0.1",
-                    "org.apache.avro:avro:1.8.1",
-                    "org.apache.kafka:kafka-clients:2.1.1"
-                ],
-                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
-                    "https://maven.google.com/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
-                    "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
-                ],
-                "sha256": "74111b8c628d5f6fe55569f49af12ea094942a7f17192011795180b970110f8c",
-                "url": "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
-            },
-            {
-                "coord": "ch.epfl.scala:compiler-interface:1.3.0-M4+20-c8a2f9bd",
-                "dependencies": [
-                    "com.google.protobuf:protobuf-java:3.7.0",
-                    "org.scala-sbt:util-interface:1.3.0-M4"
-                ],
-                "directDependencies": [
-                    "com.google.protobuf:protobuf-java:3.7.0",
-                    "org.scala-sbt:util-interface:1.3.0-M4"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
-                    "https://maven.google.com/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar",
-                    "https://packages.confluent.io/maven/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
-                ],
-                "sha256": "b5080bbfd4dc2beef489e4a7153b1b6099724ae7860b720e64d2b3b3b96570a5",
-                "url": "https://repo1.maven.org/maven2/ch/epfl/scala/compiler-interface/1.3.0-M4%2B20-c8a2f9bd/compiler-interface-1.3.0-M4%2B20-c8a2f9bd.jar"
-            },
-            {
-                "coord": "com.101tec:zkclient:0.11",
-                "dependencies": [
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "exclusions": [
-                    "*:jline",
-                    "*:jmxtools",
-                    "*:jms",
-                    "*:mail",
-                    "*:javax",
-                    "*:jmxri",
-                    "*:zookeeper"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar",
-                    "https://maven.google.com/com/101tec/zkclient/0.11/zkclient-0.11.jar",
-                    "https://packages.confluent.io/maven/com/101tec/zkclient/0.11/zkclient-0.11.jar"
-                ],
-                "sha256": "72e05e5031508115cafa6092cd53af306c5584957a34012511a20aac5e6c45e5",
-                "url": "https://repo1.maven.org/maven2/com/101tec/zkclient/0.11/zkclient-0.11.jar"
-            },
-            {
                 "coord": "com.esotericsoftware.kryo:kryo:2.24.0",
                 "dependencies": [
                     "com.esotericsoftware.minlog:minlog:1.2",
@@ -1244,17 +955,49 @@
                 "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.8/jackson-databind-2.9.8.jar"
             },
             {
-                "coord": "com.github.fommil:jniloader:1.1",
+                "coord": "com.fasterxml.jackson:jackson-bom:2.9.10",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
-                    "https://maven.google.com/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
-                    "https://packages.confluent.io/maven/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
+                "file": null
+            },
+            {
+                "coord": "com.github.fommil.netlib:all:1.1.2",
+                "dependencies": [
+                    "com.github.fommil.netlib:core:1.1.2",
+                    "com.github.fommil.netlib:native_ref-java:1.1",
+                    "com.github.fommil.netlib:native_system-java:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-linux-armhf:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-linux-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-linux-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-osx-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-win-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-win-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-linux-armhf:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-linux-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-linux-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-osx-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-win-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-win-x86_64:jar:natives:1.1",
+                    "com.github.fommil:jniloader:1.1",
+                    "net.sourceforge.f2j:arpack_combined_all:0.1"
                 ],
-                "sha256": "2f1def54f30e1db5f1e7f2fd600fe2ab331bd6b52037e9a21505c237020b5573",
-                "url": "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
+                "directDependencies": [
+                    "com.github.fommil.netlib:core:1.1.2",
+                    "com.github.fommil.netlib:netlib-native_ref-linux-armhf:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-linux-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-linux-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-osx-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-win-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_ref-win-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-linux-armhf:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-linux-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-linux-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-osx-x86_64:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-win-i686:jar:natives:1.1",
+                    "com.github.fommil.netlib:netlib-native_system-win-x86_64:jar:natives:1.1",
+                    "net.sourceforge.f2j:arpack_combined_all:0.1"
+                ],
+                "file": null
             },
             {
                 "coord": "com.github.fommil.netlib:core:1.1.2",
@@ -1568,6 +1311,19 @@
                 "url": "https://repo1.maven.org/maven2/com/github/fommil/netlib/netlib-native_system-win-x86_64/1.1/netlib-native_system-win-x86_64-1.1-natives.jar"
             },
             {
+                "coord": "com.github.fommil:jniloader:1.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
+                    "https://maven.google.com/com/github/fommil/jniloader/1.1/jniloader-1.1.jar",
+                    "https://packages.confluent.io/maven/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
+                ],
+                "sha256": "2f1def54f30e1db5f1e7f2fd600fe2ab331bd6b52037e9a21505c237020b5573",
+                "url": "https://repo1.maven.org/maven2/com/github/fommil/jniloader/1.1/jniloader-1.1.jar"
+            },
+            {
                 "coord": "com.github.luben:zstd-jni:1.3.7-1",
                 "dependencies": [],
                 "directDependencies": [],
@@ -1602,6 +1358,16 @@
                 ],
                 "sha256": "3f2c073c2dce44baa0bde0cd258acff9a4d874c422a8fcedefa5fbf8900dcdd5",
                 "url": "https://repo1.maven.org/maven2/com/github/oshi/oshi-core/3.4.0/oshi-core-3.4.0.jar"
+            },
+            {
+                "coord": "com.github.oshi:oshi-parent:3.4.0",
+                "dependencies": [
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "file": null
             },
             {
                 "coord": "com.github.scopt:scopt_2.11:3.4.0",
@@ -1746,6 +1512,173 @@
                 ],
                 "sha256": "4fccff8382aafc589962c4edb262f6aa595e34f1e11e61057d1c6a96e8fc7323",
                 "url": "https://repo1.maven.org/maven2/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1.jar"
+            },
+            {
+                "coord": "com.google.android.gms:play-services-base:16.1.0",
+                "dependencies": [
+                    "com.android.support:support-annotations:28.0.0",
+                    "com.android.support:support-compat:28.0.0",
+                    "com.android.support:support-core-ui:28.0.0",
+                    "com.android.support:support-core-utils:28.0.0",
+                    "com.android.support:support-fragment:28.0.0",
+                    "com.android.support:support-media-compat:26.1.0",
+                    "com.android.support:support-v4:aar:26.1.0",
+                    "com.google.android.gms:play-services-basement:aar:16.2.0",
+                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
+                ],
+                "directDependencies": [
+                    "com.google.android.gms:play-services-basement:aar:16.2.0",
+                    "com.google.android.gms:play-services-tasks:aar:16.0.1"
+                ],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
+                    "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar",
+                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
+                ],
+                "sha256": "3a543b05dfa09ca84fb47ed5e166ec7fbd7715ce630bbde44c10ffa5fb81daa4",
+                "url": "https://maven.google.com/com/google/android/gms/play-services-base/16.1.0/play-services-base-16.1.0.aar"
+            },
+            {
+                "coord": "com.google.android.gms:play-services-basement:aar:16.2.0",
+                "dependencies": [
+                    "com.android.support:support-annotations:28.0.0",
+                    "com.android.support:support-compat:28.0.0",
+                    "com.android.support:support-core-ui:28.0.0",
+                    "com.android.support:support-core-utils:28.0.0",
+                    "com.android.support:support-fragment:28.0.0",
+                    "com.android.support:support-media-compat:26.1.0",
+                    "com.android.support:support-v4:aar:26.1.0"
+                ],
+                "directDependencies": [
+                    "com.android.support:support-v4:aar:26.1.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
+                    "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar",
+                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
+                ],
+                "sha256": "5ccead5a05a632f93df0a807752a034adcd0cd62fcf30da287c6dd5b05bd3d5a",
+                "url": "https://maven.google.com/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar"
+            },
+            {
+                "coord": "com.google.android.gms:play-services-tasks:aar:16.0.1",
+                "dependencies": [
+                    "com.google.android.gms:play-services-basement:aar:16.2.0"
+                ],
+                "directDependencies": [
+                    "com.google.android.gms:play-services-basement:aar:16.2.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
+                    "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar",
+                    "https://packages.confluent.io/maven/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
+                ],
+                "sha256": "b31c18d8d1cc8d9814f295ee7435471333f370ba5bd904ca14f8f2bec4f35c35",
+                "url": "https://maven.google.com/com/google/android/gms/play-services-tasks/16.0.1/play-services-tasks-16.0.1.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform.ux:sceneform-ux:1.10.0",
+                "dependencies": [
+                    "com.android.support:support-fragment:aar:28.0.0",
+                    "com.google.ar.sceneform:core:aar:1.10.0",
+                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                    "com.google.ar.sceneform:rendering:aar:1.10.0",
+                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "directDependencies": [
+                    "com.android.support:support-fragment:aar:28.0.0",
+                    "com.google.ar.sceneform:core:aar:1.10.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
+                ],
+                "sha256": "f37d622f5f44facf953e23bcc01175c4f2df5f7234f71cd8855ca669d7c179fc",
+                "url": "https://maven.google.com/com/google/ar/sceneform/ux/sceneform-ux/1.10.0/sceneform-ux-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:core:aar:1.10.0",
+                "dependencies": [
+                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                    "com.google.ar.sceneform:rendering:aar:1.10.0",
+                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "directDependencies": [
+                    "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                    "com.google.ar.sceneform:rendering:aar:1.10.0",
+                    "com.google.ar.sceneform:sceneform-base:aar:1.10.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
+                ],
+                "sha256": "0652b7feb93b5c19ab314b79977aa739ec58c48a1bd727a4f8c31e61fe105e09",
+                "url": "https://maven.google.com/com/google/ar/sceneform/core/1.10.0/core-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:filament-android:aar:1.10.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
+                ],
+                "sha256": "24751cbda2bfa49d5ab0d53f36efa7ac4f0b1ba6c7356c8bf418cb5a61dd067f",
+                "url": "https://maven.google.com/com/google/ar/sceneform/filament-android/1.10.0/filament-android-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:rendering:aar:1.10.0",
+                "dependencies": [
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "directDependencies": [
+                    "com.google.ar:core:aar:1.10.0"
+                ],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
+                ],
+                "sha256": "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
+                "url": "https://maven.google.com/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar.sceneform:sceneform-base:aar:1.10.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
+                ],
+                "sha256": "fe2191f8a0b622bf35c91cdbe83074ff025f1641b6fe25ea0b554f208a62daff",
+                "url": "https://maven.google.com/com/google/ar/sceneform/sceneform-base/1.10.0/sceneform-base-1.10.0.aar"
+            },
+            {
+                "coord": "com.google.ar:core:aar:1.10.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/ar/core/1.10.0/core-1.10.0.aar",
+                    "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar",
+                    "https://packages.confluent.io/maven/com/google/ar/core/1.10.0/core-1.10.0.aar"
+                ],
+                "sha256": "6624df5075cb9db0887abd6c84eb0889d1d7ba11bfd930b4e06a56eaffab820a",
+                "url": "https://maven.google.com/com/google/ar/core/1.10.0/core-1.10.0.aar"
             },
             {
                 "coord": "com.google.code.findbugs:jsr305:3.0.2",
@@ -1993,19 +1926,6 @@
                 "url": "https://repo1.maven.org/maven2/com/nimbusds/oauth2-oidc-sdk/5.24.1/oauth2-oidc-sdk-5.24.1.jar"
             },
             {
-                "coord": "com.squareup:javapoet:1.11.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
-                    "https://maven.google.com/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
-                    "https://packages.confluent.io/maven/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
-                ],
-                "sha256": "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90",
-                "url": "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
-            },
-            {
                 "coord": "com.squareup.okhttp:logging-interceptor:2.7.5",
                 "dependencies": [
                     "com.squareup.okhttp:okhttp:2.7.5",
@@ -2070,6 +1990,19 @@
                 ],
                 "sha256": "114bdc1f47338a68bcbc95abf2f5cdc72beeec91812f2fcd7b521c1937876266",
                 "url": "https://repo1.maven.org/maven2/com/squareup/okio/okio/1.6.0/okio-1.6.0.jar"
+            },
+            {
+                "coord": "com.squareup:javapoet:1.11.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
+                    "https://maven.google.com/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
+                    "https://packages.confluent.io/maven/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
+                ],
+                "sha256": "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90",
+                "url": "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
             },
             {
                 "coord": "com.thoughtworks.paranamer:paranamer:2.7",
@@ -2212,22 +2145,6 @@
                 "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.12/2.4.20/akka-stream_2.12-2.4.20.jar"
             },
             {
-                "coord": "com.typesafe:config:1.3.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "exclusions": [
-                    "org.scala-lang:scala-library"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
-                    "https://maven.google.com/com/typesafe/config/1.3.0/config-1.3.0.jar",
-                    "https://packages.confluent.io/maven/com/typesafe/config/1.3.0/config-1.3.0.jar"
-                ],
-                "sha256": "d3e9dca258786c51fcbcc47d34d3b44158476af55c47d22dd8c2e38e41a2c89a",
-                "url": "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar"
-            },
-            {
                 "coord": "com.typesafe.scala-logging:scala-logging_2.11:3.9.0",
                 "dependencies": [
                     "org.scala-lang:scala-library:2.11.12",
@@ -2255,6 +2172,22 @@
                 ],
                 "sha256": "6f58222c736833066894f51de21fdac840e573a545e776dafff670b673ed52e4",
                 "url": "https://repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.11/3.9.0/scala-logging_2.11-3.9.0.jar"
+            },
+            {
+                "coord": "com.typesafe:config:1.3.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "exclusions": [
+                    "org.scala-lang:scala-library"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar",
+                    "https://maven.google.com/com/typesafe/config/1.3.0/config-1.3.0.jar",
+                    "https://packages.confluent.io/maven/com/typesafe/config/1.3.0/config-1.3.0.jar"
+                ],
+                "sha256": "d3e9dca258786c51fcbcc47d34d3b44158476af55c47d22dd8c2e38e41a2c89a",
+                "url": "https://repo1.maven.org/maven2/com/typesafe/config/1.3.0/config-1.3.0.jar"
             },
             {
                 "coord": "com.typesafe:ssl-config-core_2.12:0.2.1",
@@ -2353,6 +2286,128 @@
                 ],
                 "sha256": "cc6a41dc3eaacc9e440a6bd0d2890b20d36b4ee408fe2d67122f328bb6e01581",
                 "url": "https://repo1.maven.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.jar"
+            },
+            {
+                "coord": "io.confluent:common-config:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "io.confluent:common-utils:5.0.1",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/common-config/5.0.1/common-config-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
+                ],
+                "sha256": "d4375cdff2296888f598af6764697dc6215ceb61c023eeb0c7d5ab60583122ed",
+                "url": "https://packages.confluent.io/maven/io/confluent/common-config/5.0.1/common-config-5.0.1.jar"
+            },
+            {
+                "coord": "io.confluent:common-utils:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "directDependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.slf4j:slf4j-api:1.7.25"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
+                ],
+                "sha256": "fec75e2c7da2db6f4a1b2d288576b96cb72fa06029bcf5adfd444573e57f2a7f",
+                "url": "https://packages.confluent.io/maven/io/confluent/common-utils/5.0.1/common-utils-5.0.1.jar"
+            },
+            {
+                "coord": "io.confluent:kafka-avro-serializer:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:2.7",
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.confluent:kafka-schema-registry-client:5.0.1",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.avro:avro:1.8.1",
+                    "org.apache.commons:commons-compress:1.18",
+                    "org.apache.kafka:kafka-clients:2.1.1",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
+                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.tukaani:xz:1.5",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "directDependencies": [
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.confluent:kafka-schema-registry-client:5.0.1",
+                    "org.apache.avro:avro:1.8.1"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
+                ],
+                "sha256": "2372bb93a753ce754d0c10514cf4c61501e2c3d8960873541f72377689cb1a48",
+                "url": "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/5.0.1/kafka-avro-serializer-5.0.1.jar"
+            },
+            {
+                "coord": "io.confluent:kafka-schema-registry-client:5.0.1",
+                "dependencies": [
+                    "com.101tec:zkclient:0.11",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:2.7",
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "io.netty:netty:3.10.6.Final",
+                    "jline:jline:0.9.94",
+                    "org.apache.avro:avro:1.8.1",
+                    "org.apache.commons:commons-compress:1.18",
+                    "org.apache.kafka:kafka-clients:2.1.1",
+                    "org.apache.yetus:audience-annotations:0.5.0",
+                    "org.apache.zookeeper:zookeeper:3.4.13",
+                    "org.codehaus.jackson:jackson-core-asl:1.9.13",
+                    "org.codehaus.jackson:jackson-mapper-asl:1.9.13",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.tukaani:xz:1.5",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "io.confluent:common-config:5.0.1",
+                    "io.confluent:common-utils:5.0.1",
+                    "org.apache.avro:avro:1.8.1",
+                    "org.apache.kafka:kafka-clients:2.1.1"
+                ],
+                "file": "v1/https/packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
+                    "https://maven.google.com/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar",
+                    "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
+                ],
+                "sha256": "74111b8c628d5f6fe55569f49af12ea094942a7f17192011795180b970110f8c",
+                "url": "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/5.0.1/kafka-schema-registry-client-5.0.1.jar"
             },
             {
                 "coord": "io.kubernetes:client-java-api:4.0.0-beta1",
@@ -3567,84 +3622,6 @@
                 "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-queryable-state-client-java_2.12/1.8.0/flink-queryable-state-client-java_2.12-1.8.0.jar"
             },
             {
-                "coord": "org.apache.flink:flink-runtime_2.12:test-jar:tests:1.8.0",
-                "dependencies": [
-                    "com.esotericsoftware.kryo:kryo:2.24.0",
-                    "com.esotericsoftware.minlog:minlog:1.2",
-                    "com.github.scopt:scopt_2.12:3.5.0",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.twitter:chill-java:0.7.6",
-                    "com.twitter:chill_2.12:0.7.6",
-                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
-                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
-                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
-                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
-                    "com.typesafe:config:1.3.0",
-                    "com.typesafe:ssl-config-core_2.12:0.2.1",
-                    "commons-cli:commons-cli:1.3.1",
-                    "commons-collections:commons-collections:3.2.2",
-                    "commons-io:commons-io:2.4",
-                    "org.apache.commons:commons-compress:1.18",
-                    "org.apache.commons:commons-lang3:3.7",
-                    "org.apache.commons:commons-math3:3.5",
-                    "org.apache.flink:flink-annotations:1.8.0",
-                    "org.apache.flink:flink-core:1.8.0",
-                    "org.apache.flink:flink-hadoop-fs:1.8.0",
-                    "org.apache.flink:flink-java:1.8.0",
-                    "org.apache.flink:flink-metrics-core:1.8.0",
-                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
-                    "org.apache.flink:flink-shaded-asm-6:6.2.1-6.0",
-                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
-                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
-                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
-                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
-                    "org.apache.flink:force-shading:1.8.0",
-                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
-                    "org.javassist:javassist:3.19.0-GA",
-                    "org.objenesis:objenesis:2.1",
-                    "org.reactivestreams:reactive-streams:1.0.0",
-                    "org.scala-lang.modules:scala-java8-compat_2.12:0.8.0",
-                    "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4",
-                    "org.scala-lang:scala-library:2.11.12",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "directDependencies": [
-                    "com.github.scopt:scopt_2.12:3.5.0",
-                    "com.google.code.findbugs:jsr305:3.0.2",
-                    "com.twitter:chill_2.12:0.7.6",
-                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
-                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
-                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
-                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
-                    "commons-cli:commons-cli:1.3.1",
-                    "commons-io:commons-io:2.4",
-                    "org.apache.commons:commons-lang3:3.7",
-                    "org.apache.flink:flink-core:1.8.0",
-                    "org.apache.flink:flink-hadoop-fs:1.8.0",
-                    "org.apache.flink:flink-java:1.8.0",
-                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
-                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
-                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
-                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
-                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
-                    "org.apache.flink:force-shading:1.8.0",
-                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
-                    "org.javassist:javassist:3.19.0-GA",
-                    "org.scala-lang:scala-library:2.11.12",
-                    "org.slf4j:slf4j-api:1.7.25",
-                    "org.xerial.snappy:snappy-java:1.1.7.2"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar",
-                    "https://maven.google.com/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar",
-                    "https://packages.confluent.io/maven/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar"
-                ],
-                "sha256": "a09b2cc02a67476d5c1876dc34b0dea9fdefc4aaa2f79e61b19d38af8007b49c",
-                "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar"
-            },
-            {
                 "coord": "org.apache.flink:flink-runtime_2.12:1.8.0",
                 "dependencies": [
                     "com.esotericsoftware.kryo:kryo:2.24.0",
@@ -3721,6 +3698,84 @@
                 ],
                 "sha256": "14121e60d1e8215ebfe9c997b17b1e8b508a36835f5ec5be4269d71a472fa07c",
                 "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0.jar"
+            },
+            {
+                "coord": "org.apache.flink:flink-runtime_2.12:test-jar:tests:1.8.0",
+                "dependencies": [
+                    "com.esotericsoftware.kryo:kryo:2.24.0",
+                    "com.esotericsoftware.minlog:minlog:1.2",
+                    "com.github.scopt:scopt_2.12:3.5.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.twitter:chill-java:0.7.6",
+                    "com.twitter:chill_2.12:0.7.6",
+                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
+                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
+                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
+                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
+                    "com.typesafe:config:1.3.0",
+                    "com.typesafe:ssl-config-core_2.12:0.2.1",
+                    "commons-cli:commons-cli:1.3.1",
+                    "commons-collections:commons-collections:3.2.2",
+                    "commons-io:commons-io:2.4",
+                    "org.apache.commons:commons-compress:1.18",
+                    "org.apache.commons:commons-lang3:3.7",
+                    "org.apache.commons:commons-math3:3.5",
+                    "org.apache.flink:flink-annotations:1.8.0",
+                    "org.apache.flink:flink-core:1.8.0",
+                    "org.apache.flink:flink-hadoop-fs:1.8.0",
+                    "org.apache.flink:flink-java:1.8.0",
+                    "org.apache.flink:flink-metrics-core:1.8.0",
+                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
+                    "org.apache.flink:flink-shaded-asm-6:6.2.1-6.0",
+                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
+                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
+                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
+                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
+                    "org.apache.flink:force-shading:1.8.0",
+                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
+                    "org.javassist:javassist:3.19.0-GA",
+                    "org.objenesis:objenesis:2.1",
+                    "org.reactivestreams:reactive-streams:1.0.0",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:0.8.0",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4",
+                    "org.scala-lang:scala-library:2.11.12",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "directDependencies": [
+                    "com.github.scopt:scopt_2.12:3.5.0",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "com.twitter:chill_2.12:0.7.6",
+                    "com.typesafe.akka:akka-actor_2.12:2.4.20",
+                    "com.typesafe.akka:akka-protobuf_2.12:2.4.20",
+                    "com.typesafe.akka:akka-slf4j_2.12:2.4.20",
+                    "com.typesafe.akka:akka-stream_2.12:2.4.20",
+                    "commons-cli:commons-cli:1.3.1",
+                    "commons-io:commons-io:2.4",
+                    "org.apache.commons:commons-lang3:3.7",
+                    "org.apache.flink:flink-core:1.8.0",
+                    "org.apache.flink:flink-hadoop-fs:1.8.0",
+                    "org.apache.flink:flink-java:1.8.0",
+                    "org.apache.flink:flink-queryable-state-client-java_2.12:1.8.0",
+                    "org.apache.flink:flink-shaded-asm:5.0.4-6.0",
+                    "org.apache.flink:flink-shaded-guava:18.0-6.0",
+                    "org.apache.flink:flink-shaded-jackson:2.7.9-6.0",
+                    "org.apache.flink:flink-shaded-netty:4.1.32.Final-6.0",
+                    "org.apache.flink:force-shading:1.8.0",
+                    "org.clapper:grizzled-slf4j_2.12:1.3.2",
+                    "org.javassist:javassist:3.19.0-GA",
+                    "org.scala-lang:scala-library:2.11.12",
+                    "org.slf4j:slf4j-api:1.7.25",
+                    "org.xerial.snappy:snappy-java:1.1.7.2"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar",
+                    "https://maven.google.com/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar",
+                    "https://packages.confluent.io/maven/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar"
+                ],
+                "sha256": "a09b2cc02a67476d5c1876dc34b0dea9fdefc4aaa2f79e61b19d38af8007b49c",
+                "url": "https://repo1.maven.org/maven2/org/apache/flink/flink-runtime_2.12/1.8.0/flink-runtime_2.12-1.8.0-tests.jar"
             },
             {
                 "coord": "org.apache.flink:flink-shaded-asm-6:6.2.1-6.0",
@@ -4313,6 +4368,19 @@
                 "url": "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
             },
             {
+                "coord": "org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
+                    "https://maven.google.com/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
+                    "https://packages.confluent.io/maven/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
+                ],
+                "sha256": "a2cc192a076d9effd10becee8aacbe157f0fe2010fd4322e58aaeff198e56dbe",
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
+            },
+            {
                 "coord": "org.eclipse.jetty:jetty-http:jar:tests:9.4.20.v20190813",
                 "dependencies": [
                     "org.eclipse.jetty:jetty-io:9.4.20.v20190813",
@@ -4360,19 +4428,6 @@
                 ],
                 "sha256": "5816ef44f73e76b8ef1c1ea848cc34c7b1f24771f3675353e2ef23eb920121d8",
                 "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.20.v20190813/jetty-util-9.4.20.v20190813.jar"
-            },
-            {
-                "coord": "org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
-                    "https://maven.google.com/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar",
-                    "https://packages.confluent.io/maven/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
-                ],
-                "sha256": "a2cc192a076d9effd10becee8aacbe157f0fe2010fd4322e58aaeff198e56dbe",
-                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar"
             },
             {
                 "coord": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.2",
@@ -4480,19 +4535,6 @@
                 "url": "https://repo1.maven.org/maven2/org/jboss/spec/javax/servlet/jboss-servlet-api_4.0_spec/1.0.0.Final/jboss-servlet-api_4.0_spec-1.0.0.Final.jar"
             },
             {
-                "coord": "org.jetbrains:annotations:13.0",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
-                    "https://maven.google.com/org/jetbrains/annotations/13.0/annotations-13.0.jar",
-                    "https://packages.confluent.io/maven/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-                ],
-                "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
-                "url": "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-            },
-            {
                 "coord": "org.jetbrains.kotlin:kotlin-stdlib-common:1.3.21",
                 "dependencies": [],
                 "directDependencies": [],
@@ -4563,6 +4605,19 @@
                 "url": "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-test/1.3.21/kotlin-test-1.3.21.jar"
             },
             {
+                "coord": "org.jetbrains:annotations:13.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+                    "https://maven.google.com/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+                    "https://packages.confluent.io/maven/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+                ],
+                "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+                "url": "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+            },
+            {
                 "coord": "org.joda:joda-convert:1.2",
                 "dependencies": [],
                 "directDependencies": [],
@@ -4574,6 +4629,12 @@
                 ],
                 "sha256": "5703e1a2ac1969fe90f87076c1f1136822bf31d8948252159c86e6d0535c81a8",
                 "url": "https://repo1.maven.org/maven2/org/joda/joda-convert/1.2/joda-convert-1.2.jar"
+            },
+            {
+                "coord": "org.junit:junit-bom:5.3.1",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": null
             },
             {
                 "coord": "org.lz4:lz4-java:1.5.0",
@@ -4610,23 +4671,6 @@
                 "url": "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.1/objenesis-2.1.jar"
             },
             {
-                "coord": "org.openjfx:javafx-base:jar:mac:11.0.1",
-                "dependencies": [
-                    "org.openjfx:javafx-base:jar:mac:11.0.1"
-                ],
-                "directDependencies": [
-                    "org.openjfx:javafx-base:jar:mac:11.0.1"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar",
-                    "https://maven.google.com/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar",
-                    "https://packages.confluent.io/maven/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar"
-                ],
-                "sha256": "2d8052a08fd2e5d98e1d5a16d724ea5dd02102879de20a193225f57199803983",
-                "url": "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar"
-            },
-            {
                 "coord": "org.openjfx:javafx-base:11.0.1",
                 "dependencies": [
                     "org.openjfx:javafx-base:jar:mac:11.0.1"
@@ -4642,6 +4686,23 @@
                 ],
                 "sha256": "c5084a74417a89c69a0c122fae96a4b70bf619fc3d6218ea102a4047ec85ad04",
                 "url": "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1.jar"
+            },
+            {
+                "coord": "org.openjfx:javafx-base:jar:mac:11.0.1",
+                "dependencies": [
+                    "org.openjfx:javafx-base:jar:mac:11.0.1"
+                ],
+                "directDependencies": [
+                    "org.openjfx:javafx-base:jar:mac:11.0.1"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar",
+                    "https://maven.google.com/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar",
+                    "https://packages.confluent.io/maven/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar"
+                ],
+                "sha256": "2d8052a08fd2e5d98e1d5a16d724ea5dd02102879de20a193225f57199803983",
+                "url": "https://repo1.maven.org/maven2/org/openjfx/javafx-base/11.0.1/javafx-base-11.0.1-mac.jar"
             },
             {
                 "coord": "org.ow2.asm:asm-analysis:6.2",
@@ -4910,67 +4971,6 @@
                 ],
                 "sha256": "0a7b1063fcaeb806b40b728d01b9361d38e1ed8deb93f945994fec7c1761dad1",
                 "url": "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.19/snakeyaml-1.19.jar"
-            },
-            {
-                "coord": "com.fasterxml.jackson:jackson-bom:2.9.10",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": null
-            },
-            {
-                "coord": "com.github.fommil.netlib:all:1.1.2",
-                "dependencies": [
-                    "com.github.fommil.netlib:core:1.1.2",
-                    "com.github.fommil.netlib:native_ref-java:1.1",
-                    "com.github.fommil.netlib:native_system-java:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-linux-armhf:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-linux-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-linux-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-osx-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-win-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-win-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-linux-armhf:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-linux-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-linux-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-osx-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-win-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-win-x86_64:jar:natives:1.1",
-                    "com.github.fommil:jniloader:1.1",
-                    "net.sourceforge.f2j:arpack_combined_all:0.1"
-                ],
-                "directDependencies": [
-                    "com.github.fommil.netlib:core:1.1.2",
-                    "com.github.fommil.netlib:netlib-native_ref-linux-armhf:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-linux-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-linux-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-osx-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-win-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_ref-win-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-linux-armhf:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-linux-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-linux-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-osx-x86_64:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-win-i686:jar:natives:1.1",
-                    "com.github.fommil.netlib:netlib-native_system-win-x86_64:jar:natives:1.1",
-                    "net.sourceforge.f2j:arpack_combined_all:0.1"
-                ],
-                "file": null
-            },
-            {
-                "coord": "com.github.oshi:oshi-parent:3.4.0",
-                "dependencies": [
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "directDependencies": [
-                    "org.slf4j:slf4j-api:1.7.25"
-                ],
-                "file": null
-            },
-            {
-                "coord": "org.junit:junit-bom:5.3.1",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": null
             }
         ],
         "version": "0.1.0"

--- a/tests/custom_maven_install/unsafe_shared_cache_with_pinning_install.json
+++ b/tests/custom_maven_install/unsafe_shared_cache_with_pinning_install.json
@@ -6,17 +6,6 @@
         "conflict_resolution": {},
         "dependencies": [
             {
-                "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                "dependencies": [],
-                "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
-                ],
-                "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
-                "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
-            },
-            {
                 "coord": "com.google.code.findbugs:jsr305:3.0.2",
                 "dependencies": [],
                 "directDependencies": [],
@@ -28,15 +17,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
             },
             {
-                "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
+                    "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
                 ],
-                "sha256": "626adccd4894bee72c3f9a0384812240dcc1282fb37a87a3f6cb94924a089496",
-                "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
+                "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
+                "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
             },
             {
                 "coord": "com.google.errorprone:error_prone_annotations:2.2.0",
@@ -50,15 +39,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar"
             },
             {
-                "coord": "com.google.guava:failureaccess:jar:sources:1.0",
+                "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar"
+                    "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
                 ],
-                "sha256": "fec5411553b969fc82d30d6de300e6d2b011c768f306490e4866441a1c54232d",
-                "url": "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar"
+                "sha256": "626adccd4894bee72c3f9a0384812240dcc1282fb37a87a3f6cb94924a089496",
+                "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0-sources.jar"
             },
             {
                 "coord": "com.google.guava:failureaccess:1.0",
@@ -72,31 +61,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar"
             },
             {
-                "coord": "com.google.guava:guava:jar:sources:27.0-jre",
-                "dependencies": [
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
-                ],
-                "directDependencies": [
-                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
-                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
-                    "com.google.guava:failureaccess:jar:sources:1.0",
-                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
-                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
-                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
-                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
-                ],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar",
+                "coord": "com.google.guava:failureaccess:jar:sources:1.0",
+                "dependencies": [],
+                "directDependencies": [],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar"
+                    "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar"
                 ],
-                "sha256": "170dbf09858d1cffdaaa53d4d6ab15e6253c845318b0cc3bf21f8dffa9d433ab",
-                "url": "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar"
+                "sha256": "fec5411553b969fc82d30d6de300e6d2b011c768f306490e4866441a1c54232d",
+                "url": "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0-sources.jar"
             },
             {
                 "coord": "com.google.guava:guava:27.0-jre",
@@ -126,6 +99,33 @@
                 "url": "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar"
             },
             {
+                "coord": "com.google.guava:guava:jar:sources:27.0-jre",
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                ],
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.2.0",
+                    "com.google.guava:failureaccess:jar:sources:1.0",
+                    "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17"
+                ],
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar"
+                ],
+                "sha256": "170dbf09858d1cffdaaa53d4d6ab15e6253c845318b0cc3bf21f8dffa9d433ab",
+                "url": "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar"
+            },
+            {
                 "coord": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
                 "dependencies": [],
                 "directDependencies": [],
@@ -137,15 +137,10 @@
                 "url": "https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
             },
             {
-                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
-                "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
-                ],
-                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f",
-                "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
+                "file": null
             },
             {
                 "coord": "com.google.j2objc:j2objc-annotations:1.1",
@@ -159,15 +154,15 @@
                 "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
             },
             {
-                "coord": "org.checkerframework:checker-qual:jar:sources:2.5.2",
+                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
+                    "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
                 ],
-                "sha256": "821c5c63a6f156a3bb498c5bbb613580d9d8f4134131a5627d330fc4018669d2",
-                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
+                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f",
+                "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
             },
             {
                 "coord": "org.checkerframework:checker-qual:2.5.2",
@@ -181,15 +176,15 @@
                 "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar"
             },
             {
-                "coord": "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                "coord": "org.checkerframework:checker-qual:jar:sources:2.5.2",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar",
+                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
+                    "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
                 ],
-                "sha256": "2571474a676f775a8cdd15fb9b1da20c4c121ed7f42a5d93fca0e7b6e2015b40",
-                "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
+                "sha256": "821c5c63a6f156a3bb498c5bbb613580d9d8f4134131a5627d330fc4018669d2",
+                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2-sources.jar"
             },
             {
                 "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -203,10 +198,15 @@
                 "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
             },
             {
-                "coord": "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
+                "coord": "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
                 "dependencies": [],
                 "directDependencies": [],
-                "file": null
+                "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
+                ],
+                "sha256": "2571474a676f775a8cdd15fb9b1da20c4c121ed7f42a5d93fca0e7b6e2015b40",
+                "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
             }
         ],
         "version": "0.1.0"


### PR DESCRIPTION
Sorting the overall list of maven libraries by coordinate gives a stable order
with locality and makes it easy to understand/review changes.

When I wrote bazelbuild/rules_jvm_external#611, I did not believe this sort was
necessary; I think because something else was already producing dependencies in
sorted order. Maybe an upgrade to coursier or something else has changed this.

Either way, explicitly sorting by .coord is idempotent at worst, and it
guarantees the output will be sorted.

Also ran the following repinning commands, not all of which changed pinned files:

```
bazel run @unpinned_maven//:pin
bazel run @unpinned_policy_pinned_testing//:pin
bazel run @unpinned_maven_install_in_custom_location//:pin
bazel run @unpinned_json_artifacts_testing//:pin
bazel run @unpinned_unsafe_shared_cache_with_pinning//:pin
bazel run @unpinned_manifest_stamp_testing//:pin
bazel run @unpinned_regression_testing//:pin
```