### PR TITLE
For m2local integration tests send all output to test log and clear cache before each test to prevent caching of print output

### DIFF
--- a/private/pin.sh
+++ b/private/pin.sh
@@ -13,7 +13,7 @@ if [ "{predefined_maven_install}" = "True" ]; then
     echo "Successfully pinned resolved artifacts for @{repository_name}, $maven_install_json_loc is now up-to-date."
 else
     echo "Successfully pinned resolved artifacts for @{repository_name} in $maven_install_json_loc." \
-      "This file should be checked in your version control system."
+      "This file should be checked into your version control system."
     echo
     echo "Next, please update your WORKSPACE file by adding the maven_install_json attribute" \
       "and loading pinned_maven_install from @{repository_name}//:defs.bzl".

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -16,61 +16,60 @@ function test_duplicate_version_warning() {
 }
 
 function test_m2local_testing_found_local_artifact_through_pin() {
-  m2local_dir="~/.m2/repository"
+  m2local_dir="${HOME}/.m2/repository"
+  jar_dir="${m2local_dir}/com/example/kt/1.0.0"
+  rm -rf ${jar_dir}
   mkdir -p ${m2local_dir}
+  bazel clean --expunge >> "$TEST_LOG" 2>&1 # for https://github.com/bazelbuild/rules_jvm_external/issues/800
   # Publish a maven artifact locally - com.example.kt:1.0.0
-  bazel run --define maven_repo="file://${HOME}/.m2/repository" //tests/integration/kt_jvm_export:test.publish 
+  bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/kt_jvm_export:test.publish >> "$TEST_LOG" 2>&1
   bazel run @m2local_testing//:pin >> "$TEST_LOG" 2>&1
   rm -f m2local_testing_install.json
-  rm -rf ~/.m2/repository
+  rm -rf ${jar_dir}
 
   expect_log "Assuming maven local for artifact: com.example:kt:1.0.0"
   expect_log "Successfully pinned resolved artifacts"
 }
 
 function test_m2local_testing_found_local_artifact_through_build() {
-  m2local_dir="~/.m2/repository"
+  m2local_dir="${HOME}/.m2/repository"
+  jar_dir="${m2local_dir}/com/example/kt/1.0.0"
+  rm -rf ${jar_dir}
   mkdir -p ${m2local_dir}
+  bazel clean --expunge >> "$TEST_LOG" 2>&1 # for https://github.com/bazelbuild/rules_jvm_external/issues/800
   # Publish a maven artifact locally - com.example.kt:1.0.0
-  bazel run --define maven_repo="file://${HOME}/.m2/repository" //tests/integration/kt_jvm_export:test.publish 
+  bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/kt_jvm_export:test.publish >> "$TEST_LOG" 2>&1
   bazel build @m2local_testing//:com_example_kt >> "$TEST_LOG" 2>&1
-  rm -rf ~/.m2/repository
+  rm -rf ${jar_dir}
 
   expect_log "Assuming maven local for artifact: com.example:kt:1.0.0"
 }
 
 function test_m2local_testing_found_local_artifact_after_build_copy() {
-  m2local_dir="$HOME/.m2/repository"
-  mkdir -p ${m2local_dir}
-
-  project_dir="com/example/kt/1.0.0"
-  jar_dir="${m2local_dir}/${project_dir}"
+  jar_dir="${HOME}/.m2/repository/com/example/kt/1.0.0"
   mkdir -p "${jar_dir}"
 
-  binaries_dir="bazel-bin/tests/integration/kt_jvm_export"
   # We need to copy from binaries to local maven repo to appropriate paths
-  # this is mapping of the two, since bash 3 doesn't support
-  # maps
-   maven_files_to_copy=(
+  # this is mapping of the two, since bash 3 doesn't support maps
+  maven_files_to_copy=(
     "test-docs.jar:kt-1.0.0-javadoc.jar"
     "test-lib.jar:kt-1.0.0.jar"
     "test-lib-sources.jar:kt-1.0.0-sources.jar"
     "test-pom.xml:kt-1.0.0.pom"
   )
 
-  bazel build //tests/integration/kt_jvm_export:test.publish
+  bazel build //tests/integration/kt_jvm_export:test.publish >> "$TEST_LOG" 2>&1
   # Populate m2local from bazel-bin
   for file_map in "${maven_files_to_copy[@]}"; do
     source="${file_map%%:*}"
     dest="${file_map##*:}"
-    echo ${source}
-    echo ${dest}
-    cp "${binaries_dir}/$source" "${jar_dir}/${dest}"
+    cp "bazel-bin/tests/integration/kt_jvm_export/$source" "${jar_dir}/${dest}"
   done
 
   # Clear cache for fresh re-build
-  bazel clean --expunge
+  bazel clean --expunge >> "$TEST_LOG" 2>&1
   bazel build @m2local_testing_without_checksum//:com_example_kt >> "$TEST_LOG" 2>&1
+  rm -rf ${jar_dir}
 
   expect_log "Assuming maven local for artifact: com.example:kt:1.0.0"
 }
@@ -102,6 +101,7 @@ function test_outdated_no_external_runfiles() {
 test_xdg_cache_home() {
   readonly cachedir=/tmp/${test}-cache
   XDG_CACHE_HOME=$cachedir bazel run @unsafe_shared_cache//:pin >> "$TEST_LOG" 2>&1
+  rm -f unsafe_shared_cache_install.json
   rm -rf $cachedir
   expect_log "Successfully pinned resolved artifacts"
 }


### PR DESCRIPTION
Attempting to address https://github.com/bazelbuild/rules_jvm_external/issues/800 for Bazel HEAD which has added caching for print statements.

It also sends all output from the tests to $TEST_LOG so it does go to stdout when the tests are run.