### PR TITLE
fix NO_PROXY handling under Java 9+

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -117,6 +117,13 @@ def _is_file(repository_ctx, path):
 def _is_directory(repository_ctx, path):
     return repository_ctx.which("test") and repository_ctx.execute(["test", "-d", path]).return_code == 0
 
+def _shell_quote(s):
+    # Lifted from
+    #   https://github.com/bazelbuild/bazel-skylib/blob/6a17363a3c27dde70ab5002ad9f2e29aff1e1f4b/lib/shell.bzl#L49
+    # because this file cannot load symbols from bazel_skylib since commit
+    # 47505f644299aa2483d0df06c2bb2c7aa10d26d4.
+    return "'" + s.replace("'", "'\\''") + "'"
+
 def _execute(repository_ctx, cmd, timeout = 600, environment = {}, progress_message = None):
     if progress_message:
         repository_ctx.report_progress(progress_message)
@@ -426,7 +433,7 @@ def _add_outdated_files(repository_ctx, artifacts, repositories):
         repository_ctx.attr._outdated,
         {
             "{repository_name}": repository_ctx.name,
-            "{proxy_opts}": " ".join(_get_java_proxy_args(repository_ctx)),
+            "{proxy_opts}": " ".join([_shell_quote(arg) for arg in _get_java_proxy_args(repository_ctx)]),
         },
         executable = True,
     )

--- a/private/proxy.bzl
+++ b/private/proxy.bzl
@@ -73,6 +73,6 @@ def get_java_proxy_args(http_proxy, https_proxy, no_proxy):
     if no_proxy:
         if no_proxy.startswith("."):
             no_proxy = "*" + no_proxy
-        proxy_args.append("-Dhttp.nonProxyHosts='%s'" % no_proxy.replace(",", "|").replace("|.", "|*."))
+        proxy_args.append("-Dhttp.nonProxyHosts=%s" % no_proxy.replace(",", "|").replace("|.", "|*."))
 
     return proxy_args

--- a/tests/unit/proxy_test.bzl
+++ b/tests/unit/proxy_test.bzl
@@ -18,7 +18,7 @@ def _java_proxy_parsing_no_scheme_test_impl(ctx):
             "-Dhttp.proxyPort=8888",
             "-Dhttps.proxyHost=localhost",
             "-Dhttps.proxyPort=8843",
-            "-Dhttp.nonProxyHosts='google.com'",
+            "-Dhttp.nonProxyHosts=google.com",
         ],
         get_java_proxy_args("localhost:8888", "localhost:8843", "google.com"),
     )
@@ -35,7 +35,7 @@ def _java_proxy_parsing_no_user_test_impl(ctx):
             "-Dhttp.proxyPort=80",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
-            "-Dhttp.nonProxyHosts='google.com'",
+            "-Dhttp.nonProxyHosts=google.com",
         ],
         get_java_proxy_args("http://example.com:80", "https://secureexample.com:443", "google.com"),
     )
@@ -50,7 +50,7 @@ def _java_proxy_parsing_no_port_test_impl(ctx):
         [
             "-Dhttp.proxyHost=example.com",
             "-Dhttps.proxyHost=secureexample.com",
-            "-Dhttp.nonProxyHosts='google.com'",
+            "-Dhttp.nonProxyHosts=google.com",
         ],
         get_java_proxy_args("http://example.com", "https://secureexample.com", "google.com"),
     )
@@ -67,7 +67,7 @@ def _java_proxy_parsing_trailing_slash_test_impl(ctx):
             "-Dhttp.proxyPort=80",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
-            "-Dhttp.nonProxyHosts='google.com'",
+            "-Dhttp.nonProxyHosts=google.com",
         ],
         get_java_proxy_args("http://example.com:80", "https://secureexample.com:443/", "google.com"),
     )
@@ -88,7 +88,7 @@ def _java_proxy_parsing_all_test_impl(ctx):
             "-Dhttps.proxyPassword=pass2",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
-            "-Dhttp.nonProxyHosts='google.com|localhost'",
+            "-Dhttp.nonProxyHosts=google.com|localhost",
         ],
         get_java_proxy_args("http://user1:pass1@example.com:80", "https://user2:pass2@secureexample.com:443", "google.com,localhost"),
     )


### PR DESCRIPTION
Remove single-quoting of the `-Dhttp.nonProxyHosts` argument as this arg may be spilled over to an argsfile, where quoting is considered by the JVM as part of the host expression.  (I expect the single-quoting to be unnecessary in the pre-Java9+ path, as my understanding of `rctx.execute` is that Bazel _doesn't_ use the shell, so special chars like pipes, etc. are harmless.)

Resolves #780.