### PR TITLE
Remove 'sp' from MAVEN_PRE_RELEASE_QUALIFIERS for outdated

### DIFF
--- a/private/rules/v1_lock_file.bzl
+++ b/private/rules/v1_lock_file.bzl
@@ -42,7 +42,6 @@ def _is_valid_lock_file(lock_file_contents):
     # the build files.
     return True
 
-
 def _get_input_artifacts_hash(lock_file_contents):
     dep_tree = lock_file_contents.get("dependency_tree", {})
     return dep_tree.get("__INPUT_ARTIFACTS_HASH")

--- a/private/tools/java/rules/jvm/external/maven/Outdated.java
+++ b/private/tools/java/rules/jvm/external/maven/Outdated.java
@@ -26,7 +26,7 @@ public class Outdated {
   // https://github.com/apache/maven/blob/master/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java#L307
   // and unfortunately ComparableVerison does not expose this in any public methods.
   private static final List<String> MAVEN_PRE_RELEASE_QUALIFIERS =
-      Arrays.asList("alpha", "beta", "milestone", "cr", "rc", "snapshot", "sp");
+      Arrays.asList("alpha", "beta", "milestone", "cr", "rc", "snapshot");
 
   public static class ArtifactReleaseInfo {
     public String releaseVersion;


### PR DESCRIPTION
`sp` is usually used for Service Pack and doesn't mean the release is a pre-release.