### PR TITLE
Use lock-file for maven_jar_migrator repo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,6 +46,7 @@ maven.install(
         "org.apache.maven:maven-artifact:3.9.4",
         "software.amazon.awssdk:s3:2.20.128",
     ],
+    fail_if_repin_required = True,
     lock_file = "//:rules_jvm_external_deps_install.json",
 )
 
@@ -54,6 +55,8 @@ maven.install(
     artifacts = [
         "com.google.guava:guava:28.0-jre",
     ],
+    fail_if_repin_required = True,
+    lock_file = "//:rules_jvm_external_deps_install.json",
 )
 
 use_repo(


### PR DESCRIPTION
This PR enables use of a lock-file for `maven_jar_migrator` repo. This in turn enables caching and reproducible builds.