### PR TITLE
transitive dependencies should be visible to their compat alias

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -339,6 +339,23 @@ maven_install(
 )
 
 maven_install(
+    name = "strict_visibility_with_compat_testing",
+    artifacts = [
+        # Must not be in any other maven_install where generate_compat_repositories = True
+        "com.google.http-client:google-http-client-gson:1.42.3",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+    strict_visibility = True,
+    generate_compat_repositories = True,
+)
+
+load("@strict_visibility_with_compat_testing//:compat.bzl", "compat_repositories")
+
+compat_repositories()
+
+maven_install(
     name = "maven_install_in_custom_location",
     artifacts = ["com.google.guava:guava:27.0-jre"],
     maven_install_json = "@rules_jvm_external//tests/custom_maven_install:maven_install.json",

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -314,12 +314,16 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             #   neverlink = True,
             #   testonly = True,
             #   visibility = ["//visibility:public"],
-            if repository_ctx.attr.strict_visibility and explicit_artifacts.get(simple_coord):
-                target_import_string.append("\tvisibility = [\"//visibility:public\"],")
-                alias_visibility = "\tvisibility = [\"//visibility:public\"],\n"
+            target_visibilities = []
+            if not repository_ctx.attr.strict_visibility or explicit_artifacts.get(simple_coord):
+                target_visibilities.append("//visibility:public")
+            elif repository_ctx.attr.generate_compat_repositories:
+                target_visibilities.append("@%s//:__subpackages__" % target_label)
             else:
-                target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % v for v in default_visibilities])))
-                alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % v for v in default_visibilities]))
+                target_visibilities.append("%s" % repository_ctx.attr.strict_visibility_value)
+
+            target_import_string.append("\tvisibility = [%s]," % (",".join(['"%s"' % t for t in target_visibilities])))
+            alias_visibility = "\tvisibility = [%s],\n" % (",".join(['"%s"' % t for t in target_visibilities]))
 
             # 9. Finish the java_import rule.
             #

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -320,10 +320,10 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             elif repository_ctx.attr.generate_compat_repositories:
                 target_visibilities.append("@%s//:__subpackages__" % target_label)
             else:
-                target_visibilities.append("%s" % repository_ctx.attr.strict_visibility_value)
+                target_visibilities.extend(repository_ctx.attr.strict_visibility_value)
 
-            target_import_string.append("\tvisibility = [%s]," % (",".join(['"%s"' % t for t in target_visibilities])))
-            alias_visibility = "\tvisibility = [%s],\n" % (",".join(['"%s"' % t for t in target_visibilities]))
+            target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % t for t in target_visibilities])))
+            alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % t for t in target_visibilities]))
 
             # 9. Finish the java_import rule.
             #

--- a/tests/unit/build_tests/BUILD
+++ b/tests/unit/build_tests/BUILD
@@ -78,3 +78,14 @@ build_test(
         "@maven_install_in_custom_location//:com_google_guava_guava",
     ],
 )
+
+build_test(
+    name = "compat_repository_alias_strict_version",
+    targets = [
+        "@strict_visibility_with_compat_testing//:com_google_http_client_google_http_client_gson",
+        "@com_google_http_client_google_http_client_gson//jar",
+        # Transitive compat alias will fail unless
+        # @strict_visibility_with_compat_testing//:com_google_http_client_google_http_client is visible to it
+        "@com_google_http_client_google_http_client//jar",
+    ],
+)


### PR DESCRIPTION
When `generate_compat_repositories` is True, the `jvm_import` target  is not visible to the compat alias, causing an error when trying to use the compat label.

```
# <>/external/maven/BUILD:2881:11
jvm_import(
  name = "com_google_j2objc_j2objc_annotations",
  visibility = ["//visibility:private"],
  tags = ["maven_coordinates=com.google.j2objc:j2objc-annotations:1.3", "maven_url=<>/j2objc-annotations-1.3.jar"],
  jars = ["@maven//:<>/j2objc-annotations-1.3.jar"],
  srcjar = "@maven//:<>/j2objc-annotations-1.3-sources.jar",
  deps = [],
)

# <>/external/com_google_j2objc_j2objc_annotations/jar/BUILD:2:6
alias(
  name = "jar",
  visibility = ["//visibility:public"],
  actual = "@maven//:com_google_j2objc_j2objc_annotations",
)
```

I propose adding the alias path to the visibility of the `jvm_import` when compat repositories are being generated.