### PR TITLE
Expand template variables in coordinates in additional places

### DIFF
--- a/private/rules/maven_bom.bzl
+++ b/private/rules/maven_bom.bzl
@@ -23,9 +23,12 @@ def _label(label_or_string):
 def _maven_bom_impl(ctx):
     fragments = [f[MavenBomFragmentInfo] for f in ctx.attr.fragments]
 
+    # Expand maven coordinates for any variables to be replaced.
+    coordinates = ctx.expand_make_variables("coordinates", ctx.attr.maven_coordinates, {})
+
     bom = generate_pom(
         ctx,
-        coordinates = ctx.attr.maven_coordinates,
+        coordinates = coordinates,
         versioned_dep_coordinates = [f[MavenBomFragmentInfo].coordinates for f in ctx.attr.fragments],
         pom_template = ctx.file.pom_template,
         out_name = "%s.xml" % ctx.label.name,

--- a/private/rules/maven_bom_fragment.bzl
+++ b/private/rules/maven_bom_fragment.bzl
@@ -13,6 +13,9 @@ MavenBomFragmentInfo = provider(
 
 def _maven_bom_fragment_impl(ctx):
     java_info = ctx.attr.artifact[JavaInfo]
+    
+    # Expand maven coordinates for any variables to be replaced.
+    coordinates = ctx.expand_make_variables("coordinates", ctx.attr.maven_coordinates, ctx.var)
 
     # Since Bazel 5.0.0
     if "java_outputs" in dir(java_info):
@@ -29,7 +32,7 @@ def _maven_bom_fragment_impl(ctx):
 
     return [
         MavenBomFragmentInfo(
-            coordinates = ctx.attr.maven_coordinates,
+            coordinates = coordinates,
             artifact = artifact_jar,
             srcs = ctx.file.src_artifact,
             javadocs = ctx.file.javadoc_artifact,

--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -16,9 +16,12 @@ def _pom_file_impl(ctx):
         for coords in dep[MavenInfo].as_maven_dep.to_list():
             all_maven_deps.append(coords)
 
+    # Expand maven coordinates for any variables to be replaced.
+    coordinates = ctx.expand_make_variables("coordinates", info.coordinates, ctx.var)
+
     out = generate_pom(
         ctx,
-        coordinates = info.coordinates,
+        coordinates = coordinates,
         versioned_dep_coordinates = sorted(all_maven_deps),
         pom_template = ctx.file.pom_template,
         out_name = "%s.xml" % ctx.label.name,


### PR DESCRIPTION
#794 missed adding template expansion in a few places where Maven coordinates are used. This PR covers the remaining usages.