### PR TITLE
Add explicit jq-linux condition for linux_aarch64.

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -49,6 +49,7 @@ genrule(
     cmd = "cp $< $@",
     outs = ["jq"],
     srcs = select({{
+        "@bazel_tools//src/conditions:linux_aarch64": ["jq-linux"],
         "@bazel_tools//src/conditions:linux_x86_64": ["jq-linux"],
         "@bazel_tools//src/conditions:darwin": ["jq-macos"],
         "@bazel_tools//src/conditions:windows": ["jq-windows"],


### PR DESCRIPTION
This makes everything work as anticipated when using Docker/arm64 linux + MacOS M1.