### PR TITLE
Revert "Fix examples build breakage with SecurityManager usage in examples apps."

### DIFF
--- a/examples/android_local_test/.bazelrc
+++ b/examples/android_local_test/.bazelrc
@@ -1,2 +1,0 @@
-# Bazel's Java test runner uses SecurityManager, which was deprecated in 17. Set this flag until latest stable contains https://github.com/bazelbuild/bazel/commit/6783339e3fd21655b7fa3be2daedde4491ae0348.
-test --test_arg=--jvm_flags=-Djava.security.manager=allow

--- a/examples/kt_android_local_test/.bazelrc
+++ b/examples/kt_android_local_test/.bazelrc
@@ -1,2 +1,0 @@
-# Bazel's Java test runner uses SecurityManager, which was deprecated in 17. Set this flag until latest stable contains https://github.com/bazelbuild/bazel/commit/6783339e3fd21655b7fa3be2daedde4491ae0348.
-test --test_arg=--jvm_flags=-Djava.security.manager=allow


### PR DESCRIPTION
Reverts bazelbuild/rules_jvm_external#1073

This is no longer needed since we disabled the macOS tests.