### PR TITLE
Fixed #876, the 'excluded_artifacts' should be formatted in json spec

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -295,7 +295,8 @@ def _maven_impl(mctx):
     for (name, repo) in repos.items():
         artifacts = parse.parse_artifact_spec_list(repo["artifacts"])
         artifacts_json = [_json.write_artifact_spec(a) for a in artifacts]
-
+        excluded_artifacts = parse.parse_exclusion_spec_list(repo["excluded_artifacts"])
+        excluded_artifacts_json = [_json.write_exclusion_spec(a) for a in excluded_artifacts]
         coursier_fetch(
             # Name this repository "unpinned_{name}" if the user specified a
             # maven_install.json file. The actual @{name} repository will be
@@ -307,7 +308,7 @@ def _maven_impl(mctx):
             fail_on_missing_checksum = repo.get("fail_on_missing_checksum"),
             fetch_sources = repo.get("fetch_sources"),
             fetch_javadoc = repo.get("fetch_javadoc"),
-            excluded_artifacts = repo.get("excluded_artifacts"),
+            excluded_artifacts = excluded_artifacts_json,
             generate_compat_repositories = False,
             version_conflict_policy = repo.get("version_conflict_policy"),
             override_targets = overrides,


### PR DESCRIPTION
Test case same as #876 but overriding with patch 

```sh
mkdir test_bzlmod
cd test_bzlmod

touch BUILD WORKSPACE WORKSPACE.bzlmod  
cat << EOF > MODULE.bazel 
bazel_dep(name = "rules_jvm_external", version = "5.1")
git_override(
    module_name = "rules_jvm_external",
    remote = "https://github.com/yrom/rules_jvm_external.git",
    commit = "e4dac53947fa2e664ecc3fcaf94121eeccb1015b",
)
maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")

maven.install(
    name = "androidx",
    artifacts = [
        "androidx.appcompat:appcompat:1.4.0",
    ],
    repositories = [
        "https://maven.google.com",
        "https://repo1.maven.org/maven2",
    ],
    excluded_artifacts = [
        "com.android.support:support-v4",
        "com.android.support:support-annotations",
    ],
    jetify = True,
)
use_repo(maven, "androidx")
EOF

echo "common --enable_bzlmod" > .bazelrc
echo "6.0.0" > .bazelversion

# Request downloading artifacts 
bazel query "@androidx//:all"
```

