### PR TITLE
Don't use jcenter.bintray.com in test, it is sort of EOL

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -420,7 +420,7 @@ maven_install(
         "com.google.code.findbugs:jsr305:3.0.2",
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
     ],
 )
 
@@ -447,7 +447,7 @@ maven_install(
         "com.android.support:appcompat-v7:28.0.0",
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
         "https://maven.google.com",
     ],
     fetch_sources = False,
@@ -463,7 +463,7 @@ maven_install(
         "com.android.support:appcompat-v7:28.0.0",
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
         "https://maven.google.com",
     ],
     use_starlark_android_rules = True,

--- a/tests/unit/jvm_import/jvm_import_test.bzl
+++ b/tests/unit/jvm_import/jvm_import_test.bzl
@@ -40,7 +40,7 @@ def _does_jvm_import_have_tags_impl(ctx):
 
     expected_tags = [
         "maven_coordinates=com.google.code.findbugs:jsr305:3.0.2",
-        "maven_url=https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "maven_url=https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
     ]
 
     asserts.equals(env, ctx.attr.src[TagsInfo].tags, expected_tags)


### PR DESCRIPTION
Replace with https://repo1.maven.org/maven2

Test can time out fetching from jcenter like in
https://buildkite.com/bazel/rules-jvm-external/builds/2461#c70711ec-e59f-48e9-b925-7d755a014070

It seems that in the end it is supposed to be maintained as read-only but atm times out
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/