### PR TITLE
Pin rje to a hermetic Java 11 and use the `artifact` macro

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
-build --java_language_version=11
+build --java_language_version=8
 build --java_runtime_version=remotejdk_11
 
-build --tool_java_language_version=11
+build --tool_java_language_version=8
 build --tool_java_runtime_version=remotejdk_11
 
 build --experimental_strict_java_deps=strict

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,13 @@
+build --java_language_version=11
+build --java_runtime_version=remotejdk_11
+
+build --tool_java_language_version=11
+build --tool_java_runtime_version=remotejdk_11
+
+build --experimental_strict_java_deps=strict
+build --explicit_java_test_deps
+
 # Make sure we get something helpful when tests fail
 test --verbose_failures
 test --test_output=errors
+

--- a/private/tools/java/rules/jvm/external/BUILD
+++ b/private/tools/java/rules/jvm/external/BUILD
@@ -14,16 +14,6 @@ java_library(
     srcs = ["Hasher.java"],
     visibility = [
         "//private/tools:__subpackages__",
-    ],
-)
-
-java_test(
-    name = "HasherTest",
-    size = "small",
-    srcs = ["HasherTest.java"],
-    test_class = "rules.jvm.external.HasherTest",
-    deps = [
-        ":hasher",
-        artifact("org.hamcrest:hamcrest"),
+        "//tests/com/jvm/external:__pkg__",
     ],
 )

--- a/private/tools/java/rules/jvm/external/BUILD
+++ b/private/tools/java/rules/jvm/external/BUILD
@@ -1,3 +1,5 @@
+load("//:defs.bzl", "artifact")
+
 java_library(
     name = "byte-streams",
     srcs = ["ByteStreams.java"],
@@ -22,6 +24,6 @@ java_test(
     test_class = "rules.jvm.external.HasherTest",
     deps = [
         ":hasher",
-        "@maven//:org_hamcrest_hamcrest",
+        artifact("org.hamcrest:hamcrest"),
     ],
 )

--- a/tests/com/jvm/external/BUILD
+++ b/tests/com/jvm/external/BUILD
@@ -45,6 +45,21 @@ java_test(
 )
 
 java_test(
+    name = "HasherTest",
+    size = "small",
+    srcs = ["HasherTest.java"],
+    test_class = "rules.jvm.external.HasherTest",
+    deps = [
+        "//private/tools/java/rules/jvm/external:hasher",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact("org.hamcrest:hamcrest"),
+    ],
+)
+
+java_test(
     name = "JsonArtifactsTest",
     srcs = ["JsonArtifactsTest.java"],
     test_class = "com.jvm.external.JsonArtifactsTest",

--- a/tests/com/jvm/external/BUILD
+++ b/tests/com/jvm/external/BUILD
@@ -1,11 +1,20 @@
+load("//:defs.bzl", "artifact")
+
 java_test(
     name = "ArtifactExclusionsTest",
     srcs = ["ArtifactExclusionsTest.java"],
     test_class = "com.jvm.external.ArtifactExclusionsTest",
     deps = [
-        "@exclusion_testing//:com_google_guava_guava",
-        "@maven//:org_hamcrest_hamcrest",
-        "@maven//:org_hamcrest_hamcrest_core",
+        artifact(
+            "com.google.guava:guava",
+            repository_name = "exclusion_testing",
+        ),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact("org.hamcrest:hamcrest"),
+        artifact("org.hamcrest:hamcrest_core"),
     ],
 )
 
@@ -14,11 +23,24 @@ java_test(
     srcs = ["GlobalArtifactExclusionsTest.java"],
     test_class = "com.jvm.external.GlobalArtifactExclusionsTest",
     deps = [
-        "@global_exclusion_testing//:com_diffplug_durian_durian_core",
-        "@global_exclusion_testing//:com_google_guava_guava",
-        "@global_exclusion_testing//:com_squareup_okhttp3_okhttp",
-        "@maven//:org_hamcrest_hamcrest",
-        "@maven//:org_hamcrest_hamcrest_core",
+        artifact(
+            "com.diffplug.durian:durian-core",
+            repository_name = "global_exclusion_testing",
+        ),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact(
+            "com.google.guava:guava",
+            repository_name = "global_exclusion_testing",
+        ),
+        artifact(
+            "com.squareup.okhttp3:okhttp",
+            repository_name = "global_exclusion_testing",
+        ),
+        artifact("org.hamcrest:hamcrest"),
+        artifact("org.hamcrest:hamcrest-core"),
     ],
 )
 
@@ -27,8 +49,18 @@ java_test(
     srcs = ["JsonArtifactsTest.java"],
     test_class = "com.jvm.external.JsonArtifactsTest",
     deps = [
-        "@json_artifacts_testing//:io_quarkus_quarkus_maven_plugin",
-        "@json_artifacts_testing//:org_json_json",
+        artifact(
+            "io.quarkus:quarkus-maven-plugin",
+            repository_name = "json_artifacts_testing",
+        ),
+        artifact(
+            "org.json:json",
+            repository_name = "json_artifacts_testing",
+        ),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
     ],
 )
 
@@ -37,8 +69,12 @@ java_test(
     srcs = ["NeverlinkTest.java"],
     test_class = "com.jvm.external.NeverlinkTest",
     deps = [
-        "@maven//:com_google_guava_guava",
-        "@maven//:org_hamcrest_hamcrest",
+        artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact("org.hamcrest:hamcrest"),
     ],
 )
 
@@ -49,7 +85,11 @@ java_test(
     test_class = "com.jvm.external.UnsafeSharedCacheTest",
     deps = [
         "//tests/integration:guava_import",
-        "@maven//:org_hamcrest_hamcrest",
-        "@maven//:org_hamcrest_hamcrest_core",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact("org.hamcrest:hamcrest"),
+        artifact("org.hamcrest:hamcrest-core"),
     ],
 )

--- a/tests/com/jvm/external/HasherTest.java
+++ b/tests/com/jvm/external/HasherTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import rules.jvm.external.Hasher;
 
 public class HasherTest {
 

--- a/tests/com/jvm/external/jar/BUILD
+++ b/tests/com/jvm/external/jar/BUILD
@@ -8,6 +8,10 @@ java_test(
         "//private/tools/java/rules/jvm/external:byte-streams",
         "//private/tools/java/rules/jvm/external/jar:AddJarManifestEntry",
         artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
     ],
 )
 
@@ -24,6 +28,10 @@ java_test(
     deps = [
         "//private/tools/java/rules/jvm/external/jar:ListPackages-lib",
         "@bazel_tools//tools/java/runfiles",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
         artifact("org.hamcrest:hamcrest"),
     ],
 )
@@ -37,5 +45,9 @@ java_test(
         "//private/tools/java/rules/jvm/external/jar:MergeJars",
         "//private/tools/java/rules/jvm/external/zip",
         artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
     ],
 )

--- a/tests/com/jvm/external/javadoc/BUILD
+++ b/tests/com/jvm/external/javadoc/BUILD
@@ -1,10 +1,16 @@
+load("//:defs.bzl", "artifact")
+
 java_test(
     name = "VersionTest",
     srcs = ["VersionTest.java"],
     test_class = "rules.jvm.external.javadoc.VersionTest",
     deps = [
         "//private/tools/java/rules/jvm/external/javadoc",
-        "@maven//:org_hamcrest_hamcrest",
-        "@maven//:org_hamcrest_hamcrest_core",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact("org.hamcrest:hamcrest"),
+        artifact("org.hamcrest:hamcrest-core"),
     ],
 )

--- a/tests/com/jvm/external/maven/BUILD
+++ b/tests/com/jvm/external/maven/BUILD
@@ -10,7 +10,15 @@ java_test(
     test_class = "com.jvm.external.maven.OutdatedTest",
     deps = [
         "//private/tools/java/rules/jvm/external/maven:outdated",
-        "@outdated//:org_apache_maven_maven_artifact",
         artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
+        artifact(
+            "org.apache.maven:maven-artifact",
+            repository_name = "outdated",
+        ),
+        artifact("org.hamcrest:hamcrest"),
     ],
 )

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -14,6 +14,10 @@ java_test(
     deps = [
         "//private/tools/java/rules/jvm/external/maven:MavenPublisher_deploy.jar",
         artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
         artifact("org.hamcrest:hamcrest"),
     ],
 )
@@ -31,6 +35,10 @@ java_test(
     deps = [
         ":project",
         artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing",
+        ),
         artifact("org.hamcrest:hamcrest"),
     ],
 )


### PR DESCRIPTION
We also enable strict dependencies, so we know what we
actually need to build, rather than picking up implicit
deps.