### PR TITLE
Load `JavaInfo` and `java_common` from `rules_java`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -79,6 +79,9 @@ bzl_library(
         # stardoc.
         "//visibility:public",
     ],
+    deps = [
+        "@rules_java//java:rules",
+    ],
 )
 
 alias(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,17 +12,19 @@ bazel_dep(
     version = "0.0.8",
 )
 bazel_dep(
+    name = "rules_java",
+    version = "7.3.2",
+)
+bazel_dep(
     name = "rules_kotlin",
     version = "1.9.0",
 )
 
 # Remove this once rules_android has rolled out official Bzlmod support
 remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-
 use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
 maven = use_extension(":extensions.bzl", "maven")
-
 maven.install(
     name = "rules_jvm_external_deps",
     artifacts = [
@@ -38,14 +40,12 @@ maven.install(
     ],
     lock_file = "//:rules_jvm_external_deps_install.json",
 )
-
 maven.install(
     name = "maven_jar_migrator",
     artifacts = [
         "com.google.guava:guava:28.0-jre",
     ],
 )
-
 use_repo(
     maven,
     "maven_jar_migrator",
@@ -100,13 +100,13 @@ http_file(
 
 bazel_dep(
     name = "aspect_rules_js",
-    dev_dependency = True,
     version = "1.34.1",
+    dev_dependency = True,
 )
 bazel_dep(
     name = "rules_nodejs",
-    dev_dependency = True,
     version = "5.8.2",
+    dev_dependency = True,
 )
 
 node = use_extension(
@@ -114,24 +114,23 @@ node = use_extension(
     "node",
     dev_dependency = True,
 )
-
 node.toolchain(node_version = "16.17.0")
 
 bazel_dep(
     name = "protobuf",
-    dev_dependency = True,
     version = "21.7",
+    dev_dependency = True,
 )
 bazel_dep(
     name = "rules_android",
-    dev_dependency = True,
     version = "0.1.1",
+    dev_dependency = True,
 )
 bazel_dep(
     name = "stardoc",
+    version = "0.5.6",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
-    version = "0.5.6",
 )
 
 npm = use_extension(
@@ -139,7 +138,6 @@ npm = use_extension(
     "npm",
     dev_dependency = True,
 )
-
 npm.npm_translate_lock(
     name = "npm",
     data = ["//:package.json"],
@@ -150,7 +148,6 @@ npm.npm_translate_lock(
     verify_node_modules_ignored = "//:.bazelignore",
     yarn_lock = "//:yarn.lock",
 )
-
 use_repo(npm, "npm")
 
 dev_maven = use_extension(
@@ -158,7 +155,6 @@ dev_maven = use_extension(
     "maven",
     dev_dependency = True,
 )
-
 dev_maven.install(
     artifacts = [
         "com.google.guava:guava:31.1-jre",
@@ -166,7 +162,6 @@ dev_maven.install(
     ],
     lock_file = "@rules_jvm_external//:maven_install.json",
 )
-
 dev_maven.install(
     name = "duplicate_version_warning",
     artifacts = [
@@ -181,7 +176,6 @@ dev_maven.install(
         "https://maven.google.com",
     ],
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning",
     artifact = "jffi",
@@ -189,7 +183,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.3",
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning",
     artifact = "jffi",
@@ -197,7 +190,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.2",
 )
-
 dev_maven.install(
     name = "duplicate_version_warning_same_version",
     artifacts = [
@@ -209,7 +201,6 @@ dev_maven.install(
         "https://maven.google.com",
     ],
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning_same_version",
     artifact = "jffi",
@@ -217,7 +208,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.3",
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning_same_version",
     artifact = "jffi",
@@ -225,7 +215,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.3",
 )
-
 dev_maven.artifact(
     name = "exclusion_testing",
     artifact = "guava",
@@ -236,7 +225,6 @@ dev_maven.artifact(
     group = "com.google.guava",
     version = "27.0-jre",
 )
-
 dev_maven.install(
     name = "global_exclusion_testing",
     artifacts = [
@@ -249,7 +237,6 @@ dev_maven.install(
         "org.codehaus.mojo:animal-sniffer-annotations",
     ],
 )
-
 dev_maven.install(
     name = "java_export_exclusion_testing",
     artifacts = [
@@ -273,14 +260,12 @@ dev_maven.install(
         "https://repo.spring.io/plugins-release/",
     ],
 )
-
 dev_maven.install(
     name = "jvm_import_test",
     artifacts = [
         "com.google.code.findbugs:jsr305:3.0.2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing",
     artifacts = [
@@ -294,7 +279,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_ignore_empty_files",
     artifacts = [
@@ -309,7 +293,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_ignore_empty_files_repin",
     artifacts = [
@@ -325,7 +308,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_repin",
     artifacts = [
@@ -339,7 +321,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_without_checksum",
     artifacts = [
@@ -354,7 +335,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "manifest_stamp_testing",
     artifacts = [
@@ -365,13 +345,11 @@ dev_maven.install(
     ],
     lock_file = "//tests/custom_maven_install:manifest_stamp_testing_install.json",
 )
-
 dev_maven.install(
     name = "maven_install_in_custom_location",
     artifacts = ["com.google.guava:guava:27.0-jre"],
     lock_file = "//tests/custom_maven_install:maven_install.json",
 )
-
 dev_maven.install(
     name = "override_target_in_deps",
     artifacts = [
@@ -380,13 +358,11 @@ dev_maven.install(
     ],
     lock_file = "@rules_jvm_external//tests/custom_maven_install:override_target_in_deps_install.json",
 )
-
 dev_maven.override(
     name = "override_target_in_deps",
     coordinates = "io.opentelemetry:opentelemetry-api",
     target = "@//tests/integration/override_targets:additional_deps",
 )
-
 dev_maven.install(
     name = "policy_pinned_testing",
     artifacts = [
@@ -465,7 +441,6 @@ dev_maven.install(
         "https://packages.confluent.io/maven/",
     ],
 )
-
 dev_maven.override(
     name = "regression_testing",
     coordinates = "com.google.ar.sceneform:rendering",
@@ -501,7 +476,6 @@ dev_maven.artifact(
     group = "com.google.apis",
     version = "v1-rev235-1.25.0",
 )
-
 dev_maven.install(
     name = "starlark_aar_import_test",
     # Not actually necessary since this is the default value, but useful for
@@ -517,7 +491,6 @@ dev_maven.install(
     ],
     use_starlark_android_rules = True,
 )
-
 dev_maven.install(
     name = "starlark_aar_import_with_sources_test",
     # Not actually necessary since this is the default value, but useful for
@@ -533,7 +506,6 @@ dev_maven.install(
     ],
     use_starlark_android_rules = True,
 )
-
 dev_maven.install(
     name = "strict_visibility_testing",
     artifacts = [
@@ -551,7 +523,6 @@ dev_maven.artifact(
     group = "org.eclipse.jetty",
     version = "9.4.20.v20190813",
 )
-
 dev_maven.install(
     name = "strict_visibility_with_compat_testing",
     artifacts = [
@@ -561,14 +532,12 @@ dev_maven.install(
     generate_compat_repositories = True,
     strict_visibility = True,
 )
-
 dev_maven.artifact(
     name = "testonly_testing",
     artifact = "guava",
     group = "com.google.guava",
     version = "27.0-jre",
 )
-
 dev_maven.artifact(
     name = "testonly_testing",
     testonly = True,
@@ -584,7 +553,6 @@ dev_maven.install(
         "io.grpc:grpc-netty-shaded:1.29.0",
     ],
 )
-
 dev_maven.install(
     name = "v1_lock_file_format",
     artifacts = [

--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "JavaInfo")
+
 MavenInfo = provider(
     fields = {
         # Fields to do with maven coordinates

--- a/private/rules/javadoc.bzl
+++ b/private/rules/javadoc.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load(":maven_project_jar.bzl", "DEFAULT_EXCLUDED_WORKSPACES")
 
 _JavadocInfo = provider(

--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -7,6 +7,7 @@
 # [0]: https://github.com/square/bazel_maven_repository/pull/48
 # [1]: https://github.com/bazelbuild/bazel/issues/4549
 
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load("//settings:stamp_manifest.bzl", "StampManifestProvider")
 
 def _jvm_import_impl(ctx):

--- a/private/rules/maven_bom_fragment.bzl
+++ b/private/rules/maven_bom_fragment.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load(":has_maven_deps.bzl", "MavenInfo", "has_maven_deps")
 
 MavenBomFragmentInfo = provider(

--- a/private/rules/maven_project_jar.bzl
+++ b/private/rules/maven_project_jar.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
 load(":has_maven_deps.bzl", "MavenInfo", "calculate_artifact_jars", "calculate_artifact_source_jars", "has_maven_deps")
 load(":maven_utils.bzl", "determine_additional_dependencies")
 

--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load(":has_maven_deps.bzl", "MavenInfo", "calculate_artifact_jars", "has_maven_deps")
 load(":maven_utils.bzl", "determine_additional_dependencies", "generate_pom")
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -20,6 +20,39 @@ def rules_jvm_external_deps(repositories = _DEFAULT_REPOSITORIES):
         ],
     )
 
+    # The `rules_java` major version is tied to the major version of Bazel that it supports,
+    # so this is different from the version in the MODULE file.
+    major_version = native.bazel_version.partition(".")[0]
+    if major_version == "5":
+        maybe(
+            http_archive,
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/5.5.1/rules_java-5.5.1.tar.gz",
+            ],
+            sha256 = "73b88f34dc251bce7bc6c472eb386a6c2b312ed5b473c81fe46855c248f792e0",
+        )
+
+    elif major_version == "6":
+        maybe(
+            http_archive,
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz",
+            ],
+            sha256 = "16bc94b1a3c64f2c36ceecddc9e09a643e80937076b97e934b96a8f715ed1eaa",
+        )
+
+    else:
+        maybe(
+            http_archive,
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/7.3.2/rules_java-7.3.2.tar.gz",
+            ],
+            sha256 = "3121a00588b1581bd7c1f9b550599629e5adcc11ba9c65f482bbd5cfe47fdf30",
+        )
+
     maven_install(
         name = "rules_jvm_external_deps",
         artifacts = [

--- a/setup.bzl
+++ b/setup.bzl
@@ -1,6 +1,14 @@
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 load("@rules_jvm_external_deps//:defs.bzl", "pinned_maven_install")
 
 def rules_jvm_external_setup():
     bazel_skylib_workspace()
+
+    # When using bazel 5, we have undefined toolchains from rules_js. This should be fine to skip, since we only need
+    # it for the `JavaInfo` definition.
+    major_version = native.bazel_version.partition(".")[0]
+    if major_version != "5":
+        rules_java_dependencies()
+        rules_java_toolchains()
     pinned_maven_install()

--- a/tests/unit/aar_import/aar_import_test.bzl
+++ b/tests/unit/aar_import/aar_import_test.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java:defs.bzl", "JavaInfo")
 
 def _does_aar_import_have_srcjar_impl(ctx):
     env = analysistest.begin(ctx)

--- a/tests/unit/exports/exports_test.bzl
+++ b/tests/unit/exports/exports_test.bzl
@@ -1,6 +1,7 @@
 """Unit tests for exports."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load("//private/rules:has_maven_deps.bzl", "MavenInfo", "has_maven_deps")
 load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
 


### PR DESCRIPTION
This prepares rules_jvm_external for bazelbuild/bazel#19455

Closes #967 which has been left in limbo.