### PR TITLE
Allow `bzlmod`-based builds to set repin instructions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -423,8 +423,10 @@ dev_maven.install(
         "org.mockito:mockito-core:jar:3.3.3",
         "androidx.arch.core:core-testing:aar:2.1.0",
     ],
+    fail_if_repin_required = True,
     generate_compat_repositories = True,
     lock_file = "//tests/custom_maven_install:regression_testing_install.json",
+    repin_instructions = "Please run `REPIN=1 bazel run @regression_testing//:pin` to refresh the lock file.",
     repositories = [
         "https://repo1.maven.org/maven2",
         "https://maven.google.com",

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,7 @@ Generate a javadoc from all the `deps`
 | <a id="javadoc-deps"></a>deps |  The java libraries to generate javadocs for.<br><br>          The source jars of each dep will be used to generate the javadocs.           Currently docs for transitive dependencies are not generated.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="javadoc-doc_deps"></a>doc_deps |  <code>javadoc</code> targets referenced by the current target.<br><br>            Use this to automatically add appropriate <code>-linkoffline</code> javadoc options to resolve             references to packages documented by the given javadoc targets that have <code>url</code>             specified.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="javadoc-doc_url"></a>doc_url |  The URL at which this documentation will be hosted.<br><br>            This information is only used by javadoc targets depending on this target.   | String | optional | <code>""</code> |
-| <a id="javadoc-excluded_workspaces"></a>excluded_workspaces |  A list of bazel workspace names to exclude from the generated jar   | List of strings | optional | <code>["com_google_protobuf"]</code> |
+| <a id="javadoc-excluded_workspaces"></a>excluded_workspaces |  A list of bazel workspace names to exclude from the generated jar   | List of strings | optional | <code>["com_google_protobuf", "protobuf"]</code> |
 | <a id="javadoc-javadocopts"></a>javadocopts |  javadoc options.             Note sources and classpath are derived from the deps. Any additional             options can be passed here.   | List of strings | optional | <code>[]</code> |
 
 
@@ -94,8 +94,7 @@ runtime dependencies for the following tags:
   * `maven:compile-only`: Specifies that this dependency should not be listed
     as a dependency of the artifact being generated.
 
-To skip generation of the javadoc jar, add the `no-javadocs` tag, and to skip
-generation of the sources jar, add the `no-sources` tag to the target.
+To skip generation of the javadoc jar, add the `no-javadocs` tag to the target.
 
 Generated rules:
   * `name`: A `java_library` that other rules can depend upon.
@@ -112,7 +111,7 @@ Generated rules:
 | <a id="java_export-name"></a>name |  A unique name for this target   |  none |
 | <a id="java_export-maven_coordinates"></a>maven_coordinates |  The maven coordinates for this target.   |  none |
 | <a id="java_export-deploy_env"></a>deploy_env |  A list of labels of Java targets to exclude from the generated jar. [<code>java_binary</code>](https://bazel.build/reference/be/java#java_binary) targets are *not* supported.   |  <code>[]</code> |
-| <a id="java_export-excluded_workspaces"></a>excluded_workspaces |  A dict of strings representing the workspace names of artifacts that should not be included in the maven jar to a <code>Label</code> pointing to the dependency that workspace should be replaced by, or <code>None</code> if the exclusion shouldn't be replaced with an extra dependency.   |  <code>{"com_google_protobuf": None}</code> |
+| <a id="java_export-excluded_workspaces"></a>excluded_workspaces |  A dict of strings representing the workspace names of artifacts that should not be included in the maven jar to a <code>Label</code> pointing to the dependency that workspace should be replaced by, or <code>None</code> if the exclusion shouldn't be replaced with an extra dependency.   |  <code>{"com_google_protobuf": None, "protobuf": None}</code> |
 | <a id="java_export-pom_template"></a>pom_template |  The template to be used for the pom.xml file.   |  <code>None</code> |
 | <a id="java_export-visibility"></a>visibility |  The visibility of the target   |  <code>None</code> |
 | <a id="java_export-tags"></a>tags |  <p align="center"> - </p>   |  <code>[]</code> |
@@ -195,7 +194,7 @@ maven_install(<a href="#maven_install-name">name</a>, <a href="#maven_install-re
               <a href="#maven_install-maven_install_json">maven_install_json</a>, <a href="#maven_install-override_targets">override_targets</a>, <a href="#maven_install-strict_visibility">strict_visibility</a>, <a href="#maven_install-strict_visibility_value">strict_visibility_value</a>,
               <a href="#maven_install-resolve_timeout">resolve_timeout</a>, <a href="#maven_install-additional_netrc_lines">additional_netrc_lines</a>, <a href="#maven_install-use_credentials_from_home_netrc_file">use_credentials_from_home_netrc_file</a>,
               <a href="#maven_install-fail_if_repin_required">fail_if_repin_required</a>, <a href="#maven_install-use_starlark_android_rules">use_starlark_android_rules</a>, <a href="#maven_install-aar_import_bzl_label">aar_import_bzl_label</a>,
-              <a href="#maven_install-duplicate_version_warning">duplicate_version_warning</a>)
+              <a href="#maven_install-duplicate_version_warning">duplicate_version_warning</a>, <a href="#maven_install-repin_instructions">repin_instructions</a>, <a href="#maven_install-ignore_empty_files">ignore_empty_files</a>)
 </pre>
 
 Resolves and fetches artifacts transitively from Maven repositories.
@@ -229,6 +228,8 @@ and fetch Maven artifacts transitively.
 | <a id="maven_install-use_starlark_android_rules"></a>use_starlark_android_rules |  Whether to use the native or Starlark version of the Android rules. Default is False.   |  <code>False</code> |
 | <a id="maven_install-aar_import_bzl_label"></a>aar_import_bzl_label |  The label (as a string) to use to import aar_import from. This is usually needed only if the top-level workspace file does not use the typical default repository name to import the Android Starlark rules. Default is "@build_bazel_rules_android//rules:rules.bzl".   |  <code>"@build_bazel_rules_android//android:rules.bzl"</code> |
 | <a id="maven_install-duplicate_version_warning"></a>duplicate_version_warning |  What to do if an artifact is specified multiple times. If "error" then fail the build, if "warn" then print a message and continue, if "none" then do nothing. The default is "warn".   |  <code>"warn"</code> |
+| <a id="maven_install-repin_instructions"></a>repin_instructions |  Instructions to re-pin dependencies in your repository. Will be shown when re-pinning is required.   |  <code>None</code> |
+| <a id="maven_install-ignore_empty_files"></a>ignore_empty_files |  Treat jars that are empty as if they were not found.   |  <code>False</code> |
 
 
 # Maven specification functions

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -94,6 +94,7 @@ _install = tag_class(
             ],
         ),
         "ignore_empty_files": attr.bool(default = False, doc = "Treat jars that are empty as if they were not found."),
+        "repin_instructions": attr.string(doc = "Instructions to re-pin the repository if required. Many people have wrapper scripts for keeping dependencies up to date, and would like to point users to that instead of the default. Only honoured for the root module."),
     },
 )
 
@@ -325,6 +326,9 @@ def _maven_impl(mctx):
                 timout = install.resolve_timeout
             repo["resolve_timeout"] = timeout
 
+            if mod.is_root:
+                repo["repin_instructions"] = install.repin_instructions
+
             repos[install.name] = repo
 
     existing_repos = []
@@ -405,6 +409,7 @@ def _maven_impl(mctx):
                 aar_import_bzl_label = repo.get("aar_import_bzl_label"),
                 duplicate_version_warning = repo.get("duplicate_version_warning"),
                 excluded_artifacts = excluded_artifacts_json,
+                repin_instructions = repo.get("repin_instructions"),
             )
 
             if repo.get("generate_compat_repositories"):


### PR DESCRIPTION
Fixes #1020