### PR TITLE
jvm_import: Include sha256 in tags

### DIFF
--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -269,6 +269,8 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
                 target_import_string.append("\t\t\"maven_url=None\",")
             if neverlink_artifacts.get(simple_coord):
                 target_import_string.append("\t\t\"maven:compile-only\",")
+            if artifact.get("sha256"):
+                target_import_string.append("\t\t\"maven_sha256=%s\"," % artifact["sha256"])
             target_import_string.append("\t],")
 
             # 6. If `neverlink` is True in the artifact spec, add the neverlink attribute to make this artifact

--- a/tests/unit/jvm_import/jvm_import_test.bzl
+++ b/tests/unit/jvm_import/jvm_import_test.bzl
@@ -40,10 +40,11 @@ def _does_jvm_import_have_tags_impl(ctx):
 
     expected_tags = [
         "maven_coordinates=com.google.code.findbugs:jsr305:3.0.2",
+        "maven_sha256=766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
         "maven_url=https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
     ]
 
-    asserts.equals(env, ctx.attr.src[TagsInfo].tags, expected_tags)
+    asserts.equals(env, expected_tags, ctx.attr.src[TagsInfo].tags)
     return analysistest.end(env)
 
 does_jvm_import_have_tags_test = analysistest.make(


### PR DESCRIPTION
This may help folks to do things like generate sbom files by looking at the attributes of jvm_import targets.