### PR TITLE
Enable manifest stamping by default

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,14 +10,11 @@ tasks:
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
       - tests/bazel_run_tests.sh
-    test_flags:
-      - "--//settings:stamp_manifest=True"
     test_targets:
       - "//..."
       # manual tests
       # TODO: Re-enable after fixing https://github.com/bazelbuild/rules_jvm_external/issues/375
       # - "//tests/com/jvm/external:UnsafeSharedCacheTest"
-      - "//tests/unit/manifest_stamp:diff_manifest_test" # https://github.com/bazelbuild/rules_jvm_external/issues/283
   rbe_ubuntu1604:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
@@ -82,14 +79,11 @@ tasks:
       - bazel run @unpinned_maven_install_in_custom_location//:pin
       - bazel run @duplicate_artifacts_test//:pin
       - tests/bazel_run_tests.sh
-    test_flags:
-      - "--//settings:stamp_manifest=True"
     test_targets:
       - "//..."
       # manual tests
       # commented out until https://github.com/bazelbuild/rules_jvm_external/issues/610 is fixed for Java 11
       # - "//tests/com/jvm/external:UnsafeSharedCacheTest"
-      - "//tests/unit/manifest_stamp:diff_manifest_test" # https://github.com/bazelbuild/rules_jvm_external/issues/283
   windows:
     environment:
       # This tests custom cache locations.

--- a/settings/BUILD
+++ b/settings/BUILD
@@ -8,5 +8,5 @@ exports_files(["stamp_manifest.bzl"])
 
 stamp_manifest(
     name = "stamp_manifest",
-    build_setting_default = False,
+    build_setting_default = True,
 )

--- a/tests/unit/manifest_stamp/BUILD
+++ b/tests/unit/manifest_stamp/BUILD
@@ -30,9 +30,6 @@ diff_test(
         "//conditions:default": "guava_MANIFEST.MF.golden.unix",
     }),
     file2 = "guava_MANIFEST.MF",
-    # TODO(https://github.com/bazelbuild/rules_jvm_external/issues/283): Fix reproducibility issues.
-    # This test requires --//settings:stamp_manifest.
-    tags = ["manual"],
 )
 
 genrule(


### PR DESCRIPTION
#285 introduced `Target-Label` "stamping" that is used to produce missing strict an unused dependency warnings as described in #283. #293 changed the implementation from using `singlejar` to  `jar umf`. The implementation had a hermeticity issue and to deal with this #355 disabled the stamping and introduced an option to enable it. #468 changed the implementation to use `AddJarManifestEntry` which still had a non-determinism issue which was later described in #735.

I believe the non-determinism in `AddJarManifestEntry` was fully resolved in #738 so this change re-enables the stamping by default, but in case I missed something keeps the option to disable it. A later release can remove the option completely.

The change also re-enables the test that was set to `manual` in #355.

Closes #283.