### PR TITLE
fix: Publish artifacts without additional classifiers

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -101,7 +101,7 @@ public class MavenPublisher {
         futures.add(upload(repo, credentials, coords, "." + ext, mainArtifact, gpgSign));
       }
 
-      if (args.length > 3) {
+      if (args.length > 3 && !args[3].isEmpty()) {
         List<String> extraArtifactTuples = Splitter.onPattern(",").splitToList(args[3]);
         for (String artifactTuple : extraArtifactTuples) {
           String[] splits = artifactTuple.split("=");


### PR DESCRIPTION
Fix an `ArrayIndexOutOfBoundsException` when publishing an artifact without additional classifiers.

```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
        at com.github.bazelbuild.rules_jvm_external.maven.MavenPublisher.main(MavenPublisher.java:109)
```

Fixes #1010 