### PR TITLE
Create empty directories in merged zip files

### DIFF
--- a/tests/com/jvm/external/jar/MergeJarsTest.java
+++ b/tests/com/jvm/external/jar/MergeJarsTest.java
@@ -1,6 +1,9 @@
 package com.jvm.external.jar;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +18,8 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -363,21 +368,68 @@ public class MergeJarsTest {
             "--sources", input.toAbsolutePath().toString(),
     });
 
-    Set<String> dirNames = new HashSet<>();
-    try (InputStream is = Files.newInputStream(output);
-         ZipInputStream zis = new ZipInputStream(is)) {
-      ZipEntry entry = zis.getNextEntry();
-      while (entry != null) {
-        if (entry.isDirectory()) {
-          dirNames.add(entry.getName());
-        }
-        entry = zis.getNextEntry();
-      }
+    List<String> dirNames = readDirNames(output);
 
-      assertTrue(dirNames.toString(), dirNames.contains("foo/"));
-      assertTrue(dirNames.toString(), dirNames.contains("foo/bar/"));
-    }
+    assertTrue(dirNames.toString(), dirNames.contains("foo/"));
+    assertTrue(dirNames.toString(), dirNames.contains("foo/bar/"));
+  }
 
+  @Test
+  public void shouldNotBeConfusedBySimilarNamesWhenCreatingDirectories() throws IOException {
+    Path input = temp.newFile("example.jar").toPath();
+    createJar(input, ImmutableMap.of(
+            "foo/bar/baz.txt", "Hello, World!",
+            "foo/bar/baz/qux.txt", "Goodbye, cruel World!"));
+
+    Path output = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[] {
+            "--output", output.toAbsolutePath().toString(),
+            "--sources", input.toAbsolutePath().toString(),
+    });
+
+    List<String> dirNames = readDirNames(output);
+
+    assertTrue(dirNames.toString(), dirNames.contains("foo/"));
+    assertTrue(dirNames.toString(), dirNames.contains("foo/bar/"));
+    assertTrue(dirNames.toString(), dirNames.contains("foo/bar/baz/"));
+
+    Map<String, String> contents = readJar(output);
+    assertEquals("Hello, World!", contents.get("foo/bar/baz.txt"));
+    assertEquals("Goodbye, cruel World!", contents.get("foo/bar/baz/qux.txt"));
+  }
+
+  @Test
+  public void orderingOfAutomaticallyCreatedDirectoriesIsConduciveToSensibleUnpacking() throws IOException {
+    Path input = temp.newFile("example.jar").toPath();
+    createJar(input, ImmutableMap.of(
+            "foo/bar/baz/qux/quux.txt", "Greetings, fellow mortal",
+            "foo/bar/baz.txt", "Hello, World!"));
+
+    Path output = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(new String[] {
+            "--output", output.toAbsolutePath().toString(),
+            "--sources", input.toAbsolutePath().toString(),
+    });
+
+    // We want `foo/` to appear before `foo/bar/` and so on so that a simple unzipper can
+    // just walk the zip, creating directories as it goes, and have everything work the
+    // way we expect.
+    List<String> dirNames = readDirNames(output);
+
+    int indexOfFoo = dirNames.indexOf("foo/");
+    int indexOfBar = dirNames.indexOf("foo/bar/");
+
+    assertTrue(indexOfBar > indexOfFoo);
+
+    int indexOfBaz = dirNames.indexOf("foo/bar/baz/");
+
+    assertTrue(indexOfBaz > indexOfBar);
+
+    int indexOfQux = dirNames.indexOf("foo/bar/baz/qux/");
+
+    assertTrue(indexOfQux > indexOfBaz);
   }
 
   private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
@@ -427,5 +479,23 @@ public class MergeJarsTest {
     }
 
     return builder.build();
+  }
+
+  private static List<String> readDirNames(Path output) throws IOException {
+    // Ordering matters! Retain insertion order
+    ImmutableList.Builder<String> dirNames = ImmutableList.builder();
+
+    try (InputStream is = Files.newInputStream(output);
+         ZipInputStream zis = new ZipInputStream(is)) {
+      ZipEntry entry = zis.getNextEntry();
+      while (entry != null) {
+        if (entry.isDirectory()) {
+          dirNames.add(entry.getName());
+        }
+        entry = zis.getNextEntry();
+      }
+    }
+
+    return dirNames.build();
   }
 }


### PR DESCRIPTION
Without this, some tools will not correctly unpack zip
files in some cases. This also restores behaviour from
rje where we would create these intermediate folders.