### PR TITLE
Add classifier_artifacts parameter to java_export to allow users to publish extra artifacts

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -106,12 +106,12 @@ Generated rules:
 | <a id="java_export-name"></a>name |  A unique name for this target   |  none |
 | <a id="java_export-maven_coordinates"></a>maven_coordinates |  The maven coordinates for this target.   |  none |
 | <a id="java_export-deploy_env"></a>deploy_env |  A list of labels of Java targets to exclude from the generated jar. [<code>java_binary</code>](https://bazel.build/reference/be/java#java_binary) targets are *not* supported.   |  <code>[]</code> |
-| <a id="java_export-classifier_artifacts"></a>classifier_artifacts | A dict of classifier -> label of additional artifacts to publish.|<code>{}</code>|
 | <a id="java_export-excluded_workspaces"></a>excluded_workspaces |  A dict of strings representing the workspace names of artifacts that should not be included in the maven jar to a <code>Label</code> pointing to the dependency that workspace should be replaced by, or <code>None</code> if the exclusion shouldn't be replaced with an extra dependency.   |  <code>{"com_google_protobuf": None}</code> |
 | <a id="java_export-pom_template"></a>pom_template |  The template to be used for the pom.xml file.   |  <code>None</code> |
 | <a id="java_export-visibility"></a>visibility |  The visibility of the target   |  <code>None</code> |
 | <a id="java_export-tags"></a>tags |  <p align="center"> - </p>   |  <code>[]</code> |
 | <a id="java_export-testonly"></a>testonly |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="java_export-classifier_artifacts"></a>classifier_artifacts |  A dict of classifier -&gt; artifact of additional artifacts to publish to Maven.   |  <code>{}</code> |
 | <a id="java_export-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,6 +106,7 @@ Generated rules:
 | <a id="java_export-name"></a>name |  A unique name for this target   |  none |
 | <a id="java_export-maven_coordinates"></a>maven_coordinates |  The maven coordinates for this target.   |  none |
 | <a id="java_export-deploy_env"></a>deploy_env |  A list of labels of Java targets to exclude from the generated jar. [<code>java_binary</code>](https://bazel.build/reference/be/java#java_binary) targets are *not* supported.   |  <code>[]</code> |
+| <a id="java_export-classifier_artifacts"></a>classifier_artifacts | A dict of classifier -> label of additional artifacts to publish.|<code>{}</code>|
 | <a id="java_export-excluded_workspaces"></a>excluded_workspaces |  A dict of strings representing the workspace names of artifacts that should not be included in the maven jar to a <code>Label</code> pointing to the dependency that workspace should be replaced by, or <code>None</code> if the exclusion shouldn't be replaced with an extra dependency.   |  <code>{"com_google_protobuf": None}</code> |
 | <a id="java_export-pom_template"></a>pom_template |  The template to be used for the pom.xml file.   |  <code>None</code> |
 | <a id="java_export-visibility"></a>visibility |  The visibility of the target   |  <code>None</code> |

--- a/examples/java-export/BUILD
+++ b/examples/java-export/BUILD
@@ -9,6 +9,9 @@ load("@rules_jvm_external//:defs.bzl", "java_export", "maven_bom")
 
 java_export(
     name = "example-export",
+    classifier_artifacts = {
+        "release": "//src/main/java/com/github/bazelbuild/rulesjvmexternal/example/export:tar",
+    },
     maven_coordinates = "com.example:bazel-example:0.0.1",
     runtime_deps = [
         "//src/main/java/com/github/bazelbuild/rulesjvmexternal/example/export",

--- a/examples/java-export/src/main/java/com/github/bazelbuild/rulesjvmexternal/example/export/BUILD
+++ b/examples/java-export/src/main/java/com/github/bazelbuild/rulesjvmexternal/example/export/BUILD
@@ -1,4 +1,5 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 java_library(
     name = "export",
@@ -9,5 +10,13 @@ java_library(
     deps = [
         "//src/main/proto",
         artifact("com.google.guava:guava"),
+    ],
+)
+
+pkg_tar(
+    name = "tar",
+    srcs = glob(["*"]),
+    visibility = [
+        "//:__pkg__",
     ],
 )

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -248,7 +248,7 @@ def maven_export(
         coordinates = maven_coordinates,
         pom = "%s-pom" % name,
         artifact = ":%s-maven-artifact" % name,
-        classifier_artifacts = {v: k for (k, v) in classifier_artifacts.items()},
+        classifier_artifacts = {v: k for (k, v) in classifier_artifacts.items() if v},
         visibility = visibility,
         tags = tags,
         testonly = testonly,

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -13,6 +13,7 @@ def java_export(
         visibility = None,
         tags = [],
         testonly = None,
+        classifier_artifacts = {},
         **kwargs):
     """Extends `java_library` to allow maven artifacts to be uploaded.
 
@@ -66,6 +67,7 @@ def java_export(
         that should not be included in the maven jar to a `Label` pointing to the dependency
         that workspace should be replaced by, or `None` if the exclusion shouldn't be replaced
         with an extra dependency.
+      classifier_artifacts: A dict of classifier -> artifact of additional artifacts to publish to Maven.
       visibility: The visibility of the target
       kwargs: These are passed to [`java_library`](https://bazel.build/reference/be/java#java_library),
         and so may contain any valid parameter for that rule.
@@ -96,6 +98,7 @@ def java_export(
         tags,
         testonly,
         javadocopts,
+        classifier_artifacts = classifier_artifacts,
     )
 
 def maven_export(
@@ -108,7 +111,8 @@ def maven_export(
         visibility = None,
         tags = [],
         testonly = False,
-        javadocopts = []):
+        javadocopts = [],
+        classifier_artifacts = {}):
     """
     All arguments are the same as java_export with the addition of:
       lib_name: Name of the library that has been built.
@@ -235,13 +239,15 @@ def maven_export(
         testonly = testonly,
     )
 
+    classifier_artifacts.setdefault("sources", ":%s-maven-source" % name)
+    classifier_artifacts.setdefault("javadoc", docs_jar)
+
     maven_publish(
         name = "%s.publish" % name,
         coordinates = maven_coordinates,
         pom = "%s-pom" % name,
-        javadocs = docs_jar,
-        artifact_jar = ":%s-maven-artifact" % name,
-        source_jar = ":%s-maven-source" % name,
+        artifact = ":%s-maven-artifact" % name,
+        classifier_artifacts = {v: k for (k, v) in classifier_artifacts.items()},
         visibility = visibility,
         tags = tags,
         testonly = testonly,

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -176,6 +176,7 @@ def maven_export(
     excluded_workspaces = excluded_workspaces if excluded_workspaces else []
     javadocopts = javadocopts if javadocopts else []
     tags = tags if tags else []
+    classifier_artifacts = classifier_artifacts if classifier_artifacts else {}
 
     additional_dependencies = {label: name for (name, label) in excluded_workspaces.items() if label}
 

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -239,6 +239,7 @@ def maven_export(
         testonly = testonly,
     )
 
+    classifier_artifacts = dict(classifier_artifacts)  # unfreeze
     classifier_artifacts.setdefault("sources", ":%s-maven-source" % name)
     classifier_artifacts.setdefault("javadoc", docs_jar)
 

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -179,6 +179,8 @@ def maven_export(
 
     additional_dependencies = {label: name for (name, label) in excluded_workspaces.items() if label}
 
+    classifier_artifacts = dict(classifier_artifacts)  # unfreeze
+
     # Merge the jars to create the maven project jar
     maven_project_jar(
         name = "%s-project" % name,
@@ -212,6 +214,7 @@ def maven_export(
         tags = tags,
         testonly = testonly,
     )
+    classifier_artifacts.setdefault("sources", ":%s-maven-source" % name)
 
     docs_jar = None
     if not "no-javadocs" in tags:
@@ -228,6 +231,7 @@ def maven_export(
             tags = tags,
             testonly = testonly,
         )
+        classifier_artifacts.setdefault("javadoc", docs_jar)
 
     pom_file(
         name = "%s-pom" % name,
@@ -238,10 +242,6 @@ def maven_export(
         tags = tags,
         testonly = testonly,
     )
-
-    classifier_artifacts = dict(classifier_artifacts)  # unfreeze
-    classifier_artifacts.setdefault("sources", ":%s-maven-source" % name)
-    classifier_artifacts.setdefault("javadoc", docs_jar)
 
     maven_publish(
         name = "%s.publish" % name,

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -29,7 +29,12 @@ def _maven_publish_impl(ctx):
 
     classifier_artifacts_dict = {}
     for target, classifier in ctx.attr.classifier_artifacts.items():
-        file = target.files.to_list()[0]
+        target_files = target.files.to_list()
+        if not target_files:
+            fail("Target {} for classifier \"{}\" of {} has no files in its output.".format(target, classifier, coordinates))
+        if len(target_files) > 1:
+            print("WARNING: Target {} for classifier \"{}\" of {} has more than one file in its output, using the first one.".format(target, classifier, coordinates))
+        file = target_files[0]
         classifier_artifacts_dict[classifier] = file
 
     ctx.actions.write(

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -3,15 +3,16 @@ MavenPublishInfo = provider(
         "coordinates": "Maven coordinates for the project, which may be None",
         "pom": "Pom.xml file for metdata",
         "javadocs": "Javadoc jar file for documentation files",
-        "artifact_jar": "Jar with the code and metadata for execution",
+        "artifact": "Primary artifact to be published, typically a jar",
         "source_jar": "Jar with the source code for review",
+        "classifier_artifacts": "Dict of extra artifacts to be published under classifiers",
     },
 )
 
 _TEMPLATE = """#!/usr/bin/env bash
 
 echo "Uploading {coordinates} to {maven_repo}"
-{uploader} '{maven_repo}' '{gpg_sign}' '{user}' '{password}' '{coordinates}' '{pom}' '{artifact_jar}' '{source_jar}' '{javadoc}'
+{uploader} '{maven_repo}' '{gpg_sign}' '{user}' '{password}' '{coordinates}' '{pom}' '{artifact}' '{classifier_artifacts}'
 """
 
 def _maven_publish_impl(ctx):
@@ -24,9 +25,12 @@ def _maven_publish_impl(ctx):
 
     # Expand maven coordinates for any variables to be replaced.
     coordinates = ctx.expand_make_variables("coordinates", ctx.attr.coordinates, {})
-    artifacts_short_path = ctx.file.artifact_jar.short_path if ctx.file.artifact_jar else ""
-    source_short_path = ctx.file.source_jar.short_path if ctx.file.source_jar else ""
-    javadocs_short_path = ctx.file.javadocs.short_path if ctx.file.javadocs else ""
+    artifacts_short_path = ctx.file.artifact.short_path if ctx.file.artifact else ""
+
+    classifier_artifacts_dict = {}
+    for target, classifier in ctx.attr.classifier_artifacts.items():
+        file = target.files.to_list()[0]
+        classifier_artifacts_dict[classifier] = file
 
     ctx.actions.write(
         output = executable,
@@ -39,19 +43,14 @@ def _maven_publish_impl(ctx):
             password = password,
             user = user,
             pom = ctx.file.pom.short_path,
-            artifact_jar = artifacts_short_path,
-            source_jar = source_short_path,
-            javadoc = javadocs_short_path,
+            artifact = artifacts_short_path,
+            classifier_artifacts = ",".join(["{}={}".format(classifier, file.short_path) for (classifier, file) in classifier_artifacts_dict.items()]),
         ),
     )
 
-    files = [ctx.file.pom]
-    if ctx.file.artifact_jar:
-        files.append(ctx.file.artifact_jar)
-    if ctx.file.source_jar:
-        files.append(ctx.file.source_jar)
-    if ctx.file.javadocs:
-        files.append(ctx.file.javadocs)
+    files = [ctx.file.pom] + ctx.files.classifier_artifacts
+    if ctx.file.artifact:
+        files.append(ctx.file.artifact)
 
     return [
         DefaultInfo(
@@ -64,9 +63,10 @@ def _maven_publish_impl(ctx):
         ),
         MavenPublishInfo(
             coordinates = coordinates,
-            artifact_jar = ctx.file.artifact_jar,
-            javadocs = ctx.file.javadocs,
-            source_jar = ctx.file.source_jar,
+            artifact = ctx.file.artifact,
+            classifier_artifacts = classifier_artifacts_dict,
+            javadocs = classifier_artifacts_dict.get("javadoc"),
+            source_jar = classifier_artifacts_dict.get("sources"),
             pom = ctx.file.pom,
         ),
     ]
@@ -95,15 +95,10 @@ When signing with GPG, the current default key is used.
             mandatory = True,
             allow_single_file = True,
         ),
-        "javadocs": attr.label(
+        "artifact": attr.label(
             allow_single_file = True,
         ),
-        "artifact_jar": attr.label(
-            allow_single_file = True,
-        ),
-        "source_jar": attr.label(
-            allow_single_file = True,
-        ),
+        "classifier_artifacts": attr.label_keyed_string_dict(allow_files = True),
         "_uploader": attr.label(
             executable = True,
             cfg = "exec",

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD
@@ -24,6 +24,10 @@ java_binary(
             repository_name = "rules_jvm_external_deps",
         ),
         artifact(
+            "com.google.guava:guava",
+            repository_name = "rules_jvm_external_deps",
+        ),
+        artifact(
             "software.amazon.awssdk:s3",
             repository_name = "rules_jvm_external_deps",
         ),

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -28,6 +28,7 @@ import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -86,24 +87,26 @@ public class MavenPublisher {
 
     // Calculate md5 and sha1 for each of the inputs
     Path pom = Paths.get(args[5]);
-    Path binJar = getPathIfSet(args[6]);
-    Path srcJar = getPathIfSet(args[7]);
-    Path docJar = getPathIfSet(args[8]);
+    Path mainArtifact = getPathIfSet(args[6]);
 
     try {
       List<CompletableFuture<Void>> futures = new ArrayList<>();
       futures.add(upload(repo, credentials, coords, ".pom", pom, gpgSign));
 
-      if (binJar != null) {
-        futures.add(upload(repo, credentials, coords, ".jar", binJar, gpgSign));
+      if (mainArtifact != null) {
+        String ext = com.google.common.io.Files.getFileExtension(mainArtifact.getFileName().toString());
+        futures.add(upload(repo, credentials, coords, "." + ext, mainArtifact, gpgSign));
       }
 
-      if (srcJar != null) {
-        futures.add(upload(repo, credentials, coords, "-sources.jar", srcJar, gpgSign));
-      }
-
-      if (docJar != null) {
-        futures.add(upload(repo, credentials, coords, "-javadoc.jar", docJar, gpgSign));
+      if(args.length > 7) {
+        List<String> extraArtifactTuples = Splitter.onPattern(",").splitToList(args[7]);
+        for(String artifactTuple : extraArtifactTuples) {
+          String[] splits = artifactTuple.split("=");
+          String classifier = splits[0];
+          Path artifact = Paths.get(splits[1]);
+          String ext = com.google.common.io.Files.getFileExtension(splits[1]);
+          futures.add(upload(repo, credentials, coords, String.format("-%s.%s", classifier, ext), artifact, gpgSign));
+        }
       }
 
       CompletableFuture<Void> all =

--- a/tests/integration/java_export/PublishShapeTest.java
+++ b/tests/integration/java_export/PublishShapeTest.java
@@ -89,8 +89,7 @@ public class PublishShapeTest {
                 coordinates,
                 pomXml.getAbsolutePath(),
                 stubJar.getAbsolutePath(),
-                stubJar.getAbsolutePath(),
-                stubJar.getAbsolutePath())
+                String.format("javadoc=%s,sources=%s", stubJar.getAbsolutePath(), stubJar.getAbsolutePath()))
             .redirectErrorStream(true)
             .start();
 


### PR DESCRIPTION
This PR addresses the remaining issues in #805 which got pretty close to being mergeable. I also renamed "extra_artifacts" to "classifier_artifacts" to stick closer to Maven terminology. Also, since javadocs and source jars are special cases of classifier artifacts, I refactored them to use the same code path.