### PR TITLE
Fix `testonly` attribute handling

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -206,7 +206,7 @@ def _maven_impl(mctx):
                 to_add.update({"neverlink": artifact.neverlink})
 
             if artifact.testonly:
-                to_add.update({"version": artifact.testonly})
+                to_add.update({"testonly": artifact.testonly})
 
             if artifact.exclusions:
                 artifact_exclusions = []


### PR DESCRIPTION
Fix the following error when using `test_only` in Bzlmod
```
ERROR: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_pcloudy/829441223e9fec5a5a2e3d1dd743fdf0/external/rules_jvm_external~5.2/private/extensions/maven.bzl", line 304, column 52, in _maven_impl
		artifacts_json = [_json.write_artifact_spec(a) for a in artifacts]
	File "/private/var/tmp/_bazel_pcloudy/829441223e9fec5a5a2e3d1dd743fdf0/external/rules_jvm_external~5.2/specs.bzl", line 230, column 38, in _artifact_spec_to_json
		"\", \"version\": \"" + artifact_spec["version"] + "\""
Error: unsupported binary operation: string + bool
```