### PR TITLE
Add `manifest_entries` to `java_export`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -40,8 +40,8 @@ Generate a javadoc from all the `deps`
 ## java_export
 
 <pre>
-java_export(<a href="#java_export-name">name</a>, <a href="#java_export-maven_coordinates">maven_coordinates</a>, <a href="#java_export-deploy_env">deploy_env</a>, <a href="#java_export-excluded_workspaces">excluded_workspaces</a>, <a href="#java_export-pom_template">pom_template</a>, <a href="#java_export-visibility">visibility</a>,
-            <a href="#java_export-tags">tags</a>, <a href="#java_export-testonly">testonly</a>, <a href="#java_export-classifier_artifacts">classifier_artifacts</a>, <a href="#java_export-kwargs">kwargs</a>)
+java_export(<a href="#java_export-name">name</a>, <a href="#java_export-maven_coordinates">maven_coordinates</a>, <a href="#java_export-manifest_entries">manifest_entries</a>, <a href="#java_export-deploy_env">deploy_env</a>, <a href="#java_export-excluded_workspaces">excluded_workspaces</a>,
+            <a href="#java_export-pom_template">pom_template</a>, <a href="#java_export-visibility">visibility</a>, <a href="#java_export-tags">tags</a>, <a href="#java_export-testonly">testonly</a>, <a href="#java_export-classifier_artifacts">classifier_artifacts</a>, <a href="#java_export-kwargs">kwargs</a>)
 </pre>
 
 Extends `java_library` to allow maven artifacts to be uploaded.
@@ -94,6 +94,7 @@ Generated rules:
 | :------------- | :------------- | :------------- |
 | <a id="java_export-name"></a>name |  A unique name for this target   |  none |
 | <a id="java_export-maven_coordinates"></a>maven_coordinates |  The maven coordinates for this target.   |  none |
+| <a id="java_export-manifest_entries"></a>manifest_entries |  A dict of <code>String: String</code> containing additional manifest entry attributes and values.   |  <code>{}</code> |
 | <a id="java_export-deploy_env"></a>deploy_env |  A list of labels of Java targets to exclude from the generated jar. [<code>java_binary</code>](https://bazel.build/reference/be/java#java_binary) targets are *not* supported.   |  <code>[]</code> |
 | <a id="java_export-excluded_workspaces"></a>excluded_workspaces |  A dict of strings representing the workspace names of artifacts that should not be included in the maven jar to a <code>Label</code> pointing to the dependency that workspace should be replaced by, or <code>None</code> if the exclusion shouldn't be replaced with an extra dependency.   |  <code>{"com_google_protobuf": None, "protobuf": None}</code> |
 | <a id="java_export-pom_template"></a>pom_template |  The template to be used for the pom.xml file.   |  <code>None</code> |

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -7,6 +7,7 @@ load(":pom_file.bzl", "pom_file")
 def java_export(
         name,
         maven_coordinates,
+        manifest_entries = {},
         deploy_env = [],
         excluded_workspaces = {name: None for name in DEFAULT_EXCLUDED_WORKSPACES},
         pom_template = None,
@@ -61,6 +62,7 @@ def java_export(
       name: A unique name for this target
       maven_coordinates: The maven coordinates for this target.
       pom_template: The template to be used for the pom.xml file.
+      manifest_entries: A dict of `String: String` containing additional manifest entry attributes and values.
       deploy_env: A list of labels of Java targets to exclude from the generated jar.
         [`java_binary`](https://bazel.build/reference/be/java#java_binary) targets are *not*
         supported.
@@ -96,16 +98,17 @@ def java_export(
     )
 
     maven_export(
-        name,
-        maven_coordinates,
-        lib_name,
-        deploy_env,
-        excluded_workspaces,
-        pom_template,
-        visibility,
-        tags,
-        testonly,
-        javadocopts,
+        name = name,
+        maven_coordinates = maven_coordinates,
+        lib_name = lib_name,
+        manifest_entries = manifest_entries,
+        deploy_env = deploy_env,
+        excluded_workspaces = excluded_workspaces,
+        pom_template = pom_template,
+        visibility = visibility,
+        tags = tags,
+        testonly = testonly,
+        javadocopts = javadocopts,
         classifier_artifacts = classifier_artifacts,
         doc_deps = doc_deps,
         doc_url = doc_url,
@@ -116,6 +119,7 @@ def maven_export(
         name,
         maven_coordinates,
         lib_name,
+        manifest_entries = {},
         deploy_env = [],
         excluded_workspaces = {},
         pom_template = None,
@@ -173,6 +177,7 @@ def maven_export(
       name: A unique name for this target
       maven_coordinates: The maven coordinates for this target.
       pom_template: The template to be used for the pom.xml file.
+      manifest_entries: A dict of `String: String` containing additional manifest entry attributes and values.
       deploy_env: A list of labels of Java targets to exclude from the generated jar.
         [`java_binary`](https://bazel.build/reference/be/java#java_binary) targets are *not*
         supported.
@@ -191,6 +196,7 @@ def maven_export(
     maven_coordinates_tags = ["maven_coordinates=%s" % maven_coordinates]
 
     # Sometimes users pass `None` as the value for attributes. Guard against this
+    manifest_entries = manifest_entries if manifest_entries else {}
     deploy_env = deploy_env if deploy_env else []
     excluded_workspaces = excluded_workspaces if excluded_workspaces else {}
     javadocopts = javadocopts if javadocopts else []
@@ -207,6 +213,7 @@ def maven_export(
     maven_project_jar(
         name = "%s-project" % name,
         target = ":%s" % lib_name,
+        manifest_entries = manifest_entries,
         deploy_env = deploy_env,
         excluded_workspaces = excluded_workspaces.keys(),
         additional_dependencies = additional_dependencies,

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//:defs.bzl", "artifact", "java_export")
 load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
 
@@ -90,6 +91,19 @@ java_export(
     tags = [
         "no-javadocs",
     ],
+    deps = [
+        ":dep",
+    ],
+)
+
+java_export(
+    name = "with-manifest",
+    srcs = ["Main.java"],
+    manifest_entries = {
+        "Cheese": "cheddar",
+        "Second-Cheese": "brie",
+    },
+    maven_coordinates = "com.example:manifested:1.0.0",
     deps = [
         ":dep",
     ],
@@ -196,4 +210,25 @@ sh_test(
     deps = [
         "@bazel_tools//tools/bash/runfiles",
     ],
+)
+
+genrule(
+    name = "extract-extra-manifest-lines",
+    srcs = [
+        ":with-manifest",
+    ],
+    outs = [
+        "manifested_MANIFEST.MF",
+    ],
+    cmd = "$(location //tests/com/github/bazelbuild/rules_jvm_external/manifest:Print) $< | grep -E 'Cheese' | sort > $@",
+    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+    tools = [
+        "//tests/com/github/bazelbuild/rules_jvm_external/manifest:Print",
+    ],
+)
+
+diff_test(
+    name = "check-manifest-lines-added",
+    file1 = "check-manifest-lines-added-MANIFEST.MF.golden",
+    file2 = ":extract-extra-manifest-lines",
 )

--- a/tests/integration/java_export/check-manifest-lines-added-MANIFEST.MF.golden
+++ b/tests/integration/java_export/check-manifest-lines-added-MANIFEST.MF.golden
@@ -1,0 +1,2 @@
+Cheese: cheddar
+Second-Cheese: brie


### PR DESCRIPTION
Allows users to add specific manifest line to the jars generated by `java_export`. This is similar to the `deploy_manifest_lines` from `java_binary`, but features a dict instead of a list, since it's really a key/value pair.