### PR TITLE
Pass downloaded_file_path to http_file

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -486,6 +486,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
                 # later version than the url field, so not all maven_install.json
                 # contains the mirror_urls field.
                 http_files.append("        urls = [\"%s\"]," % artifact["url"])
+            http_files.append("        downloaded_file_path = \"%s\"," % artifact["file"])
             http_files.append("    )")
 
     http_files.extend(_get_jq_http_files())

--- a/tests/unit/aar_import/BUILD
+++ b/tests/unit/aar_import/BUILD
@@ -1,5 +1,32 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(":aar_import_test.bzl", "aar_import_test_suite")
+
+aar_import(
+    name = "aar_import_that_consumes_the_downloaded_file_directly",
+    # Will produce an error if the downloaded file does not have the `.aar` file extension
+    aar = "@com_android_support_appcompat_v7_28_0_0//file:file",
+)
+
+build_test(
+    name = "test_does_aar_artifact_have_the_correct_file_extension",
+    targets = [
+        ":aar_import_that_consumes_the_downloaded_file_directly",
+    ],
+)
 
 build_test(
     name = "starlark_aar_import_test",

--- a/tests/unit/jvm_import/BUILD
+++ b/tests/unit/jvm_import/BUILD
@@ -13,5 +13,19 @@
 # limitations under the License.
 
 load(":jvm_import_test.bzl", "jvm_import_test_suite")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+java_import(
+    name = "java_import_that_consumes_the_downloaded_file_directly",
+    # Will produce an error if the downloaded file does not have the `.jar` file extension
+    jars = ["@com_google_guava_guava_27_0_jre//file"],
+)
+
+build_test(
+    name = "test_does_jar_artifact_have_the_correct_file_extension",
+    targets = [
+        ":java_import_that_consumes_the_downloaded_file_directly",
+    ],
+)
 
 jvm_import_test_suite(name = "jvm_import_tests")


### PR DESCRIPTION
Ensures that the correct file extensions exist on the files being downloaded

https://github.com/bazelbuild/rules_jvm_external/issues/684