### PR TITLE
fix: determine the version of java correctly

### DIFF
--- a/private/java_utilities.bzl
+++ b/private/java_utilities.bzl
@@ -2,19 +2,26 @@
 # Utilites for working with java versions
 #
 
-# Get numeric java version from `java -version` output e.g:
-#
-#     openjdk version "11.0.9" 2020-10-20
-#     OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
-#     OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
-#
-def parse_java_version(java_version_output):
-    # Look for 'version "x.y.z"' in the output'
-    if len(java_version_output.split("version ")) > 1:
-        java_version = java_version_output.split("version ")[1].partition("\n")[0].split(" ")[0].replace("\"", "")
-    else:
-        return None
+def is_version_character(c):
+    """Returns True if the character is a version character, otherwise False."""
+    return c.isdigit() or c == "."
 
+def index_of_version_character(s):
+    """Determines index of 1st occurrence of version character in string."""
+    for i in range(len(s)):
+        if is_version_character(s[i]):
+            return i
+    return None
+
+def index_of_non_version_character_from(s, index):
+    """Determines index of 1st occurrence of non-version character in string."""
+    for i in range(index, len(s)):
+        if not is_version_character(s[i]):
+            return i
+    return None
+
+def get_major_version(java_version):
+    """Returns the major version from Java version string."""
     if not java_version:
         return None
     elif "." not in java_version:
@@ -24,7 +31,21 @@ def parse_java_version(java_version_output):
     else:
         return int(java_version.split(".")[0])
 
-    return None
+# Get numeric java version from `java -version` output e.g:
+#
+#     openjdk version "11.0.9" 2020-10-20
+#     OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
+#     OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
+#
+def parse_java_version(java_version_output):
+    first_line = java_version_output.strip().split("\n")[0]
+    if not first_line:
+        return None
+    i = index_of_version_character(first_line)
+    if i == None:
+        return None
+    j = index_of_non_version_character_from(first_line, i + 1)
+    return get_major_version(first_line[i:j])
 
 # Build the contents of a java Command-Line Argument File from a list of
 # arguments.

--- a/tests/unit/java_utilities_test.bzl
+++ b/tests/unit/java_utilities_test.bzl
@@ -68,6 +68,16 @@ OpenJDK 64-Bit Server VM (build 15+36-1562, mixed mode, sharing)
 """),
     )
 
+    asserts.equals(
+        env,
+        22,
+        parse_java_version("""
+openjdk 22-ea 2024-03-19
+OpenJDK Runtime Environment (Red_Hat-22.0.0.0.36-1) (build 22-ea+36)
+OpenJDK 64-Bit Server VM (Red_Hat-22.0.0.0.36-1) (build 22-ea+36, mixed mode, sharing)
+"""),
+    )
+
     return unittest.end(env)
 
 parse_java_version_test = unittest.make(_parse_java_version_test_impl)


### PR DESCRIPTION
Fedora Linux has updated its latest JDK to version `22-ea` and that breaks the version parsing routine on here. 

```
zsh❯ java --version
openjdk 22-ea 2024-03-19
OpenJDK Runtime Environment (Red_Hat-22.0.0.0.36-1) (build 22-ea+36)
OpenJDK 64-Bit Server VM (Red_Hat-22.0.0.0.36-1) (build 22-ea+36, mixed mode, sharing)

zsh❯ which java
/usr/lib/jvm/java-22-openjdk/bin/java
```

The rewritten version parser should adapt better.