### PR TITLE
Strip username from pinned urls

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -998,7 +998,7 @@ def _coursier_fetch_impl(repository_ctx):
             # This file comes from maven local, so handle it in two different ways depending if
             # dependency pinning is used:
             # a) If the repository is unpinned, we keep the file as is, but clear the url to skip it
-            # b) Otherwise, we clear the url and also simlink the file from the mavel local directory
+            # b) Otherwise, we clear the url and also simlink the file from the maven local directory
             #    to file within the repository rule workspace
             print("Assuming maven local for artifact: %s" % artifact["coord"])
             artifact.update({"url": None})


### PR DESCRIPTION
As described in #574 there is a situation where we depend on a private repository which requires authentication, and that authentication is provided through coursier properties files. In this case it's not ideal that the username of the person who performed a pinning is present in both the file and url attributes stored in the pinned json file. This creates quite a bit of noise when reviewing changes.

This PR attempts to clean away this string without affecting other authentication flows. I'm fairly new to starlark and this project in particular so it's very possible that I've overlooked potential side effects. PTAL