### PR TITLE
Bump to Coursier v2.1.2.

### DIFF
--- a/private/versions.bzl
+++ b/private/versions.bzl
@@ -1,8 +1,8 @@
-_COURSIER_CLI_VERSION = "v2.1.0-RC6"
+_COURSIER_CLI_VERSION = "v2.1.2"
 
 COURSIER_CLI_HTTP_FILE_NAME = ("coursier_cli_" + _COURSIER_CLI_VERSION).replace(".", "_").replace("-", "_")
 COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/download/{COURSIER_CLI_VERSION}/coursier.jar".format(COURSIER_CLI_VERSION = _COURSIER_CLI_VERSION)
 
 # Run 'bazel run //:mirror_coursier' to upload a copy of the jar to the Bazel mirror.
 COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
-COURSIER_CLI_SHA256 = "1b49a7bcbcc595fe1123a5c069816ae31efe6a9625b15dd6fa094f7ff439175e"
+COURSIER_CLI_SHA256 = "fc3bbb5e83334d67458f2a274fc89b38ac58f25d9eaf83e7128705badde89531"


### PR DESCRIPTION
v2.1.2 contains an OOM fix while collecting transitive deps. It also speeds up resolution time.

https://github.com/coursier/coursier/releases/tag/v2.1.2
https://github.com/coursier/coursier/pull/2580

Before:
$ bazelisk run @unpinned_regression_testing//:pin
INFO: Analyzed target @unpinned_regression_testing//:pin (1 packages loaded, 3 targets configured). INFO: Found 1 target...
Target @unpinned_regression_testing//:pin up-to-date:
  bazel-bin/external/unpinned_regression_testing/pin
INFO: Elapsed time: 17.980s, Critical Path: 0.01s

After:
$ bazelisk run @unpinned_regression_testing//:pin
INFO: Analyzed target @unpinned_regression_testing//:pin (26 packages loaded, 99 targets configured). INFO: Found 1 target...
Target @unpinned_regression_testing//:pin up-to-date:
  bazel-bin/external/unpinned_regression_testing/pin
INFO: Elapsed time: 10.234s, Critical Path: 0.01s

@nkoroste @mauriciogg 