### PR TITLE
Normalise timestamps from maven_project_jar with those from java_library

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/zip/StableZipEntry.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/zip/StableZipEntry.java
@@ -25,7 +25,7 @@ public class StableZipEntry extends ZipEntry {
 
   // File time is taken from the epoch (1970-01-01T00:00:00Z), but zip files
   // have a different epoch. Oof. Make something sensible up.
-  private static final LocalDateTime DOS_EPOCH = LocalDateTime.of(1985, 2, 1, 0, 0);
+  private static final LocalDateTime DOS_EPOCH = LocalDateTime.of(2010, 1, 1, 0, 0);
   // ZIP timestamps have a resolution of 2 seconds.
   // see http://www.info-zip.org/FAQ.html#limits
   private static final long MINIMUM_TIMESTAMP_INCREMENT = 2000L;

--- a/tests/integration/java_export/PublishShapeTest.java
+++ b/tests/integration/java_export/PublishShapeTest.java
@@ -85,7 +85,8 @@ public class PublishShapeTest {
                 coordinates,
                 pomXml.getAbsolutePath(),
                 stubJar.getAbsolutePath(),
-                String.format("javadoc=%s,sources=%s", stubJar.getAbsolutePath(), stubJar.getAbsolutePath()))
+                String.format(
+                    "javadoc=%s,sources=%s", stubJar.getAbsolutePath(), stubJar.getAbsolutePath()))
             .redirectErrorStream(true);
     pb.environment().put("MAVEN_REPO", repoRoot.toURI().toASCIIString());
     pb.environment().put("MAVEN_USER", "");


### PR DESCRIPTION
It's a bit weird that the jars created by `maven_project_jar` have timestamps from 1985, but the outputs from `java_library` are from 2010. Time to make them the same.