### PR TITLE
Fix timout->timeout typo

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -322,7 +322,7 @@ def _maven_impl(mctx):
             # Get the longest timeout
             timeout = repo.get("resolve_timeout", install.resolve_timeout)
             if install.resolve_timeout > timeout:
-                timout = install.resolve_timeout
+                timeout = install.resolve_timeout
             repo["resolve_timeout"] = timeout
 
             if mod.is_root:


### PR DESCRIPTION
This fixes an issue where the longest timeout wasn't actually being used. 

I haven't observed this actual problem, but just noticed that timout was an unused variable in the code, and it seems highly likely the intention was to have `timeout` here instead.