### PR TITLE
Fix dependencies BOM so it does not include a circular dep

### DIFF
--- a/private/rules/maven_bom.bzl
+++ b/private/rules/maven_bom.bzl
@@ -64,7 +64,7 @@ def _maven_dependencies_bom_impl(ctx):
     all_deps = depset(transitive = [f.maven_info.maven_deps for f in fragments]).to_list()
     combined_deps = [a for a in all_deps if a not in first_order_deps]
 
-    unpacked = unpack_coordinates(ctx.attr.maven_coordinates)
+    unpacked = unpack_coordinates(ctx.attr.bom_coordinates)
     dependencies_bom = generate_pom(
         ctx,
         coordinates = ctx.attr.maven_coordinates,
@@ -94,6 +94,10 @@ _maven_dependencies_bom = rule(
             providers = [
                 [MavenBomFragmentInfo],
             ],
+        ),
+        "bom_coordinates": attr.string(
+            doc = "Coordinates of the bom to include",
+            mandatory = True,
         ),
     },
 )
@@ -183,6 +187,7 @@ def maven_bom(
             maven_coordinates = dependencies_maven_coordinates,
             pom_template = dependencies_pom_template,
             fragments = fragments,
+            bom_coordinates = maven_coordinates,
             tags = tags,
             testonly = testonly,
             visibility = visibility,

--- a/tests/integration/maven_bom/bom-dependencies.golden.xml
+++ b/tests/integration/maven_bom/bom-dependencies.golden.xml
@@ -12,7 +12,7 @@
         <dependencies>
             <dependency>
                 <groupId>com.example</groupId>
-                <artifactId>bom-deps</artifactId>
+                <artifactId>bom</artifactId>
                 <version>1.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/tests/integration/maven_bom/transitive-bom-dependencies.golden.xml
+++ b/tests/integration/maven_bom/transitive-bom-dependencies.golden.xml
@@ -12,7 +12,7 @@
         <dependencies>
             <dependency>
                 <groupId>com.example</groupId>
-                <artifactId>bom-transitive-deps</artifactId>
+                <artifactId>bom-transitive</artifactId>
                 <version>1.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>


### PR DESCRIPTION
*sigh* How did I miss this before? The dependencies BOM attempted to import itself, rather than the BOM that contained the primary deps. This PR fixes that.