### PR TITLE
Fix CODEOWNERS only requesting reviews from @cheister

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-* @jin
-* @Wyverald 
-* @shs96c 
-* @cheister
+* @jin @Wyverald @shs96c @cheister


### PR DESCRIPTION
Only @cheister was getting owners review because GitHub doesn't support multiline aggregation and took the last row :-)

@Wyverald let me know if you'd still like to be in RJE's CODEOWNERS. 