### PR TITLE
Allow compile jars to strip illegal automatic module names

### DIFF
--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -41,6 +41,10 @@ def _jvm_import_impl(ctx):
     # the lint check will emit a `bad path element` warning. We get quiet and
     # correct builds if we remove the `Class-Path` manifest entry entirely.
     args.add_all(["--remove-entry", "Class-Path"])
+
+    # Make sure the compile jar is safe to compile with
+    args.add("--make-safe")
+
     ctx.actions.run(
         executable = ctx.executable._add_jar_manifest_entry,
         arguments = [args],

--- a/private/tools/java/rules/jvm/external/jar/AddJarManifestEntry.java
+++ b/private/tools/java/rules/jvm/external/jar/AddJarManifestEntry.java
@@ -249,11 +249,9 @@ public class AddJarManifestEntry {
     });
     toRemove.forEach(name -> manifest.getMainAttributes().remove(new Attributes.Name(name)));
 
-    if (!makeSafe) {
-      return;
+    if (makeSafe) {
+      checkAutomaticModuleName(jar, manifest);
     }
-
-    checkAutomaticModuleName(jar, manifest);
   }
 
   private static Manifest checkAutomaticModuleName(Path jar, Manifest manifest) {


### PR DESCRIPTION
There are plenty of jars out there that have an `Automatic-Module-Name`
that isn't legal. Normally, this doesn't matter too much, but when
compiling code with a modern compiler bazel will use a module path,
and that cares _a lot_, causing builds to fail.

To rectify this, we can pass an additional flag when creating the
compile jar that will strip illegal automatic module names from the
generated manifests.