### PR TITLE
Prepare for Java 8 support dropping from modern JDKs

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/BUILD
@@ -4,6 +4,7 @@ java_library(
     javacopts = [
         "--release",
         "8",
+        "-Xlint:-options",
     ],
     visibility = [
         "//private/tools/java:__subpackages__",

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
@@ -6,6 +6,7 @@ java_library(
     javacopts = [
         "--release",
         "8",
+        "-Xlint:-options",
     ],
     visibility = [
         "//private/tools/java:__subpackages__",


### PR DESCRIPTION
Modern JDKs print a warning that Java 8 support is deprecated and will be removed in a future release. To prevent that warning being displayed, we add an additional `javac` flag when compiling the code which targets Java 8.

The long-term solution is to only target Java 11+, which I suggest we do after Java 21 ships in Septembe after 2023.