### PR TITLE
Set minimum Bazel support to 4.x by updating tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,9 +27,9 @@ tasks:
       # These tests are currently incompatible with RBE
       - "-//tests/integration/override_targets"
       - "-//tests/com/jvm/external/maven:OutdatedTest"
-  ubuntu1804_1_0_1:
+  ubuntu1804_3_5_1:
     platform: ubuntu1804
-    bazel: 1.0.1
+    bazel: 3.5.1
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
@@ -37,9 +37,9 @@ tasks:
     test_targets:
       - "--"
       - "//..."
-  ubuntu1804_1_1_0:
+  ubuntu1804_4_2_2:
     platform: ubuntu1804
-    bazel: 1.1.0
+    bazel: 4.2.2
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
@@ -47,9 +47,9 @@ tasks:
     test_targets:
       - "--"
       - "//..."
-  ubuntu1804_1_2_0:
+  ubuntu1804_5_0_0:
     platform: ubuntu1804
-    bazel: 1.2.0
+    bazel: 5.0.0
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,9 +27,9 @@ tasks:
       # These tests are currently incompatible with RBE
       - "-//tests/integration/override_targets"
       - "-//tests/com/jvm/external/maven:OutdatedTest"
-  ubuntu1804_3_5_1:
+  ubuntu1804_4_0_0:
     platform: ubuntu1804
-    bazel: 3.5.1
+    bazel: 4.0.0
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Table of Contents
 Get the [latest release
 here](https://github.com/bazelbuild/rules_jvm_external/releases/latest).
 
+## Prerequisites
+
+* Bazel 4.0.0 and above
+
+Support for Bazel versions before `4.0.0` is only available on rules_jvm_external releases `4.2` or earlier.
+
 ## Usage
 
 List the top-level Maven artifacts and servers in the WORKSPACE:


### PR DESCRIPTION
Removing 1.x, adding 4.x and 5.x