### PR TITLE
java_export: set default testonly = None

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -10,7 +10,7 @@ def java_export(
         pom_template = None,
         visibility = None,
         tags = [],
-        testonly = False,
+        testonly = None,
         **kwargs):
     """Extends `java_library` to allow maven artifacts to be uploaded.
 

--- a/private/rules/kt_jvm_export.bzl
+++ b/private/rules/kt_jvm_export.bzl
@@ -8,7 +8,7 @@ def kt_jvm_export(
         pom_template = None,
         visibility = None,
         tags = [],
-        testonly = False,
+        testonly = None,
         **kwargs):
     """Extends `kt_jvm_library` to allow maven artifacts to be uploaded. This
     rule is the Kotlin JVM version of `java_export`.


### PR DESCRIPTION
This is a followup for #674.
I noticed that having `testonly=False` by default overrides packages' `default_testonly` value unnecessarily.