### PR TITLE
Normalize path returned by get_coursier_cache_or_default in _relativize_and_symlink_file_in_coursier_cache

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -190,12 +190,17 @@ def _relativize_and_symlink_file_in_coursier_cache(repository_ctx, absolute_path
     # Also replace '\' with '/` to normalize windows paths to *nix style paths
     # BUILD files accept only *nix paths, so we normalize them here.
     #
+    # Also, replace '//' with '/', otherwise parsing of the file path for the
+    # coursier cache will fail if variables like HOME or COURSIER_CACHE have a
+    # trailing slash.
+    #
     # We assume that coursier uses the default cache location
     # TODO(jin): allow custom cache locations
-    absolute_path_parts = absolute_path.split(get_coursier_cache_or_default(
+    coursier_cache_path = get_coursier_cache_or_default(
         repository_ctx,
         repository_ctx.attr.use_unsafe_shared_cache or repository_ctx.attr.name.startswith("unpinned_"),
-    ))
+    ).replace("//", "/")
+    absolute_path_parts = absolute_path.split(coursier_cache_path)
     if len(absolute_path_parts) != 2:
         fail("Error while trying to parse the path of file in the coursier cache: " + absolute_path)
     else:


### PR DESCRIPTION
Fixes #824.

Ideally, this would use paths.normalize in skylib, but that would require changes to how rules_jvm_external setups up dependencies.