### PR TITLE
Enable pinned_coursier_fetch to use the Starlark version of aar_import

### DIFF
--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -146,4 +146,6 @@ def maven_install(
             additional_netrc_lines = additional_netrc_lines,
             fail_if_repin_required = fail_if_repin_required,
             duplicate_version_warning = duplicate_version_warning,
+            use_starlark_android_rules = use_starlark_android_rules,
+            aar_import_bzl_label = aar_import_bzl_label,
         )


### PR DESCRIPTION
see https://github.com/bazelbuild/bazel/issues/5354

pinned_coursier_fetch was missed in original pr https://github.com/bazelbuild/rules_jvm_external/pull/526