### PR TITLE
Do not remove LICENSE files when combining jars

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
@@ -131,6 +131,7 @@ public class MergeJars {
 
           if ("META-INF/".equals(entry.getName())
               || (!entry.getName().startsWith("META-INF/")
+                  && !entry.getName().equals("LICENSE")
                   && excludedPaths.contains(entry.getName()))) {
             continue;
           }

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
@@ -232,6 +232,32 @@ public class MergeJarsTest {
   }
 
   @Test
+  public void shouldNotExcludeLicenseFiles() throws IOException {
+    // Create jars with names such that the first is sorted after the second
+    Path includeFrom = temp.newFile("include.jar").toPath();
+    createJar(
+        includeFrom,
+        ImmutableMap.of("LICENSE", "Hello, World!"));
+
+    Path excludeFrom = temp.newFile("exclude.jar").toPath();
+    createJar(excludeFrom, ImmutableMap.of("LICENSE", "Something else!"));
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(
+        new String[] {
+          "--output", outputJar.toAbsolutePath().toString(),
+          "--sources", includeFrom.toAbsolutePath().toString(),
+          "--exclude", excludeFrom.toAbsolutePath().toString()
+        });
+
+    Map<String, String> contents = readJar(outputJar);
+    // We expect the manifest and one file
+    assertEquals(2, contents.size());
+    assertEquals("Hello, World!", contents.get("LICENSE"));
+  }
+
+  @Test
   public void shouldNotIncludeManifestOrMetaInfEntriesFromExclusions() throws IOException {
     // Create jars with names such that the first is sorted after the second
     Path includeFrom = temp.newFile("include.jar").toPath();


### PR DESCRIPTION
maven_project_jar has a jar combining action which is attempting
to exclude dependencies' contents from the jar. However this also
removes LICENSE file from the Jar file since it is quite common for
external dependencies to include as well.

This is similar to META_INF case which the jar merging tool is special
casing and the PR piggy backs on that special case.
