### PR TITLE
Make `example/bzlmod/.bazelrc` a real file

### DIFF
--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -1,1 +1,4 @@
-../../.bazelrc
+import ../../.bazelrc
+
+common --experimental_enable_bzlmod
+build --java_language_version=11

--- a/examples/bzlmod/.bazelrc.example
+++ b/examples/bzlmod/.bazelrc.example
@@ -1,2 +1,0 @@
-common --experimental_enable_bzlmod
-build --java_language_version=11


### PR DESCRIPTION
The BCR tests append extra flags to it, so don't
fail when it's a symlink.