### PR TITLE
Fix pinning error with Bzlmod

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -310,6 +310,7 @@ def _maven_impl(mctx):
             # created from the maven_install.json file in the coursier_fetch
             # invocation after this.
             name = "unpinned_" + name if repo.get("lock_file") else name,
+            user_provided_name = name,
             repositories = repo.get("repositories"),
             artifacts = artifacts_json,
             fail_on_missing_checksum = repo.get("fail_on_missing_checksum"),
@@ -358,6 +359,7 @@ def _maven_impl(mctx):
 
             pinned_coursier_fetch(
                 name = name,
+                user_provided_name = name,
                 repositories = repo.get("repositories"),
                 artifacts = artifacts_json,
                 fetch_sources = repo.get("fetch_sources"),


### PR DESCRIPTION
Fixes the `bazel run` command suggested when the lockfile is outdated and Bzlmod is used.