### PR TITLE
m2local: solve files not getting resolved

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -559,8 +559,12 @@ def _pinned_coursier_fetch_impl(repository_ctx):
             "        netrc = \"../%s/netrc\"," % (repository_ctx.name),
         ])
         if len(artifact["urls"]) == 0 and importer.has_m2local(maven_install_json_content) and artifact.get("file") != None:
+            if _is_windows(repository_ctx):
+                user_home = repository_ctx.os.environ.get("USERPROFILE").replace("\\", "/")
+            else:
+                user_home = repository_ctx.os.environ.get("HOME")
             m2local_urls = [
-                "file://%s/.m2/repository/%s" % (repository_ctx.os.environ["HOME"], artifact["file"]),
+                "file://%s/.m2/repository/%s" % (user_home, artifact["file"]),
             ]
         else:
             m2local_urls = []

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -558,8 +558,14 @@ def _pinned_coursier_fetch_impl(repository_ctx):
             # File-path is relative defined from http_file traveling to repository_ctx.
             "        netrc = \"../%s/netrc\"," % (repository_ctx.name),
         ])
+        if len(artifact["urls"]) == 0 and importer.has_m2local(maven_install_json_content) and artifact.get("file") != None:
+            m2local_urls = [
+                "file://%s/.m2/repository/%s" % (repository_ctx.os.environ["HOME"], artifact["file"]),
+            ]
+        else:
+            m2local_urls = []
         http_files.append("        urls = %s," % repr(
-            [remove_auth_from_url(url) for url in artifact["urls"]],
+            [remove_auth_from_url(url) for url in artifact["urls"] + m2local_urls],
         ))
         http_files.append("        downloaded_file_path = \"%s\"," % artifact["file"])
         http_files.append("    )")

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -30,9 +30,6 @@ load(
 )
 
 def _genrule_copy_artifact_from_http_file(artifact, visibilities):
-    # skip artifacts without any urls (ie: maven local artifacts)
-    if not len(artifact["urls"]):
-        return ""
     http_file_repository = escape(artifact["coordinates"])
 
     file = artifact.get("out", artifact["file"])

--- a/private/rules/v1_lock_file.bzl
+++ b/private/rules/v1_lock_file.bzl
@@ -31,6 +31,9 @@ def _is_valid_lock_file(lock_file_contents):
     # the build files.
     return True
 
+def _has_m2local(lock_file_contents):
+    return lock_file_contents.get("m2local", False)
+
 def _get_input_artifacts_hash(lock_file_contents):
     dep_tree = lock_file_contents.get("dependency_tree", {})
     return dep_tree.get("__INPUT_ARTIFACTS_HASH")
@@ -138,4 +141,5 @@ v1_lock_file = struct(
     compute_lock_file_hash = _compute_lock_file_hash,
     get_artifacts = _get_artifacts,
     get_netrc_entries = _get_netrc_entries,
+    has_m2local = _has_m2local,
 )

--- a/private/rules/v2_lock_file.bzl
+++ b/private/rules/v2_lock_file.bzl
@@ -26,6 +26,9 @@ def _is_valid_lock_file(lock_file_contents):
 
     return True
 
+def _has_m2local(lock_file_contents):
+    return lock_file_contents.get("m2local", False)
+
 def _get_input_artifacts_hash(lock_file_contents):
     return lock_file_contents.get("__INPUT_ARTIFACTS_HASH")
 
@@ -189,4 +192,5 @@ v2_lock_file = struct(
     get_artifacts = _get_artifacts,
     get_netrc_entries = _get_netrc_entries,
     render_lock_file = _render_lock_file,
+    has_m2local = _has_m2local,
 )

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -22,7 +22,7 @@ function test_duplicate_version_warning() {
   expect_log "Successfully pinned resolved artifacts"
 }
 
-function test_m2local_testing_found_local_artifact_through_pin() {
+function test_m2local_testing_found_local_artifact_through_pin_and_build() {
   m2local_dir="${HOME}/.m2/repository"
   jar_dir="${m2local_dir}/com/example/kt/1.0.0"
   rm -rf ${jar_dir}
@@ -31,6 +31,7 @@ function test_m2local_testing_found_local_artifact_through_pin() {
   # Publish a maven artifact locally - com.example.kt:1.0.0
   bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/kt_jvm_export:test.publish >> "$TEST_LOG" 2>&1
   bazel run @m2local_testing//:pin >> "$TEST_LOG" 2>&1
+  bazel build @m2local_testing//:com_example_kt >> "$TEST_LOG" 2>&1
   rm -f m2local_testing_install.json
   rm -rf ${jar_dir}
 
@@ -38,12 +39,13 @@ function test_m2local_testing_found_local_artifact_through_pin() {
   expect_log "Successfully pinned resolved artifacts"
 }
 
-function test_unpinned_m2local_testing_found_local_artifact_through_pin() {
+function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build() {
   m2local_dir="~/.m2/repository"
   mkdir -p ${m2local_dir}
   # Publish a maven artifact locally - com.example.kt:1.0.0
   bazel run --define maven_repo="file://${HOME}/.m2/repository" //tests/integration/kt_jvm_export:test.publish 
   bazel run @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
+  bazel build @m2local_testing_repin//:com_example_kt >> "$TEST_LOG" 2>&1
   rm -f m2local_testing_install.json
   rm -rf ~/.m2/repository
 
@@ -137,8 +139,8 @@ TESTS=(
   "test_duplicate_version_warning_same_version"
   "test_outdated"
   "test_outdated_no_external_runfiles"
-  "test_m2local_testing_found_local_artifact_through_pin"
-  "test_unpinned_m2local_testing_found_local_artifact_through_pin"
+  "test_m2local_testing_found_local_artifact_through_pin_and_build"
+  "test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build"
   "test_m2local_testing_found_local_artifact_through_build"
   "test_m2local_testing_found_local_artifact_after_build_copy"
   "test_v1_lock_file_format"


### PR DESCRIPTION
Coursier can resolve m2local artifacts when pinning. However, if you try using them, they will fail stamping:

```
Stamping the manifest of @maven//:dev_zio_zio_test_2_12 failed: missing input file 'external/maven/dev/zio/zio-test_2.12/2.0.18-RC0-whatever/zio-test_2.12-2.0.18-RC0-whatever.jar', owner: '@maven//:dev/zio/zio-test_2.12/2.0.18-RC0-whatever/zio-test_2.12-2.0.18-RC0-whatever.jar'
```

This is assuming, that I have built dev.zio:zio-test-junit_2.12:2.0.18-RC0-whatever locally, deployed it to ~/.m2/repository and then set up a dependency on it, enabled m2local and tried using the artifact.

There are two reasons to that:
1. In coursier.bzl we are not adding a local url to the generated http_file() usage (so it does not download it)
2. A corresponding genrule entry is not generated in dependency_tree_parser.bzl

Fix it by adding a local url in coursier.bzl and ensure a genrule is added. This way the file is downloaded and then properly copied (and is available for stamping).

Added has_m2local to v2_lock_file.bzl.