### PR TITLE
Remove the `unsafe_shared_cache` option

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,7 +8,6 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @duplicate_artifacts_test//:pin
       - tests/bazel_run_tests.sh
     test_targets:
       - "//..."
@@ -64,7 +63,6 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @duplicate_artifacts_test//:pin
       - tests/bazel_run_tests.sh
     test_targets:
       - "--"
@@ -77,7 +75,6 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @duplicate_artifacts_test//:pin
       - tests/bazel_run_tests.sh
     test_targets:
       - "//..."
@@ -90,7 +87,6 @@ tasks:
     shell_commands:
       - bazel run @unpinned_regression_testing//:pin
       - bazel run @unpinned_maven_install_in_custom_location//:pin
-      - bazel run @duplicate_artifacts_test//:pin
       - tests/bazel_run_tests.sh
     test_targets:
       - "--"

--- a/README.md
+++ b/README.md
@@ -385,53 +385,6 @@ maven_install(
 )
 ```
 
-### Using a persistent artifact cache
-
-> NOTE: Prefer using artifact pinning / maven_install.json instead. This
-> is a caching mechanism that was implemented before artifact pinning,
-> which uses Coursier's own persistent cache. With artifact pinning and
-> maven_install.json, the persistent cache is integrated directly into
-> Bazel's internal cache.
-
-To download artifacts into a shared and persistent directory in your home
-directory, set `use_unsafe_shared_cache = True` in `maven_install`.
-
-```python
-maven_install(
-    artifacts = [
-        # ...
-    ],
-    repositories = [
-        # ...
-    ],
-    use_unsafe_shared_cache = True,
-)
-```
-
-This is **not safe** as Bazel is currently not able to detect changes in the
-shared cache. For example, if an artifact is deleted from the shared cache,
-Bazel will not re-run the repository rule automatically.
-
-To change the location of the cache from the home directory, set the
-`COURSIER_CACHE` environment variable. You can also use the `--repo_env` flag to
-set the variable on the command line and in `.bazelrc` files:
-
-```
-$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=COURSIER_CACHE=/tmp/custom_cache
-```
-
-This feature also enables checking the downloaded artifacts into your source
-tree by declaring `COURSIER_CACHE` to be `<project root>/some/directory`. For
-example:
-
-```
-$ bazel build @maven_with_unsafe_shared_cache//... --repo_env=COURSIER_CACHE=$(pwd)/third_party
-```
-
-The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
-will create independent caches for each `maven_install` repository, located at
-`$(bazel info output_base)/external/@<repository_name>/v1`.
-
 ### Using a custom Coursier download url
 
 By default bazel bootstraps Coursier via [the urls specificed in versions.bzl](private/versions.bzl).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,35 +125,6 @@ load("@maven//:defs.bzl", "pinned_maven_install")
 pinned_maven_install()
 
 maven_install(
-    name = "unsafe_shared_cache",
-    artifacts = [
-        "com.google.guava:guava:27.0-jre",
-    ],
-    fetch_sources = True,
-    repositories = [
-        "https://repo1.maven.org/maven2",
-    ],
-    use_unsafe_shared_cache = True,
-)
-
-maven_install(
-    name = "unsafe_shared_cache_with_pinning",
-    artifacts = [
-        "com.google.guava:guava:27.0-jre",
-    ],
-    fetch_sources = True,
-    maven_install_json = "//tests/custom_maven_install:unsafe_shared_cache_with_pinning_install.json",
-    repositories = [
-        "https://repo1.maven.org/maven2",
-    ],
-    use_unsafe_shared_cache = True,
-)
-
-load("@unsafe_shared_cache_with_pinning//:defs.bzl", "pinned_maven_install")
-
-pinned_maven_install()
-
-maven_install(
     name = "exclusion_testing",
     artifacts = [
         maven.artifact(
@@ -357,21 +328,6 @@ maven_install(
 load("@maven_install_in_custom_location//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
-
-# https://github.com/bazelbuild/rules_jvm_external/issues/311
-maven_install(
-    name = "duplicate_artifacts_test",
-    artifacts = [
-        "com.typesafe.play:play_2.11:2.5.19",
-        "org.scalatestplus.play:scalatestplus-play_2.11:2.0.1",
-    ],
-    fetch_sources = True,
-    repositories = [
-        "https://repo1.maven.org/maven2",
-    ],
-    use_unsafe_shared_cache = True,
-    version_conflict_policy = "pinned",
-)
 
 maven_install(
     name = "jetify_all_test",

--- a/docs/api.md
+++ b/docs/api.md
@@ -182,10 +182,10 @@ Generated rules:
 
 <pre>
 maven_install(<a href="#maven_install-name">name</a>, <a href="#maven_install-repositories">repositories</a>, <a href="#maven_install-artifacts">artifacts</a>, <a href="#maven_install-fail_on_missing_checksum">fail_on_missing_checksum</a>, <a href="#maven_install-fetch_sources">fetch_sources</a>, <a href="#maven_install-fetch_javadoc">fetch_javadoc</a>,
-              <a href="#maven_install-use_unsafe_shared_cache">use_unsafe_shared_cache</a>, <a href="#maven_install-excluded_artifacts">excluded_artifacts</a>, <a href="#maven_install-generate_compat_repositories">generate_compat_repositories</a>,
-              <a href="#maven_install-version_conflict_policy">version_conflict_policy</a>, <a href="#maven_install-maven_install_json">maven_install_json</a>, <a href="#maven_install-override_targets">override_targets</a>, <a href="#maven_install-strict_visibility">strict_visibility</a>,
-              <a href="#maven_install-strict_visibility_value">strict_visibility_value</a>, <a href="#maven_install-resolve_timeout">resolve_timeout</a>, <a href="#maven_install-jetify">jetify</a>, <a href="#maven_install-jetify_include_list">jetify_include_list</a>,
-              <a href="#maven_install-additional_netrc_lines">additional_netrc_lines</a>, <a href="#maven_install-use_credentials_from_home_netrc_file">use_credentials_from_home_netrc_file</a>, <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>,
+              <a href="#maven_install-excluded_artifacts">excluded_artifacts</a>, <a href="#maven_install-generate_compat_repositories">generate_compat_repositories</a>, <a href="#maven_install-version_conflict_policy">version_conflict_policy</a>,
+              <a href="#maven_install-maven_install_json">maven_install_json</a>, <a href="#maven_install-override_targets">override_targets</a>, <a href="#maven_install-strict_visibility">strict_visibility</a>, <a href="#maven_install-strict_visibility_value">strict_visibility_value</a>,
+              <a href="#maven_install-resolve_timeout">resolve_timeout</a>, <a href="#maven_install-jetify">jetify</a>, <a href="#maven_install-jetify_include_list">jetify_include_list</a>, <a href="#maven_install-additional_netrc_lines">additional_netrc_lines</a>,
+              <a href="#maven_install-use_credentials_from_home_netrc_file">use_credentials_from_home_netrc_file</a>, <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>,
               <a href="#maven_install-use_starlark_android_rules">use_starlark_android_rules</a>, <a href="#maven_install-aar_import_bzl_label">aar_import_bzl_label</a>, <a href="#maven_install-duplicate_version_warning">duplicate_version_warning</a>)
 </pre>
 
@@ -206,7 +206,6 @@ and fetch Maven artifacts transitively.
 | <a id="maven_install-fail_on_missing_checksum"></a>fail_on_missing_checksum |  fail the fetch if checksum attributes are not present.   |  <code>True</code> |
 | <a id="maven_install-fetch_sources"></a>fetch_sources |  Additionally fetch source JARs.   |  <code>False</code> |
 | <a id="maven_install-fetch_javadoc"></a>fetch_javadoc |  Additionally fetch javadoc JARs.   |  <code>False</code> |
-| <a id="maven_install-use_unsafe_shared_cache"></a>use_unsafe_shared_cache |  Download artifacts into a persistent shared cache on disk. Unsafe as Bazel is currently unable to detect modifications to the cache.   |  <code>False</code> |
 | <a id="maven_install-excluded_artifacts"></a>excluded_artifacts |  A list of Maven artifact coordinates in the form of <code>group:artifact</code> to be excluded from the transitive dependencies.   |  <code>[]</code> |
 | <a id="maven_install-generate_compat_repositories"></a>generate_compat_repositories |  Additionally generate repository aliases in a .bzl file for all JAR artifacts. For example, <code>@maven//:com_google_guava_guava</code> can also be referenced as <code>@com_google_guava_guava//jar</code>.   |  <code>False</code> |
 | <a id="maven_install-version_conflict_policy"></a>version_conflict_policy |  Policy for user-defined vs. transitive dependency version conflicts.  If "pinned", choose the user's version unconditionally.  If "default", follow Coursier's default policy.   |  <code>"default"</code> |

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -77,7 +77,6 @@ _install = tag_class(
         "excluded_artifacts": attr.string_list(doc = "Artifacts to exclude, in `artifactId:groupId` format. Only used on unpinned installs", default = []),  # list of artifacts to exclude
         "fail_on_missing_checksum": attr.bool(default = True),
         "resolve_timeout": attr.int(default = 600),
-        "use_unsafe_shared_cache": attr.bool(default = False),
         "version_conflict_policy": attr.string(
             doc = """Policy for user-defined vs. transitive dependency version conflicts
 
@@ -162,7 +161,6 @@ def _maven_impl(mctx):
     # - strict_visibility: bool. A logical OR over all `strict_visibility` for all `install` tags with the same name.
     # - strict_visibility_value: a string list. Build will fail is duplicated and different.
     # - use_starlark_android_rules: bool. A logical OR over all `use_starlark_android_rules` for all `install` tags with the same name.
-    # - use_unsafe_shared_cache: bool. A logical OR over all `use_unsafe_shared_cache` for all `install` tags with the same name.
     # - version_conflict_policy: string. Fails build if different and not a default.
 
     # Mapping of `name`s to `bazel_module.name` This will allow us to warn users when more than
@@ -245,7 +243,6 @@ def _maven_impl(mctx):
             _logical_or(repo, "jetify", False, install.jetify)
             _logical_or(repo, "strict_visibility", False, install.strict_visibility)
             _logical_or(repo, "use_starlark_android_rules", False, install.use_starlark_android_rules)
-            _logical_or(repo, "use_unsafe_shared_cache", False, install.use_unsafe_shared_cache)
 
             repo["version_conflict_policy"] = _fail_if_different(
                 "version_conflict_policy",
@@ -308,7 +305,6 @@ def _maven_impl(mctx):
             fail_on_missing_checksum = repo.get("fail_on_missing_checksum"),
             fetch_sources = repo.get("fetch_sources"),
             fetch_javadoc = repo.get("fetch_javadoc"),
-            use_unsafe_shared_cache = repo.get("use_unsafe_shared_cache"),
             excluded_artifacts = repo.get("excluded_artifacts"),
             generate_compat_repositories = False,
             version_conflict_policy = repo.get("version_conflict_policy"),

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -10,7 +10,6 @@ def maven_install(
         fail_on_missing_checksum = True,
         fetch_sources = False,
         fetch_javadoc = False,
-        use_unsafe_shared_cache = False,
         excluded_artifacts = [],
         generate_compat_repositories = False,
         version_conflict_policy = "default",
@@ -41,8 +40,6 @@ def maven_install(
       fail_on_missing_checksum: fail the fetch if checksum attributes are not present.
       fetch_sources: Additionally fetch source JARs.
       fetch_javadoc: Additionally fetch javadoc JARs.
-      use_unsafe_shared_cache: Download artifacts into a persistent shared cache on disk. Unsafe as Bazel is
-        currently unable to detect modifications to the cache.
       excluded_artifacts: A list of Maven artifact coordinates in the form of `group:artifact` to be
         excluded from the transitive dependencies.
       generate_compat_repositories: Additionally generate repository aliases in a .bzl file for all JAR
@@ -115,7 +112,6 @@ def maven_install(
         fail_on_missing_checksum = fail_on_missing_checksum,
         fetch_sources = fetch_sources,
         fetch_javadoc = fetch_javadoc,
-        use_unsafe_shared_cache = use_unsafe_shared_cache,
         excluded_artifacts = excluded_artifacts_json_strings,
         generate_compat_repositories = generate_compat_repositories,
         version_conflict_policy = version_conflict_policy,

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -98,20 +98,11 @@ function test_outdated_no_external_runfiles() {
   expect_log "junit:junit \[4.12"
 }
 
-test_xdg_cache_home() {
-  readonly cachedir=/tmp/${test}-cache
-  XDG_CACHE_HOME=$cachedir bazel run @unsafe_shared_cache//:pin >> "$TEST_LOG" 2>&1
-  rm -f unsafe_shared_cache_install.json
-  rm -rf $cachedir
-  expect_log "Successfully pinned resolved artifacts"
-}
-
 TESTS=(
   "test_duplicate_version_warning"
   "test_duplicate_version_warning_same_version"
   "test_outdated"
   "test_outdated_no_external_runfiles"
-  "test_xdg_cache_home"
   "test_m2local_testing_found_local_artifact_through_pin"
   "test_m2local_testing_found_local_artifact_through_build"
   "test_m2local_testing_found_local_artifact_after_build_copy"

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -50,13 +50,6 @@ build_test(
 )
 
 build_test(
-    name = "unsafe_shared_cache_with_pinning",
-    targets = [
-        "@unsafe_shared_cache_with_pinning//:com_google_guava_guava",
-    ],
-)
-
-build_test(
     name = "strict_version",
     targets = [
         "@strict_visibility_testing//:org_apache_tomcat_tomcat_catalina",


### PR DESCRIPTION
This feature wasn't being tested properly, so we had no way of determining whether it would work. For the case of pinning artifacts (which is the recommended approach) it's possible to use the `COURSIER_CACHE` env var to still use the shared cache.