### PR TITLE
Handle the case where dependencies are empty

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -436,6 +436,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
         "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_file\")",
         "load(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")",
         "def pinned_maven_install():",
+        "    pass",  # Keep it syntactically correct in case of empty dependencies.
     ]
     maven_artifacts = []
     netrc_entries = importer.get_netrc_entries(maven_install_json_content)


### PR DESCRIPTION
Sometimes, some issue lead to the `pinned_maven_install()` function being completely empty, making the defs.bzl file syntactically incorrect, causing all sorts of issues making it hard to recover (needing a `bazel clean --expunge` or a manual edition of the file to fix the syntax).

This prevents that kind of situation.