### PR TITLE
Set http.proxyProtocol and https.proxyProtocol for coursier

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -713,9 +713,17 @@ def make_coursier_dep_tree(
         if parse_java_version(exec_result.stdout + exec_result.stderr) > 8:
             java_cmd = cmd[0]
             java_args = cmd[1:]
+
+            argsfile_content = build_java_argsfile_content(java_args)
+            if _is_verbose(repository_ctx):
+                repository_ctx.execute(
+                    ["echo", "\nargsfile_content:\n%s" % argsfile_content],
+                    quiet = False,
+                )
+
             repository_ctx.file(
                 "java_argsfile",
-                build_java_argsfile_content(java_args),
+                argsfile_content,
                 executable = False,
             )
             cmd = [java_cmd, "@{}".format(repository_ctx.path("java_argsfile"))]

--- a/private/proxy.bzl
+++ b/private/proxy.bzl
@@ -41,6 +41,9 @@ def get_java_proxy_args(http_proxy, https_proxy, no_proxy):
     proxy_args = []
 
     if http_proxy:
+        # We only need to set proxyProtocol until https://github.com/coursier/coursier/pull/2701
+        # is merged and we can update coursier
+        proxy_args.append("-Dhttp.proxyProtocol=http")
         proxy_user = _get_proxy_user(http_proxy)
         if proxy_user:
             proxy_args.append("-Dhttp.proxyUser=%s" % proxy_user)
@@ -55,6 +58,9 @@ def get_java_proxy_args(http_proxy, https_proxy, no_proxy):
             proxy_args.append("-Dhttp.proxyPort=%s" % proxy_port)
 
     if https_proxy:
+        # We only need to set proxyProtocol until https://github.com/coursier/coursier/pull/2701
+        # is merged and we can update coursier
+        proxy_args.append("-Dhttps.proxyProtocol=https")
         proxy_user = _get_proxy_user(https_proxy)
         if proxy_user:
             proxy_args.append("-Dhttps.proxyUser=%s" % proxy_user)

--- a/tests/unit/proxy_test.bzl
+++ b/tests/unit/proxy_test.bzl
@@ -14,8 +14,10 @@ def _java_proxy_parsing_no_scheme_test_impl(ctx):
     asserts.equals(
         env,
         [
+            "-Dhttp.proxyProtocol=http",
             "-Dhttp.proxyHost=localhost",
             "-Dhttp.proxyPort=8888",
+            "-Dhttps.proxyProtocol=https",
             "-Dhttps.proxyHost=localhost",
             "-Dhttps.proxyPort=8843",
             "-Dhttp.nonProxyHosts=google.com",
@@ -31,8 +33,10 @@ def _java_proxy_parsing_no_user_test_impl(ctx):
     asserts.equals(
         env,
         [
+            "-Dhttp.proxyProtocol=http",
             "-Dhttp.proxyHost=example.com",
             "-Dhttp.proxyPort=80",
+            "-Dhttps.proxyProtocol=https",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
             "-Dhttp.nonProxyHosts=google.com",
@@ -48,7 +52,9 @@ def _java_proxy_parsing_no_port_test_impl(ctx):
     asserts.equals(
         env,
         [
+            "-Dhttp.proxyProtocol=http",
             "-Dhttp.proxyHost=example.com",
+            "-Dhttps.proxyProtocol=https",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttp.nonProxyHosts=google.com",
         ],
@@ -63,8 +69,10 @@ def _java_proxy_parsing_trailing_slash_test_impl(ctx):
     asserts.equals(
         env,
         [
+            "-Dhttp.proxyProtocol=http",
             "-Dhttp.proxyHost=example.com",
             "-Dhttp.proxyPort=80",
+            "-Dhttps.proxyProtocol=https",
             "-Dhttps.proxyHost=secureexample.com",
             "-Dhttps.proxyPort=443",
             "-Dhttp.nonProxyHosts=google.com",
@@ -80,10 +88,12 @@ def _java_proxy_parsing_all_test_impl(ctx):
     asserts.equals(
         env,
         [
+            "-Dhttp.proxyProtocol=http",
             "-Dhttp.proxyUser=user1",
             "-Dhttp.proxyPassword=pass1",
             "-Dhttp.proxyHost=example.com",
             "-Dhttp.proxyPort=80",
+            "-Dhttps.proxyProtocol=https",
             "-Dhttps.proxyUser=user2",
             "-Dhttps.proxyPassword=pass2",
             "-Dhttps.proxyHost=secureexample.com",


### PR DESCRIPTION
In coursier version v2.1.0-M7 and later there was a [change to the proxy setup](https://github.com/coursier/coursier/pull/2440) that requires `http.proxyProtocol` or `https.proxyProtocol` to be set for the proxy to work.  I created https://github.com/coursier/coursier/pull/2701 to fix this, but until that is merged we need to set the values in our proxy settings.

This PR also adds better verbose logging for args_files. 