### PR TITLE
Fix examples build breakage with SecurityManager usage in examples apps.

### DIFF
--- a/examples/android_local_test/.bazelrc
+++ b/examples/android_local_test/.bazelrc
@@ -1,0 +1,2 @@
+# Bazel's Java test runner uses SecurityManager, which was deprecated in 17. Set this flag until latest stable contains https://github.com/bazelbuild/bazel/commit/6783339e3fd21655b7fa3be2daedde4491ae0348.
+test --test_arg=--jvm_flags=-Djava.security.manager=allow

--- a/examples/kt_android_local_test/.bazelrc
+++ b/examples/kt_android_local_test/.bazelrc
@@ -1,0 +1,2 @@
+# Bazel's Java test runner uses SecurityManager, which was deprecated in 17. Set this flag until latest stable contains https://github.com/bazelbuild/bazel/commit/6783339e3fd21655b7fa3be2daedde4491ae0348.
+test --test_arg=--jvm_flags=-Djava.security.manager=allow


### PR DESCRIPTION
Both android_local_test and kt_android_local_test are failing to:

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/test:main_activity_test
-----------------------------------------------------------------------------
JUnit4 Test Runner
java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
	at java.base/java.lang.System.setSecurityManager(System.java:429)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.installSecurityManager(JUnit4Runner.java:256)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:113)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:145)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:76)

BazelTestRunner exiting with a return value of 1
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2024-03-18 04:03:24 --

```

https://github.com/bazelbuild/bazel/commit/6783339e3fd21655b7fa3be2daedde4491ae0348 is the short-term fix that hardcodes the flag into android_local_test, but our CI is still using 7.1.0 which doesn't have the commit. For now, set the allowlist flag in the bazelrc files for these examples.

The long term fix is to cut the dependency from BazelTestRunner to the SecurityManager through Junit4.

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/1067