### PR TITLE
WIP: Rules license support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -548,3 +548,13 @@ rbe_autoconfig(name = "buildkite_config")
 load("//migration:maven_jar_migrator_deps.bzl", "maven_jar_migrator_repositories")
 
 maven_jar_migrator_repositories()
+
+RULE_LICENSE_COMMIT = "683e47b13cb92cb3c2f484e35c6573a100f8fd25"
+
+http_archive(
+    name = "rules_license",
+    sha256 = "78ffce40439a2af5b1d289a0a8f3b9aabc3857a527080164fb2e02b06b654130",
+    strip_prefix = "rules_license-%s" % RULE_LICENSE_COMMIT,
+    url = "https://github.com/bazelbuild/rules_license/archive/%s.zip" % RULE_LICENSE_COMMIT,
+)
+

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -158,6 +158,12 @@ def _get_aar_import_statement_or_empty_str(repository_ctx):
     else:
         return ""
 
+def _get_rules_license_import_statement_or_empty_str(repository_ctx):
+    if repository_ctx.attr.license_json:
+        return "load(\"@rules_license//rules:license.bzl\", \"license\")" 
+    else:
+        return ""
+
 def _java_path(repository_ctx):
     java_home = repository_ctx.os.environ.get("JAVA_HOME")
     if java_home != None:
@@ -539,7 +545,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
             repository_name = repository_ctx.name,
             imports = generated_imports,
             aar_import_statement = _get_aar_import_statement_or_empty_str(repository_ctx),
-            rules_license_import_statement = "load(\"@rules_license//rules:license.bzl\", \"license\")" if repository_ctx.attr.license_json else "",
+            rules_license_import_statement = _get_rules_license_import_statement_or_empty_str(repository_ctx),
         ),
         executable = False,
     )
@@ -1057,7 +1063,7 @@ def _coursier_fetch_impl(repository_ctx):
             repository_name = repository_name,
             imports = generated_imports,
             aar_import_statement = _get_aar_import_statement_or_empty_str(repository_ctx),
-            rules_license_import_statement = "load(\"@rules_license//rules:license.bzl\", \"license\")" if repository_ctx.attr.license_json else "",
+            rules_license_import_statement = _get_rules_license_import_statement_or_empty_str(repository_ctx),
         ),
         executable = False,
     )
@@ -1240,7 +1246,7 @@ coursier_fetch = repository_rule(
                 "none",
             ],
         ),
-        "license_json": attr.label(),
+        "license_json": attr.label(doc = "JSON representing rules_license's necessary metadata for applying licenses to imported artifacts"),
     },
     environ = [
         "JAVA_HOME",

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -787,13 +787,6 @@ def _download_jq(repository_ctx):
         repository_ctx.download(value.url, "jq-%s" % os, sha256 = value.sha256, executable = True)
 
 def _coursier_fetch_impl(repository_ctx):
-    print("DAM from _coursier_fetch_impl")
-
-    # print("license_info", license_info)
-    # print("license_info", license_info["example:package:id"])
-    # print("license_json ", repository_ctx.attr.license_json.workspace_root)
-    # print("license_json: ", repository_ctx.file(repository_ctx.attr.license_json))
-    # print("OriginPackageInfo: ", repository_ctx.attr.license_json[OriginPackageInfo].data)
     # Not using maven_install.json, so we resolve and fetch from scratch.
     # This takes significantly longer as it doesn't rely on any local
     # caches and uses Coursier's own download mechanisms.

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -47,7 +47,7 @@ def _deduplicate_list(items):
 # tree.
 #
 # Made function public for testing.
-def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_artifacts, testonly_artifacts, override_targets):
+def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_artifacts, testonly_artifacts, override_targets, license_info):
     # The list of java_import/aar_import declaration strings to be joined at the end
     all_imports = []
 
@@ -293,7 +293,35 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
                 target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % v for v in default_visibilities])))
                 alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % v for v in default_visibilities]))
 
-            # 9. Finish the java_import rule.
+            # 9. If `strict_visibility` is True in the artifact spec, define public
+            #    visibility only for non-transitive dependencies.
+            #
+            # java_import(
+            # 	name = "org_hamcrest_hamcrest_library",
+            # 	jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
+            # 	srcjar = "https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+            # 	deps = [
+            # 		":org_hamcrest_hamcrest_core",
+            # 	],
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
+            #   neverlink = True,
+            #   testonly = True,
+            #   visibility = ["//visibility:public"],
+            #   applicable_licenses = ["@myorg_compliance//licenses:license-org.hamcrest:hamcrest.library:1.3"]
+            target_import_string.append("\tapplicable_licenses = [")
+
+            if artifact["coord"] in license_info:
+                licenses = license_info[artifact["coord"]]
+                # target_import_labels.append("\t\t\"%s\",\n" % dep_target_label)
+                for license in licenses:
+                    print(license)
+                    target_import_string.append("\t\t\":%s\"," % (license["name"]))
+            target_import_string.append("\t],")     
+
+            # 10. Finish the java_import rule.
             #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library",
@@ -313,7 +341,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
 
             all_imports.append("\n".join(target_import_string))
 
-            # 10. Create a versionless alias target
+            # 11. Create a versionless alias target
             #
             # alias(
             #   name = "org_hamcrest_hamcrest_library_1_3",
@@ -323,7 +351,21 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n%s)" %
                                (versioned_target_alias_label, target_label, alias_visibility))
 
-            # 11. If using maven_install.json, use a genrule to copy the file from the http_file
+            # 13. If there is a corresponding for the artifact, create a license target.
+            #
+            # license(
+            #   name = "license-org.hamcrest:hamcrest.library:1.3",
+            #   license_text = "LICENSE-org.hamcrest:hamcrest.library:1.3",
+            #   package_name = "org.hamcrest:hamcrest.library:1.3",
+            #   license_kinds = [
+            #       "@rules_license//licenses/spdx:BSD-1-Clause", 
+            #   ]
+            # )
+            if artifact["coord"] in license_info:
+                for license in license_info[artifact["coord"]]:
+                    all_imports.append("license(\n\tname = \"%s\",\n\tliense_text = \"%s\",\n\tpackage_name = \"%s\",\n\tlicense_kinds = %s\n)" %
+                                        (license["name"], license["license_text"], license["package_name"], license["license_kinds"]))
+            # 12. If using maven_install.json, use a genrule to copy the file from the http_file
             # repository into this repository.
             #
             # genrule(
@@ -334,6 +376,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             # )
             if repository_ctx.attr.maven_install_json:
                 all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
+
 
         else:  # artifact_path == None:
             # Special case for certain artifacts that only come with a POM file.

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -350,7 +350,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n%s)" %
                                (versioned_target_alias_label, target_label, alias_visibility))
 
-            # 13. If there is a corresponding for the artifact, create a license target.
+            # 12. If there is a corresponding for the artifact, create a license target.
             #
             # license(
             #   name = "license-org.hamcrest:hamcrest.library:1.3",
@@ -364,7 +364,7 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
                 for license in license_info[artifact["coord"]]:
                     all_imports.append("license(\n\tname = \"%s\",\n\tliense_text = \"%s\",\n\tpackage_name = \"%s\",\n\tlicense_kinds = %s\n)" %
                                         (license["name"], license["license_text"], license["package_name"], license["license_kinds"]))
-            # 12. If using maven_install.json, use a genrule to copy the file from the http_file
+            # 13. If using maven_install.json, use a genrule to copy the file from the http_file
             # repository into this repository.
             #
             # genrule(

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -317,7 +317,6 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
                 licenses = license_info[artifact["coord"]]
                 # target_import_labels.append("\t\t\"%s\",\n" % dep_target_label)
                 for license in licenses:
-                    print(license)
                     target_import_string.append("\t\t\":%s\"," % (license["name"]))
             target_import_string.append("\t],")     
 

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -25,7 +25,9 @@ def maven_install(
         fail_if_repin_required = False,
         use_starlark_android_rules = False,
         aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
-        duplicate_version_warning = "warn"):
+        duplicate_version_warning = "warn",
+        license_json = None,
+        license_lookup = None):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -126,6 +128,7 @@ def maven_install(
         use_starlark_android_rules = use_starlark_android_rules,
         aar_import_bzl_label = aar_import_bzl_label,
         duplicate_version_warning = duplicate_version_warning,
+        license_json = license_json,
     )
 
     if maven_install_json != None:

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -26,8 +26,7 @@ def maven_install(
         use_starlark_android_rules = False,
         aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
         duplicate_version_warning = "warn",
-        license_json = None,
-        license_lookup = None):
+        license_json = None):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve


### PR DESCRIPTION
This change updates maven_install to accept a JSON file with license info metadata, so it can then generate a rule_license license instances in the BUILD file it creates. In the BUILD file, maven_install will use the applicable_licenses global attribute to add the license to the artifact.

See an example usage of this feature here: https://github.com/bazelbuild/rules_license/pull/35

https://docs.google.com/document/d/1XnDEQArn_hAIiExSHPgo8v2UZWP3eRf0OtUldLuHso8/edit#