### PR TITLE
Allow passing sensitive credentials for java_export with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,7 +1065,7 @@ In order to publish the artifact, use `bazel run`:
 
 Or, to publish to (eg) Sonatype's OSS repo:
 
-```python
+```shell
 MAVEN_USER=example_user MAVEN_PASSWORD=hunter2 bazel run --stamp \
   --define "maven_repo=https://oss.sonatype.org/service/local/staging/deploy/maven2" \
   --define gpg_sign=true \

--- a/README.md
+++ b/README.md
@@ -1066,10 +1066,8 @@ In order to publish the artifact, use `bazel run`:
 Or, to publish to (eg) Sonatype's OSS repo:
 
 ```python
-bazel run --stamp \
+MAVEN_USER=example_user MAVEN_PASSWORD=hunter2 bazel run --stamp \
   --define "maven_repo=https://oss.sonatype.org/service/local/staging/deploy/maven2" \
-  --define "maven_user=example_user" \
-  --define "maven_password=hunter2" \
   --define gpg_sign=true \
   //user_project:exported_lib.publish`
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install", "artifact")
 ## javadoc
 
 <pre>
-javadoc(<a href="#javadoc-name">name</a>, <a href="#javadoc-deps">deps</a>, <a href="#javadoc-javadocopts">javadocopts</a>)
+javadoc(<a href="#javadoc-name">name</a>, <a href="#javadoc-additional_dependencies">additional_dependencies</a>, <a href="#javadoc-deps">deps</a>, <a href="#javadoc-excluded_workspaces">excluded_workspaces</a>, <a href="#javadoc-javadocopts">javadocopts</a>)
 </pre>
 
 Generate a javadoc from all the `deps`
@@ -43,7 +43,9 @@ Generate a javadoc from all the `deps`
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="javadoc-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="javadoc-additional_dependencies"></a>additional_dependencies |  Mapping of <code>Label</code>s to the excluded workspace names. Note that this must match the values passed to the <code>pom_file</code> rule so the <code>pom.xml</code> correctly lists these dependencies.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
 | <a id="javadoc-deps"></a>deps |  The java libraries to generate javadocs for.<br><br>          The source jars of each dep will be used to generate the javadocs.           Currently docs for transitive dependencies are not generated.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="javadoc-excluded_workspaces"></a>excluded_workspaces |  A list of bazel workspace names to exclude from the generated jar   | List of strings | optional | <code>["com_google_protobuf"]</code> |
 | <a id="javadoc-javadocopts"></a>javadocopts |  javadoc options.             Note sources and classpath are derived from the deps. Any additional             options can be passed here.   | List of strings | optional | <code>[]</code> |
 
 
@@ -62,11 +64,12 @@ This macro can be used as a drop-in replacement for `java_library`, but
 also generates an implicit `name.publish` target that can be run to publish
 maven artifacts derived from this macro to a maven repository. The publish
 rule understands the following variables (declared using `--define` when
-using `bazel run`):
+using `bazel run`, or as environment variables in ALL_CAPS form):
 
-  * `maven_repo`: A URL for the repo to use. May be "https" or "file".
-  * `maven_user`: The user name to use when uploading to the maven repository.
-  * `maven_password`: The password to use when uploading to the maven repository.
+  * `maven_repo`: A URL for the repo to use. May be "https" or "file". Can also be set with environment variable `MAVEN_REPO`.
+  * `maven_user`: The user name to use when uploading to the maven repository. Can also be set with environment variable `MAVEN_USER`.
+  * `maven_password`: The password to use when uploading to the maven repository. Can also be set with environment variable `MAVEN_PASSWORD`.
+
 
 This macro also generates a `name-pom` target that creates the `pom.xml` file
 associated with the artifacts. The template used is derived from the (optional)

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -20,11 +20,12 @@ def java_export(
     also generates an implicit `name.publish` target that can be run to publish
     maven artifacts derived from this macro to a maven repository. The publish
     rule understands the following variables (declared using `--define` when
-    using `bazel run`):
+    using `bazel run`, or as environment variables in ALL_CAPS form):
 
-      * `maven_repo`: A URL for the repo to use. May be "https" or "file".
-      * `maven_user`: The user name to use when uploading to the maven repository.
-      * `maven_password`: The password to use when uploading to the maven repository.
+      * `maven_repo`: A URL for the repo to use. May be "https" or "file". Can also be set with environment variable `MAVEN_REPO`.
+      * `maven_user`: The user name to use when uploading to the maven repository. Can also be set with environment variable `MAVEN_USER`.
+      * `maven_password`: The password to use when uploading to the maven repository. Can also be set with environment variable `MAVEN_PASSWORD`.
+
 
     This macro also generates a `name-pom` target that creates the `pom.xml` file
     associated with the artifacts. The template used is derived from the (optional)

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -9,10 +9,14 @@ MavenPublishInfo = provider(
 )
 
 _TEMPLATE = """#!/usr/bin/env bash
-
-echo "Uploading {coordinates} to {maven_repo}"
+maven_repo='{maven_repo}'
+echo Uploading '{coordinates}' to "${{MAVEN_REPO:-$maven_repo}}"
 {uploader} '{maven_repo}' '{gpg_sign}' '{user}' '{password}' '{coordinates}' '{pom}' '{artifact_jar}' '{source_jar}' '{javadoc}'
 """
+
+def _escape_arg(str):
+    # Escape a string that will be single quoted in bash and might contain single quotes.
+    return str.replace("'", "'\\''")
 
 def _maven_publish_impl(ctx):
     executable = ctx.actions.declare_file("%s-publisher" % ctx.attr.name)
@@ -21,6 +25,8 @@ def _maven_publish_impl(ctx):
     gpg_sign = ctx.var.get("gpg_sign", "false")
     user = ctx.var.get("maven_user", "")
     password = ctx.var.get("maven_password", "")
+    if password:
+        print("WARNING: using --define to set maven_password is unsafe. Set env var MAVEN_PASSWORD=xxx instead.")
 
     # Expand maven coordinates for any variables to be replaced.
     coordinates = ctx.expand_make_variables("coordinates", ctx.attr.coordinates, {})
@@ -33,11 +39,11 @@ def _maven_publish_impl(ctx):
         is_executable = True,
         content = _TEMPLATE.format(
             uploader = ctx.executable._uploader.short_path,
-            coordinates = coordinates,
-            gpg_sign = gpg_sign,
-            maven_repo = maven_repo,
-            password = password,
-            user = user,
+            coordinates = _escape_arg(coordinates),
+            gpg_sign = _escape_arg(gpg_sign),
+            maven_repo = _escape_arg(maven_repo),
+            password = _escape_arg(password),
+            user = _escape_arg(user),
             pom = ctx.file.pom.short_path,
             artifact_jar = artifacts_short_path,
             source_jar = source_short_path,
@@ -77,7 +83,7 @@ maven_publish = rule(
 
 The maven repository may accessed locally using a `file://` URL, or
 remotely using an `https://` URL. The following flags may be set
-using `--define`:
+using `--define` or via environment variables (in all caps, e.g. `MAVEN_REPO`):
 
   gpg_sign: Whether to sign artifacts using GPG
   maven_repo: A URL for the repo to use. May be "https" or "file".

--- a/private/rules/maven_publish.bzl
+++ b/private/rules/maven_publish.bzl
@@ -13,8 +13,8 @@ export MAVEN_REPO="${{MAVEN_REPO:-{maven_repo}}}"
 export GPG_SIGN="${{GPG_SIGN:-{gpg_sign}}}"
 export MAVEN_USER="${{MAVEN_USER:-{user}}}"
 export MAVEN_PASSWORD="${{MAVEN_PASSWORD:-{password}}}"
-echo Uploading '{coordinates}' to "${{MAVEN_REPO}}"
-{uploader} '{coordinates}' '{pom}' '{artifact_jar}' '{source_jar}' '{javadoc}'
+echo Uploading "{coordinates}" to "${{MAVEN_REPO}}"
+{uploader} "{coordinates}" '{pom}' '{artifact_jar}' '{source_jar}' '{javadoc}'
 """
 
 def _escape_arg(str):

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -65,33 +65,22 @@ public class MavenPublisher {
     "file:/", "https://", "gs://", "s3://", "artifactregistry://"
   };
 
-  private static String getArg(String[] args, String envName, int argPos) {
-    String envVal = System.getenv(envName);
-    if (envVal != null) {
-      return envVal;
-    }
-    if (argPos < args.length) {
-      return args[argPos];
-    }
-    return null;
-  }
-
   public static void main(String[] args)
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    String repo = getArg(args, "MAVEN_REPO", 0);
+    String repo = System.getenv("MAVEN_REPO");
     if (!isSchemeSupported(repo)) {
       throw new IllegalArgumentException(
           "Repository must be accessed via the supported schemes: "
               + Arrays.toString(SUPPORTED_SCHEMES));
     }
 
-    boolean gpgSign = Boolean.parseBoolean(getArg(args, "GPG_SIGN", 1));
+    boolean gpgSign = Boolean.parseBoolean(System.getenv("GPG_SIGN"));
     Credentials credentials = new BasicAuthCredentials(
-            getArg(args, "MAVEN_USER", 2),
-            getArg(args, "MAVEN_PASSWORD", 3)
+            System.getenv("MAVEN_USER"),
+            System.getenv("MAVEN_PASSWORD")
     );
 
-    List<String> parts = Arrays.asList(args[4].split(":"));
+    List<String> parts = Arrays.asList(args[0].split(":"));
     if (parts.size() != 3) {
       throw new IllegalArgumentException("Coordinates must be a triplet: " + Arrays.toString(parts.toArray()));
     }
@@ -99,10 +88,10 @@ public class MavenPublisher {
     Coordinates coords = new Coordinates(parts.get(0), parts.get(1), parts.get(2));
 
     // Calculate md5 and sha1 for each of the inputs
-    Path pom = Paths.get(args[5]);
-    Path binJar = getPathIfSet(args[6]);
-    Path srcJar = getPathIfSet(args[7]);
-    Path docJar = getPathIfSet(args[8]);
+    Path pom = Paths.get(args[1]);
+    Path binJar = getPathIfSet(args[2]);
+    Path srcJar = getPathIfSet(args[3]);
+    Path docJar = getPathIfSet(args[4]);
 
     try {
       List<CompletableFuture<Void>> futures = new ArrayList<>();

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -65,21 +65,35 @@ public class MavenPublisher {
     "file:/", "https://", "gs://", "s3://", "artifactregistry://"
   };
 
+  private static String getArg(String[] args, String envName, int argPos) {
+    String envVal = System.getenv(envName);
+    if (envVal != null) {
+      return envVal;
+    }
+    if (argPos < args.length) {
+      return args[argPos];
+    }
+    return null;
+  }
+
   public static void main(String[] args)
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    String repo = args[0];
+    String repo = getArg(args, "MAVEN_REPO", 0);
     if (!isSchemeSupported(repo)) {
       throw new IllegalArgumentException(
           "Repository must be accessed via the supported schemes: "
               + Arrays.toString(SUPPORTED_SCHEMES));
     }
 
-    boolean gpgSign = Boolean.parseBoolean(args[1]);
-    Credentials credentials = new BasicAuthCredentials(args[2], args[3]);
+    boolean gpgSign = Boolean.parseBoolean(getArg(args, "GPG_SIGN", 1));
+    Credentials credentials = new BasicAuthCredentials(
+            getArg(args, "MAVEN_USER", 2),
+            getArg(args, "MAVEN_PASSWORD", 3)
+    );
 
     List<String> parts = Arrays.asList(args[4].split(":"));
     if (parts.size() != 3) {
-      throw new IllegalArgumentException("Coordinates must be a triplet: " + Arrays.toString(args));
+      throw new IllegalArgumentException("Coordinates must be a triplet: " + Arrays.toString(parts.toArray()));
     }
 
     Coordinates coords = new Coordinates(parts.get(0), parts.get(1), parts.get(2));

--- a/tests/integration/java_export/PublishShapeTest.java
+++ b/tests/integration/java_export/PublishShapeTest.java
@@ -82,10 +82,6 @@ public class PublishShapeTest {
                 "java",
                 "-jar",
                 deployJar.toAbsolutePath().toString(),
-                "", // Set this via env var
-                "false", // No gpg signing
-                "", // User name
-                "", // Password,
                 coordinates,
                 pomXml.getAbsolutePath(),
                 stubJar.getAbsolutePath(),
@@ -93,6 +89,9 @@ public class PublishShapeTest {
                 stubJar.getAbsolutePath())
             .redirectErrorStream(true);
     pb.environment().put("MAVEN_REPO", repoRoot.toURI().toASCIIString());
+    pb.environment().put("MAVEN_USER", "");
+    pb.environment().put("MAVEN_PASSWORD", "");
+    pb.environment().put("GPG_SIGN", "false");
     Process process = pb.start();
 
     process.waitFor();

--- a/tests/integration/java_export/PublishShapeTest.java
+++ b/tests/integration/java_export/PublishShapeTest.java
@@ -76,13 +76,13 @@ public class PublishShapeTest {
     // We'd prefer to use `bazel run`, but this is a reasonable proxy for
     // ./uploader {maven_repo} {gpg_sign} {user} {password} {coordinates} pom.xml artifact.jar
     // source.jar doc.jar
-    Process process =
+    ProcessBuilder pb =
         new ProcessBuilder()
             .command(
                 "java",
                 "-jar",
                 deployJar.toAbsolutePath().toString(),
-                repoRoot.toURI().toASCIIString(),
+                "", // Set this via env var
                 "false", // No gpg signing
                 "", // User name
                 "", // Password,
@@ -91,8 +91,9 @@ public class PublishShapeTest {
                 stubJar.getAbsolutePath(),
                 stubJar.getAbsolutePath(),
                 stubJar.getAbsolutePath())
-            .redirectErrorStream(true)
-            .start();
+            .redirectErrorStream(true);
+    pb.environment().put("MAVEN_REPO", repoRoot.toURI().toASCIIString());
+    Process process = pb.start();
 
     process.waitFor();
 


### PR DESCRIPTION
This PR fixes #679 by allowing users to specify `maven_user` and `maven_pass` via environment variable when using `maven_publish`. 