### PR TITLE
Add no-remote-cache tags to intermediate artifacts so rules_jvm_external works with --remote_download_toplevel set

### DIFF
--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -38,6 +38,7 @@ def _genrule_copy_artifact_from_http_file(artifact, visibilities):
         "genrule(",
         "     name = \"%s_extension\"," % http_file_repository,
         "     srcs = [\"@%s//file\"]," % http_file_repository,
+        "     tags = [\"no-remote-cache\"],",
         "     outs = [\"%s\"]," % file,
         "     cmd = \"cp $< $@\",",
     ]
@@ -182,6 +183,7 @@ def _generate_target(
 
     coordinates = artifact.get("maven_coordinates", artifact["coordinates"])
     target_import_string.append("\ttags = [")
+    target_import_string.append("\t\t\"no-remote-cache\",")
     target_import_string.append("\t\t\"maven_coordinates=%s\"," % coordinates)
     if len(artifact["urls"]):
         target_import_string.append("\t\t\"maven_url=%s\"," % artifact["urls"][0])


### PR DESCRIPTION
When updating to Bazel 7.0.0 the default [Build without the Bytes (BwoB) setting](https://blog.bazel.build/2023/10/06/bwob-in-bazel-7.html) goes from `--remote_download_all` to `--remote_download_toplevel`.  For our build, this started breaking the intermediate jars used by rules_jvm_external and we had to go back to `--remote_download_all` to have them work.  In our case, if we did a `bazel clean` then a `bazel build` it would not find the intermediate jar targets used by rules_jvm_external.

This change fixes rules_jvm_external when `--remote_download_toplevel` is set but I'm not sure if this is the correct fix or not.  I'm looking for input if there might be another way to keep it working.  Bazel common cache tags reference is [here](https://bazel.build/reference/be/common-definitions#common-attributes)

