### PR TITLE
 [maven] Handle the case where a resolution contains an artifact with differing classifiers at different versions

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/Coordinates.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/Coordinates.java
@@ -95,6 +95,10 @@ public class Coordinates implements Comparable<Coordinates> {
     return new Coordinates(getGroupId(), getArtifactId(), extension, getClassifier(), getVersion());
   }
 
+  public Coordinates setVersion(String version) {
+    return new Coordinates(getGroupId(), getArtifactId(), getExtension(), getClassifier(), version);
+  }
+
   public String getExtension() {
     return extension;
   }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
@@ -17,6 +17,10 @@ java_library(
             repository_name = "rules_jvm_external_deps",
         ),
         artifact(
+            "org.apache.maven:maven-artifact",
+            repository_name = "rules_jvm_external_deps",
+        ),
+        artifact(
             "org.apache.maven:maven-core",
             repository_name = "rules_jvm_external_deps",
         ),

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -218,14 +217,16 @@ public class MavenResolver implements Resolver {
       }
     }
 
-    Graph<Coordinates> initialResolution = buildGraph(coordsListener.getRemappings(), directDependencies);
+    Graph<Coordinates> initialResolution =
+        buildGraph(coordsListener.getRemappings(), directDependencies);
     GraphNormalizationResult graphNormalizationResult = makeVersionsConsistent(initialResolution);
 
     Set<Coordinates> simpleRequestedDeps =
         request.getDependencies().stream()
             .map(com.github.bazelbuild.rules_jvm_external.resolver.Artifact::getCoordinates)
             .collect(Collectors.toSet());
-    Set<Conflict> conflicts = Sets.union(
+    Set<Conflict> conflicts =
+        Sets.union(
             getConflicts(simpleRequestedDeps, directDependencies),
             graphNormalizationResult.getConflicts());
 
@@ -251,7 +252,8 @@ public class MavenResolver implements Resolver {
       }
     }
 
-    Set<Conflict> conflicts = mappedVersions.entrySet().stream()
+    Set<Conflict> conflicts =
+        mappedVersions.entrySet().stream()
             .filter(e -> !e.getKey().equals(e.getValue()))
             .map(e -> new Conflict(e.getValue(), e.getKey()))
             .collect(Collectors.toSet());

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -516,7 +516,7 @@ public abstract class ResolverTestBase {
   }
 
   @Test
-  public void shouldNormalizeVerionsToHighestVersionIfPomsAskForDifferentClassifiers() {
+  public void shouldNormalizeVerionsToHighestVersionIfPomsAskForDifferentClassifiersWithDifferentVersions() {
     // This behaviour is exhibited by both `coursier` and `gradle`, so we're
     // going to settle on this as what's expected. `maven` will quite happily
     // (and correctly IMO) include the javadoc dep at its version and the jar

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -516,7 +516,8 @@ public abstract class ResolverTestBase {
   }
 
   @Test
-  public void shouldNormalizeVerionsToHighestVersionIfPomsAskForDifferentClassifiersWithDifferentVersions() {
+  public void
+      shouldNormalizeVerionsToHighestVersionIfPomsAskForDifferentClassifiersWithDifferentVersions() {
     // This behaviour is exhibited by both `coursier` and `gradle`, so we're
     // going to settle on this as what's expected. `maven` will quite happily
     // (and correctly IMO) include the javadoc dep at its version and the jar

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.cmd.ResolverConfig;
@@ -533,20 +532,24 @@ public abstract class ResolverTestBase {
     Coordinates depOnBase = new Coordinates("com.example:base:4.0.0");
     Coordinates depOnClassified = new Coordinates("com.example:diff:2.0.0");
 
-    Path repo = MavenRepo.create()
+    Path repo =
+        MavenRepo.create()
             .add(base)
             .add(classified)
             .add(depOnBase, base)
             .add(depOnClassified, classified)
             .getPath();
 
-    Graph<Coordinates> resolution = resolver.resolve(prepareRequestFor(repo.toUri(), depOnBase, depOnClassified)).getResolution();
+    Graph<Coordinates> resolution =
+        resolver
+            .resolve(prepareRequestFor(repo.toUri(), depOnBase, depOnClassified))
+            .getResolution();
     Set<Coordinates> nodes = resolution.nodes();
 
     assertTrue("javadoc with higher version number not found", nodes.contains(classified));
     assertTrue(
-            "regular jar with higher version number not found",
-            nodes.contains(classified.setClassifier(null))); // Same version, no classifer
+        "regular jar with higher version number not found",
+        nodes.contains(classified.setClassifier(null))); // Same version, no classifer
   }
 
   private Model createModel(Coordinates coords) {

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.cmd.ResolverConfig;
@@ -513,6 +514,39 @@ public abstract class ResolverTestBase {
             .collect(Collectors.toSet());
 
     assertEquals(children.toString(), 1, children.size());
+  }
+
+  @Test
+  public void shouldNormalizeVerionsToHighestVersionIfPomsAskForDifferentClassifiers() {
+    // This behaviour is exhibited by both `coursier` and `gradle`, so we're
+    // going to settle on this as what's expected. `maven` will quite happily
+    // (and correctly IMO) include the javadoc dep at its version and the jar
+    // dep at its version. The problem is that when we come to render the lock
+    // file we can't have two items with the same `groupId:artifactId` with
+    // different versions, so I guess that's another reason to normalise the
+    // weird thing that the other resolvers do.
+
+    // The default coordinate has a lower version number than the coordinate
+    // with the classifier.
+    Coordinates base = new Coordinates("com.example:odd-deps:1.0.0");
+    Coordinates classified = base.setClassifier("javadoc").setVersion("18.0");
+    Coordinates depOnBase = new Coordinates("com.example:base:4.0.0");
+    Coordinates depOnClassified = new Coordinates("com.example:diff:2.0.0");
+
+    Path repo = MavenRepo.create()
+            .add(base)
+            .add(classified)
+            .add(depOnBase, base)
+            .add(depOnClassified, classified)
+            .getPath();
+
+    Graph<Coordinates> resolution = resolver.resolve(prepareRequestFor(repo.toUri(), depOnBase, depOnClassified)).getResolution();
+    Set<Coordinates> nodes = resolution.nodes();
+
+    assertTrue("javadoc with higher version number not found", nodes.contains(classified));
+    assertTrue(
+            "regular jar with higher version number not found",
+            nodes.contains(classified.setClassifier(null))); // Same version, no classifer
   }
 
   private Model createModel(Coordinates coords) {


### PR DESCRIPTION
The behaviour exhibited by both `coursier` and `gradle` is that when a dependency graph contains anything with the same `groupId:artifactId` and a higher version, the higher version is selected, so we're going to settle on this as what's expected.

In addition, our lock file relies on the `groupId:artifactId` to always have the same version too, so that's another reason to follow what `gradle` and `coursier` do.

`maven` will quite happily (and correctly IMO) include deps at different versions if their classifiers differ, which is different from that behaviour. Work around that by revising values in the build graph.