### PR TITLE
Add ignorePaths for allstar binary artifacts check.

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,21 @@
+# Ignore reason: Files are reviewed by the core committers. https://github.com/bazelbuild/rules_jvm_external/issues/808
+ignorePaths:
+- private/tools/prebuilt/hasher_deploy.jar
+- private/tools/prebuilt/list_packages_deploy.jar
+- private/tools/prebuilt/outdated_deploy.jar
+- third_party/jetifier/jetifier-standalone/bin/jetifier-standalone
+- third_party/jetifier/jetifier-standalone/bin/jetifier-standalone.bat
+- third_party/jetifier/jetifier-standalone/lib/annotations-13.0.jar
+- third_party/jetifier/jetifier-standalone/lib/asm-8.0.1.jar
+- third_party/jetifier/jetifier-standalone/lib/asm-analysis-8.0.1.jar
+- third_party/jetifier/jetifier-standalone/lib/asm-commons-8.0.1.jar
+- third_party/jetifier/jetifier-standalone/lib/asm-tree-8.0.1.jar
+- third_party/jetifier/jetifier-standalone/lib/asm-util-8.0.1.jar
+- third_party/jetifier/jetifier-standalone/lib/commons-cli-1.3.1.jar
+- third_party/jetifier/jetifier-standalone/lib/gson-2.8.0.jar
+- third_party/jetifier/jetifier-standalone/lib/jdom2-2.0.6.jar
+- third_party/jetifier/jetifier-standalone/lib/jetifier-core-1.0.0-beta10.jar
+- third_party/jetifier/jetifier-standalone/lib/jetifier-processor-1.0.0-beta10.jar
+- third_party/jetifier/jetifier-standalone/lib/jetifier-standalone.jar
+- third_party/jetifier/jetifier-standalone/lib/kotlin-stdlib-1.3.71.jar
+- third_party/jetifier/jetifier-standalone/lib/kotlin-stdlib-common-1.3.71.jar


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_jvm_external/issues/808