### PR TITLE
Stop hard-coding `-source 8 -target 8`

### DIFF
--- a/private/tools/java/rules/jvm/external/jar/BUILD
+++ b/private/tools/java/rules/jvm/external/jar/BUILD
@@ -1,12 +1,6 @@
 java_binary(
     name = "AddJarManifestEntry",
     srcs = ["AddJarManifestEntry.java"],
-    javacopts = [
-        "-source",
-        "8",
-        "-target",
-        "8",
-    ],
     main_class = "rules.jvm.external.jar.AddJarManifestEntry",
     visibility = [
         "//visibility:public",
@@ -21,12 +15,6 @@ java_binary(
     srcs = [
         "DuplicateEntryStrategy.java",
         "MergeJars.java",
-    ],
-    javacopts = [
-        "-source",
-        "8",
-        "-target",
-        "8",
     ],
     main_class = "rules.jvm.external.jar.MergeJars",
     visibility = [

--- a/private/tools/java/rules/jvm/external/javadoc/BUILD
+++ b/private/tools/java/rules/jvm/external/javadoc/BUILD
@@ -1,12 +1,6 @@
 java_binary(
     name = "javadoc",
     srcs = glob(["*.java"]),
-    javacopts = [
-        "-source",
-        "8",
-        "-target",
-        "8",
-    ],
     main_class = "rules.jvm.external.javadoc.JavadocJarMaker",
     visibility = [
         "//visibility:public",

--- a/private/tools/java/rules/jvm/external/maven/BUILD
+++ b/private/tools/java/rules/jvm/external/maven/BUILD
@@ -3,12 +3,6 @@ load("@rules_jvm_external//:defs.bzl", "artifact")
 java_binary(
     name = "MavenPublisher",
     srcs = ["MavenPublisher.java"],
-    javacopts = [
-        "-source",
-        "8",
-        "-target",
-        "8",
-    ],
     main_class = "rules.jvm.external.maven.MavenPublisher",
     visibility = ["//visibility:public"],
     deps = [
@@ -27,12 +21,6 @@ java_binary(
 java_binary(
     name = "outdated",
     srcs = ["Outdated.java"],
-    javacopts = [
-        "-source",
-        "8",
-        "-target",
-        "8",
-    ],
     main_class = "rules.jvm.external.maven.Outdated",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
And instead compile with whatever the default `--tool_java_language_version` is. Explicitly specifying a language level for individual targets should be unecessary.

I noticed this debugging https://github.com/bazelbuild/bazel/issues/15272