### PR TITLE
Implement allowlist mode for transitive artifacts

### DIFF
--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -25,7 +25,8 @@ def maven_install(
         fail_if_repin_required = False,
         use_starlark_android_rules = False,
         aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
-        duplicate_version_warning = "warn"):
+        duplicate_version_warning = "warn",
+        allowlist_mode = False,):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -126,6 +127,7 @@ def maven_install(
         use_starlark_android_rules = use_starlark_android_rules,
         aar_import_bzl_label = aar_import_bzl_label,
         duplicate_version_warning = duplicate_version_warning,
+        allowlist_mode = allowlist_mode,
     )
 
     if maven_install_json != None:


### PR DESCRIPTION
This PR introduces an option called `allowlist_mode` to allow stricter control on what transitive dependencies get downloaded / included, closes #663.
The idea is pretty simple: use all declared `artifacts` as an allowlist and filter the coursier deptree using the allowlist so that no undeclared artifact can be downloaded.