### PR TITLE
Deprecate jetify

### DIFF
--- a/private/rules/jetifier.bzl
+++ b/private/rules/jetifier.bzl
@@ -2,6 +2,8 @@ load("//:specs.bzl", "parse")
 load(":jetifier_maven_map.bzl", "jetifier_maven_map")
 load(":jvm_import.bzl", "jvm_import")
 
+_DEPRECATION_MESSAGE = "Please update your dependencies to no longer require jetification."
+
 def _jetify_impl(ctx):
     srcs = ctx.attr.srcs
     outfiles = []
@@ -40,6 +42,7 @@ jetify = rule(
 def jetify_aar_import(name, aar, _aar_import = None, visibility = None, **kwargs):
     jetify(
         name = "jetified_" + name,
+        deprecation = _DEPRECATION_MESSAGE,
         srcs = [aar],
         visibility = visibility,
     )
@@ -57,6 +60,7 @@ def jetify_aar_import(name, aar, _aar_import = None, visibility = None, **kwargs
 def jetify_jvm_import(name, jars, visibility = None, **kwargs):
     jetify(
         name = "jetified_" + name,
+        deprecation = _DEPRECATION_MESSAGE,
         srcs = jars,
         visibility = visibility,
     )

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -75,6 +75,9 @@ def maven_install(
         fail the build, if "warn" then print a message and continue, if "none" then do nothing. The default
         is "warn".
     """
+    if jetify:
+        print("Jetify use has been deprecated. Please manually update your `artifacts` to avoid requiring this tool.")
+
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
         repositories_json_strings.append(_json.write_repository_spec(repository))


### PR DESCRIPTION
AndroidX is a series of dependencies that Google released, like standard libraries but for all things Google. At some point they switched the namespace on those libraries to `androidx`, which caused a ton of runtime crashes because you'd have older versions of libraries that hadn't updated to Androidx conflicting with ones that have updated.

The last release of jetifier was in 2020, and since then the tool has been deprecated & so we should also mark it as deprecated and remove from rules_jvm_external a future release.