### PR TITLE
Filter java_export source jar based on deploy_env

### DIFF
--- a/private/rules/maven_project_jar.bzl
+++ b/private/rules/maven_project_jar.bzl
@@ -39,7 +39,9 @@ def _maven_project_jar_impl(ctx):
         ctx,
         ctx.executable._merge_jars,
         depset(artifact_srcs),
-        depset(transitive = [ji.transitive_source_jars for ji in info.dep_infos.to_list()]),
+        depset(transitive =
+                   [ji.transitive_source_jars for ji in info.dep_infos.to_list()] +
+                   [jar[JavaInfo].transitive_source_jars for jar in ctx.attr.deploy_env]),
         src_jar,
     )
 

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -116,3 +116,31 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+filegroup(
+    name = "deploy-env-sources",
+    srcs = [":deploy-env-project"],
+    output_group = "maven_source",
+)
+
+genrule(
+    name = "list-deploy-env-sources",
+    srcs = [
+        ":deploy-env-sources",
+    ],
+    outs = ["sources.txt"],
+    cmd = "for SRC in $(SRCS); do jar tf $$SRC >> $@; done",
+)
+
+sh_test(
+    name = "check-deploy-env-sources",
+    srcs = [
+        "check-deploy-env-sources.sh",
+    ],
+    data = [
+        ":sources.txt",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/integration/java_export/check-deploy-env-sources.sh
+++ b/tests/integration/java_export/check-deploy-env-sources.sh
@@ -1,0 +1,24 @@
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euox pipefail
+
+sources_file=$(rlocation rules_jvm_external/tests/integration/java_export/sources.txt)
+
+if grep -q Dependency.java "$sources_file"; then
+  echo "Unexpectedly found dependency source file in jar"
+  exit 1
+fi
+
+if ! grep -q Main.java "$sources_file"; then
+  echo "Missing main source file from jar"
+  exit 1
+fi


### PR DESCRIPTION
The project jar has entries coming from the deploy_env filtered out. This commit ensures that the same filtering applies to source jars.