### PR TITLE
Fix mirror_coursier script

### DIFF
--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -1,4 +1,8 @@
 load("//private/rules:artifact.bzl", "artifact")
+load(
+    "//private:versions.bzl",
+    "COURSIER_CLI_HTTP_FILE_NAME",
+)
 
 genrule(
     name = "buildifier-bin",
@@ -17,6 +21,7 @@ sh_binary(
     srcs = [":mirror_coursier.sh"],
     data = ["@coursier_cli//file"],
     visibility = ["//:__pkg__"],
+    args = [COURSIER_CLI_HTTP_FILE_NAME],
 )
 
 genrule(

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -1,8 +1,5 @@
 load("//private/rules:artifact.bzl", "artifact")
-load(
-    "//private:versions.bzl",
-    "COURSIER_CLI_HTTP_FILE_NAME",
-)
+load("//private:versions.bzl", "COURSIER_CLI_HTTP_FILE_NAME")
 
 genrule(
     name = "buildifier-bin",

--- a/scripts/mirror_coursier.sh
+++ b/scripts/mirror_coursier.sh
@@ -18,13 +18,14 @@
 # on Google Cloud Storage for redundancy. The original artifacts are
 # hosted on https://github.com/coursier/coursier/releases.
 
-set -euo pipefail
+set -xeuo pipefail
 
-readonly repo_name=$(ls external/ | grep coursier_cli_v*)
-readonly coursier_cli_jar="external/$repo_name/file/downloaded"
+readonly dest_filename=$1; shift;
+readonly coursier_cli_jar="external/_main~_repo_rules~coursier_cli/file/downloaded"
 chmod u+x $coursier_cli_jar
 
-# Upload Coursier to GCS
-# -n for no-clobber, so we don't overwrite existing files
-gsutil cp -n $coursier_cli_jar \
-  gs://bazel-mirror/coursier_cli/$repo_name.jar
+# Upload Coursier to Bazel/Google-managed GCS
+# -n for no-clobber, so we don't overwrite existing files.
+# -v prints the URI after a successful upload.
+gsutil cp -v -n $coursier_cli_jar \
+  gs://bazel-mirror/coursier_cli/$dest_filename.jar


### PR DESCRIPTION
The script was referencing a location in `$output_base/execroot/external` that no longer existed after the switch to bzlmod. The version number is also no longer in the pathname, so load it from versions.bzl directly. 
