### PR TITLE
Quote java arguments written to arguments file.

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -16,7 +16,7 @@ load("//:specs.bzl", "parse", "utils")
 load("//private:artifact_utilities.bzl", "deduplicate_and_sort_artifacts")
 load("//private:coursier_utilities.bzl", "SUPPORTED_PACKAGING_TYPES", "escape", "is_maven_local_path")
 load("//private:dependency_tree_parser.bzl", "JETIFY_INCLUDE_LIST_JETIFY_ALL", "parser")
-load("//private:java_utilities.bzl", "parse_java_version")
+load("//private:java_utilities.bzl", "build_java_argsfile_content", "parse_java_version")
 load("//private:proxy.bzl", "get_java_proxy_args")
 load(
     "//private:versions.bzl",
@@ -816,7 +816,7 @@ def make_coursier_dep_tree(
             java_args = cmd[1:]
             repository_ctx.file(
                 "java_argsfile",
-                "\n".join([str(f) for f in java_args]) + "\n",
+                build_java_argsfile_content(java_args),
                 executable = False,
             )
             cmd = [java_cmd, "@{}".format(repository_ctx.path("java_argsfile"))]

--- a/private/java_utilities.bzl
+++ b/private/java_utilities.bzl
@@ -25,3 +25,11 @@ def parse_java_version(java_version_output):
         return int(java_version.split(".")[0])
 
     return None
+
+# Build the contents of a java Command-Line Argument File from a list of
+# arguments.
+#
+# This quotes all arguments (and escapes all quotation marks in arguments) so
+# that arguments containing white space are treated as single arguments.
+def build_java_argsfile_content(args):
+    return "\n".join(['"' + str(f).replace('"', r'\"') + '"' for f in args]) + "\n"

--- a/tests/unit/java_utilities_test.bzl
+++ b/tests/unit/java_utilities_test.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//private:java_utilities.bzl", "parse_java_version")
+load("//private:java_utilities.bzl", "build_java_argsfile_content", "parse_java_version")
 
 def _parse_java_version_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -72,8 +72,32 @@ OpenJDK 64-Bit Server VM (build 15+36-1562, mixed mode, sharing)
 
 parse_java_version_test = unittest.make(_parse_java_version_test_impl)
 
+def _build_java_argsfile_content_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        """"--credentials"
+"some.private.maven.re johndoe:example-password"
+""",
+        build_java_argsfile_content(["--credentials", "some.private.maven.re johndoe:example-password"]),
+    )
+
+    asserts.equals(
+        env,
+        """"--credentials"
+"some.private.maven.re johndoe:example-password-with-\\"quotation-marks\\""
+""",
+        build_java_argsfile_content(["--credentials", "some.private.maven.re johndoe:example-password-with-\"quotation-marks\""]),
+    )
+
+    return unittest.end(env)
+
+build_java_argsfile_content_test = unittest.make(_build_java_argsfile_content_test_impl)
+
 def java_utilities_test_suite():
     unittest.suite(
         "java_utilities_tests",
         parse_java_version_test,
+        build_java_argsfile_content_test,
     )


### PR DESCRIPTION
This pull request is intended to fix the `java` Command-Line Argument File creation so that arguments are quoted (i.e. they are wrapped in quotes, and any quotes inside an argument are escaped). See #720 for context. In particular, this allows arguments with white space to be treated as single arguments. In particular this fixes the passing of `--credentials` arguments to coursier, which are expected to have a format like `--credentials "oss.sonatype.org alex-sonatype:aLeXsOnAtYpE"`

* See https://docs.oracle.com/en/java/javase/18/docs/specs/man/java.html#java-command-line-argument-files for the `java` Command-Line Argument File specs.
* See https://get-coursier.io/docs/other-credentials.html#inline for the coursier inline credentials format.