### PR TITLE
Fix transitive dependencies resolution

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -665,8 +665,6 @@ def make_coursier_dep_tree(
     fetch_artifact_coordinates = []
     for coord in artifact_coordinates:
         # Undo any `,type=` suffix from `utils.artifact_coordinate` so coursier can form correct urls.
-        #    "net.bytebuddy:byte-buddy-agent:1.14.4,type=jar,classifier=agent"
-        # -> "net.bytebuddy:byte-buddy-agent:1.14.4,classifier=agent"
         fetch_artifact_coordinates.append(
             ",".join([c for c in coord.split(",") if not c.startswith("type=")]),
         )
@@ -676,9 +674,6 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
-            #    "net.bytebuddy:byte-buddy-agent:1.14.4,type=jar,classifier=agent"
-            # -> "net.bytebuddy:byte-buddy-agent:1.14.4"
-
             cmd.extend([
                 "--force-version",
                 ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -667,17 +667,25 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
+            # "net.bytebuddy:byte-buddy-agent:1.14.4,type=jar,classifier=agent"
+            # "net.bytebuddy:byte-buddy-agent:1.14.4,classifier=agent,type=jar"
+
             a = ["--force-version", coord.split(",classifier=")[0]]
             b = [
                 "--force-version",
                 ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
             ]
+            c = [
+                "--force-version",
+                ",".join([c for c in coord.split(",") if not c.startswith("classifier=")]),
+            ]
 
-            if "byte-buddy" in coord:
+            if ":byte-buddy:" in coord:
                 print("ARTEM look! a=" + str(a) + " coord=" + str(coord))
                 print("ARTEM look! b=" + str(b) + " coord=" + str(coord))
+                print("ARTEM look! c=" + str(c) + " coord=" + str(coord))
 
-            cmd.extend(b)
+            cmd.extend(c)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")
     cmd.append("--no-default")

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -667,7 +667,14 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
-            cmd.extend(["--force-version", coord.split(",classifier=")[0]])
+            a = ["--force-version", coord.split(",classifier=")[0]]
+            print("ARTEM look! a=" + str(a))
+            b = [
+                                "--force-version",
+                                ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
+                            ]
+            print("ARTEM look! b=" + str(b))
+            cmd.extend(b)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")
     cmd.append("--no-default")

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -666,7 +666,7 @@ def make_coursier_dep_tree(
     sanitized_artifact_coordinates = []
 
     for coord in artifact_coordinates:
-        sanitized_artifact_coordinates.append(coord.split(",")[0])
+        sanitized_artifact_coordinates.append(",".join([c for c in coord.split(",") if not c.startswith("type=")]))
 
     cmd.extend(sanitized_artifact_coordinates)
     if version_conflict_policy == "pinned":

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -667,12 +667,17 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
-            result = [
-                         "--force-version",
-                         ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
-                     ] if ",classifier" in coord and ",type" in coord else ["--force-version", coord.split(",classifier=")[0]]
+            a = ["--force-version", coord.split(",classifier=")[0]]
+            b = [
+                "--force-version",
+                ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
+            ]
 
-            cmd.extend(result)
+            if "byte-buddy" in coord:
+                print("ARTEM look! a=" + str(a))
+                print("ARTEM look! b=" + str(b))
+                
+            cmd.extend(b)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")
     cmd.append("--no-default")

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -667,10 +667,7 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
-            cmd.extend([
-                "--force-version",
-                ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
-            ])
+            cmd.extend(["--force-version", coord.split(",classifier=")[0]])
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")
     cmd.append("--no-default")

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -663,7 +663,12 @@ def make_coursier_dep_tree(
     cmd = _generate_java_jar_command(repository_ctx, repository_ctx.path("coursier"))
     cmd.extend(["fetch"])
 
-    cmd.extend(artifact_coordinates)
+    sanitized_artifact_coordinates = []
+
+    for coord in artifact_coordinates:
+        sanitized_artifact_coordinates.append(coord.split(",")[0])
+
+    cmd.extend(sanitized_artifact_coordinates)
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -665,6 +665,8 @@ def make_coursier_dep_tree(
     fetch_artifact_coordinates = []
     for coord in artifact_coordinates:
         # Undo any `,type=` suffix from `utils.artifact_coordinate` so coursier can form correct urls.
+        #    "net.bytebuddy:byte-buddy-agent:1.14.4,type=jar,classifier=agent"
+        # -> "net.bytebuddy:byte-buddy-agent:1.14.4,classifier=agent"
         fetch_artifact_coordinates.append(
             ",".join([c for c in coord.split(",") if not c.startswith("type=")]),
         )

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -667,20 +667,12 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
-            if "classifier" in coord:
-                print("ARTEM look! coord=" + coord + " has classifier!")
+            result = [
+                         "--force-version",
+                         ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
+                     ] if ",classifier" in coord and ",type" in coord else ["--force-version", coord.split(",classifier=")[0]]
 
-            if "type" in coord:
-                print("ARTEM look! coord=" + coord + " has type!")
-                
-            a = ["--force-version", coord.split(",classifier=")[0]]
-            print("ARTEM look! a=" + str(a))
-            b = [
-                "--force-version",
-                ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
-            ]
-            print("ARTEM look! b=" + str(b))
-            cmd.extend(b)
+            cmd.extend(result)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")
     cmd.append("--no-default")

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -674,9 +674,9 @@ def make_coursier_dep_tree(
             ]
 
             if "byte-buddy" in coord:
-                print("ARTEM look! a=" + str(a))
-                print("ARTEM look! b=" + str(b))
-                
+                print("ARTEM look! a=" + str(a) + " coord=" + str(coord))
+                print("ARTEM look! b=" + str(b) + " coord=" + str(coord))
+
             cmd.extend(b)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -662,16 +662,15 @@ def make_coursier_dep_tree(
 
     cmd = _generate_java_jar_command(repository_ctx, repository_ctx.path("coursier"))
 
-    sanitized_artifact_coordinates = []
-
+    fetch_artifact_coordinates = []
     for coord in artifact_coordinates:
         # Undo any `,type=` suffix from `utils.artifact_coordinate` so coursier can form correct urls.
-        sanitized_artifact_coordinates.append(
-            ",".join([c for c in coord.split(",") if not c.startswith("type=")])
+        fetch_artifact_coordinates.append(
+            ",".join([c for c in coord.split(",") if not c.startswith("type=")]),
         )
-
     cmd.extend(["fetch"])
-    cmd.extend(sanitized_artifact_coordinates)
+    cmd.extend(fetch_artifact_coordinates)
+
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -667,12 +667,18 @@ def make_coursier_dep_tree(
     if version_conflict_policy == "pinned":
         for coord in artifact_coordinates:
             # Undo any `,classifier=` and/or `,type=` suffix from `utils.artifact_coordinate`.
+            if "classifier" in coord:
+                print("ARTEM look! coord=" + coord + " has classifier!")
+
+            if "type" in coord:
+                print("ARTEM look! coord=" + coord + " has type!")
+                
             a = ["--force-version", coord.split(",classifier=")[0]]
             print("ARTEM look! a=" + str(a))
             b = [
-                                "--force-version",
-                                ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
-                            ]
+                "--force-version",
+                ",".join([c for c in coord.split(",") if not c.startswith("classifier=") and not c.startswith("type=")]),
+            ]
             print("ARTEM look! b=" + str(b))
             cmd.extend(b)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -690,7 +690,7 @@ def make_coursier_dep_tree(
                 print("ARTEM look! b=" + str(b) + " coord=" + str(coord))
                 print("ARTEM look! c=" + str(c) + " coord=" + str(coord))
 
-            cmd.extend(c)
+            cmd.extend(b)
     cmd.extend(["--artifact-type", ",".join(SUPPORTED_PACKAGING_TYPES + ["src", "doc"])])
     cmd.append("--verbose" if _is_verbose(repository_ctx) else "--quiet")
     cmd.append("--no-default")

--- a/specs.bzl
+++ b/specs.bzl
@@ -254,7 +254,7 @@ json = struct(
 # Coursier expects artifacts to be defined in the form `group:artifact:version`, but it also supports some attributes:
 # `url`, `ext`, `classifier`, `exclude` and `type`.
 # In contrast with group, artifact and version, the attributes are a key=value comma-separated string appended at the end,
-# For example: `coursier fetch group:artifact:version,classifier=xxx,url=yyy`
+# For example: `coursier fetch group:artifact:version,classifier=xxx,type=yyy`
 #
 def _artifact_to_coord(artifact):
     classifier = (",classifier=" + artifact["classifier"]) if artifact.get("classifier") != None else ""


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/pull/908 introduced a bug #917 where some transitive dependencies were not resolved

I've traced it and think the `coursier fetch` args now started to include `,type=xxx` into them which seems to have broken coursier resolution.

The fix preprocesses `artifact_coordinates` for the `coursier fetch` command and I now see transitive dependencies resolved correctly:

```json
"org.mockito:mockito-core": [
      "net.bytebuddy:byte-buddy",
      "net.bytebuddy:byte-buddy-agent",
      "org.objenesis:objenesis"
],
```