### PR TITLE
Allow semicolons in maven_repo

### DIFF
--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -11,7 +11,7 @@ MavenPublishInfo = provider(
 _TEMPLATE = """#!/usr/bin/env bash
 
 echo "Uploading {coordinates} to {maven_repo}"
-{uploader} {maven_repo} {gpg_sign} {user} {password} {coordinates} {pom} {artifact_jar} {source_jar} {javadoc}
+{uploader} "{maven_repo}" "{gpg_sign}" "{user}" "{password}" "{coordinates}" "{pom}" "{artifact}" "{source_jar}" "{javadoc}"
 """
 
 def _maven_publish_impl(ctx):

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -11,22 +11,22 @@ MavenPublishInfo = provider(
 _TEMPLATE = """#!/usr/bin/env bash
 
 echo "Uploading {coordinates} to {maven_repo}"
-{uploader} "{maven_repo}" "{gpg_sign}" "{user}" "{password}" "{coordinates}" "{pom}" "{artifact_jar}" "{source_jar}" "{javadoc}"
+{uploader} '{maven_repo}' '{gpg_sign}' '{user}' '{password}' '{coordinates}' '{pom}' '{artifact_jar}' '{source_jar}' '{javadoc}'
 """
 
 def _maven_publish_impl(ctx):
     executable = ctx.actions.declare_file("%s-publisher" % ctx.attr.name)
 
-    maven_repo = ctx.var.get("maven_repo", "''")
-    gpg_sign = ctx.var.get("gpg_sign", "'false'")
-    user = ctx.var.get("maven_user", "''")
-    password = ctx.var.get("maven_password", "''")
+    maven_repo = ctx.var.get("maven_repo", "")
+    gpg_sign = ctx.var.get("gpg_sign", "false")
+    user = ctx.var.get("maven_user", "")
+    password = ctx.var.get("maven_password", "")
 
     # Expand maven coordinates for any variables to be replaced.
     coordinates = ctx.expand_make_variables("coordinates", ctx.attr.coordinates, {})
-    artifacts_short_path = ctx.file.artifact_jar.short_path if ctx.file.artifact_jar else "''"
-    source_short_path = ctx.file.source_jar.short_path if ctx.file.source_jar else "''"
-    javadocs_short_path = ctx.file.javadocs.short_path if ctx.file.javadocs else "''"
+    artifacts_short_path = ctx.file.artifact_jar.short_path if ctx.file.artifact_jar else ""
+    source_short_path = ctx.file.source_jar.short_path if ctx.file.source_jar else ""
+    javadocs_short_path = ctx.file.javadocs.short_path if ctx.file.javadocs else ""
 
     ctx.actions.write(
         output = executable,

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -11,7 +11,7 @@ MavenPublishInfo = provider(
 _TEMPLATE = """#!/usr/bin/env bash
 
 echo "Uploading {coordinates} to {maven_repo}"
-{uploader} "{maven_repo}" "{gpg_sign}" "{user}" "{password}" "{coordinates}" "{pom}" "{artifact}" "{source_jar}" "{javadoc}"
+{uploader} "{maven_repo}" "{gpg_sign}" "{user}" "{password}" "{coordinates}" "{pom}" "{artifact_jar}" "{source_jar}" "{javadoc}"
 """
 
 def _maven_publish_impl(ctx):


### PR DESCRIPTION
Artifactory uses [semicolons in URLs to set properties](https://jfrog.com/help/r/jfrog-artifactory-documentation/using-properties-in-deployment-and-resolution). Currently, when trying to use a maven_repo with semicolons in `maven_publish`, they are interpreted as statement terminators by bash. This PR adds quotes to all the arguments to {uploader} to solve this.