### PR TITLE
Register java toolchain inside maven_project_jar

### DIFF
--- a/private/rules/maven_project_jar.bzl
+++ b/private/rules/maven_project_jar.bzl
@@ -190,4 +190,5 @@ single artifact that other teams can download and use.
             default = "@bazel_tools//tools/jdk:current_java_toolchain",
         ),
     },
+    toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
 )


### PR DESCRIPTION
Any rule which uses java_common should register java toolchain_type.