### PR TITLE
Don't fail if an error response is missing during publishing

### DIFF
--- a/private/tools/java/rules/jvm/external/maven/MavenPublisher.java
+++ b/private/tools/java/rules/jvm/external/maven/MavenPublisher.java
@@ -216,8 +216,15 @@ public class MavenPublisher {
 
         if (code < 200 || code > 299) {
           try (InputStream in = connection.getErrorStream()) {
-            String message = new String(ByteStreams.toByteArray(in));
-            throw new IOException(String.format("Unable to upload %s (%s) %s", targetUrl, code, message));
+            String message;
+            if (in != null) {
+              String body = new String(ByteStreams.toByteArray(in));
+              message = String.format("Unable to upload %s (%s) %s", targetUrl, code, body);
+            } else {
+              message = String.format("Unable to upload %s (%s)", targetUrl, code);
+            }
+
+            throw new IOException(message);
           }
         }
       }


### PR DESCRIPTION
HttpURLConnection.getErrorStream is allowed to return null, and when this happens an NPE is raised:

```
INFO: Uploading to https://...
Exception in thread "main" java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
	at rules.jvm.external.maven.MavenPublisher.main(MavenPublisher.java:99)
Caused by: java.lang.NullPointerException
	at rules.jvm.external.ByteStreams.copy(ByteStreams.java:26)
	at rules.jvm.external.ByteStreams.toByteArray(ByteStreams.java:18)
	at rules.jvm.external.maven.MavenPublisher.lambda$httpUpload$1(MavenPublisher.java:219)
	at rules.jvm.external.maven.MavenPublisher.lambda$upload$0(MavenPublisher.java:182)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```