### PR TITLE
Add deploy_env to java_exports's javadoc class path

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -153,7 +153,7 @@ def maven_export(
             name = docs_jar,
             deps = [
                 ":%s-project" % name,
-            ],
+            ] + deploy_env,
             javadocopts = javadocopts,
             visibility = visibility,
             tags = tags,


### PR DESCRIPTION
Javadoc may have to load classes only available on the deploy_env class path in order to generate the docs.