### PR TITLE
Disable JVM perfdata when stamping jars

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -3,6 +3,9 @@ load("@rules_jvm_external//:defs.bzl", "artifact")
 java_binary(
     name = "AddJarManifestEntry",
     srcs = ["AddJarManifestEntry.java"],
+    # Disable perfdata to avoid warning on Linux hosts (https://github.com/bazelbuild/bazel/issues/3236)
+    # [warning][perf,memops] Cannot use file /tmp/hsperfdata_user/2 because it is locked by another process (errno = 11)
+    jvm_flags = ["-XX:-UsePerfData"],
     main_class = "com.github.bazelbuild.rules_jvm_external.jar.AddJarManifestEntry",
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
A [recent JDK update](https://github.com/openjdk/jdk/commit/84f23149e22561173feb0e34bca31a7345b43c89#diff-7313eb3d328797a7720fa1b2b73cd159934506593443e45534baad80cb1382b7R924-R927) started printing the following warning message from the JVM
```
[warning][perf,memops] Cannot use file /tmp/hsperfdata_username/2 because it is locked by another process (errno = 11)
``` 
on linux hosts.  Also referenced from https://github.com/bazelbuild/bazel/issues/3236

This PR disables the perfdata generation when stamping a jar so we won't get this warning message, which is printed for every jar that processed.