### PR TITLE
docs: Remove hard-coded version in bazel_dep example

### DIFF
--- a/docs/bzlmod.md
+++ b/docs/bzlmod.md
@@ -17,11 +17,11 @@ The simplest way is by adding this line to your `.bazelrc`:
 common --enable_bzlmod
 ```
 
-Now, create a `MODULE.bazel` file in the root of your workspace, containing:
+Now, create a `MODULE.bazel` file in the root of your workspace,
+setting the `version` to the latest one available on https://registry.bazel.build/modules/rules_jvm_external:
 
 ```starlark
-# FIXME: use latest release from https://registry.bazel.build/modules/rules_jvm_external
-bazel_dep(name = "rules_jvm_external", version = "4.5")
+bazel_dep(name = "rules_jvm_external", version = "...")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [


### PR DESCRIPTION
I think it's better for readers to NOT have an (ancient) version in an example, and let them go look it up.

At least I for one was too stupid to notice that inline `FIXME` and it caused me https://github.com/bazelbuild/rules_jvm_external/issues/872 pain.

Explicitly documenting how and where one has to go look up the correct version seems preferable.