### PR TITLE
Support so/dylib/dll packaging types

### DIFF
--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -29,6 +29,9 @@ SUPPORTED_PACKAGING_TYPES = [
     "hk2-jar",
     "maven-plugin",
     "scala-jar",
+    "dylib",
+    "so",
+    "dll",
 ]
 
 # See https://github.com/bazelbuild/rules_jvm_external/issues/686


### PR DESCRIPTION
I think it would be a bit nicer to set up the data dependencies in the generated rules, but I wasn't able to get it working when trying a combination of cc_import, java_library, etc. The downside of doing that is we wouldn't be able to use `select` to depend on just the platform-specific jar that we want. 

If anyone has ideas how to do better, let me know!