### PR TITLE
Silence 'WARNING: ... is a directory; dependency checking of directorihttps://github.com/cheister/rules_jvm_external/pull/new/silence-directory-warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,5 +24,15 @@ test --test_output=errors
 
 build --sandbox_tmpfs_path=/tmp
 
+# From https://github.com/aspect-build/rules_js/issues/1408 to quite down warnings from rules_js
+# Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
+# notices when a directory changes, if you have a directory listed in the srcs of some target.
+# Recommended when using
+# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
+# inputs to copy_directory actions.
+# Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
+
 # Allows the examples to extend the default bazelrc
 try-import %workspace%/.bazelrc.example


### PR DESCRIPTION
Running tests with Bazel 7 produces a lot of warnings that look like
```
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/micromark-extension-gfm-task-list-item@0.3.3/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/is-alphanumerical@1.0.4/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/is-decimal@1.0.4/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/is-alphabetical@1.0.4/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/is-hexadecimal@1.0.4/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/micromark-extension-gfm-tagfilter@0.3.0/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/mdast-util-gfm@0.1.2/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/micromark-extension-gfm@0.3.3/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/micromark-extension-gfm-autolink-literal@0.5.7/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/micromark-extension-gfm-strikethrough@0.6.5/pkg is a directory; dependency checking of directories is unsound
WARNING: /Users/cheister/Development/rules_jvm_external/BUILD:17:22: input 'package' to //:.aspect_rules_js/node_modules/micromark-extension-gfm-table@0.4.3/pkg is a directory; dependency checking of directories is unsound
```

This PR adds a setting to .bazelrc that allows Bazel to track changes to directories so we no longer get the warning messages.