### PR TITLE
update bazel_skylib to latest version (1.2.1)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,10 +20,10 @@ http_file(
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This should fix the failures in rules_jvm_external with Bazel@Head: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2613#01831092-d150-49d8-877e-102eae2c35a5