### PR TITLE
Add logging to maven resolver for number of artifacts being resolved and RJE_VERBOSE will log the entire dependency graph

### DIFF
--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -517,7 +517,7 @@ public abstract class ResolverTestBase {
 
   @Test
   public void
-      shouldNormalizeVerionsToHighestVersionIfPomsAskForDifferentClassifiersWithDifferentVersions() {
+      shouldNormalizeVersionToHighestVersionIfPomsAskForDifferentClassifiersWithDifferentVersions() {
     // This behaviour is exhibited by both `coursier` and `gradle`, so we're
     // going to settle on this as what's expected. `maven` will quite happily
     // (and correctly IMO) include the javadoc dep at its version and the jar


### PR DESCRIPTION
Add logging so you can see how many dependencies are being resolved by the maven resolver and when the env var RJE_VERBOSE is set it will print the resolved dependency graph and remappings

e.g. 
```
> RJE_VERBOSE=1 bazel run @maven_resolved_with_boms//:pin
...
Currently: resolving 1 bom artifacts
...
Currently: resolving and fetching the transitive closure of 6 artifact(s)
...
Dependency Graph:
com.google.auto.value:auto-value-annotations:jar:1.6.3 [runtime]
net.sf.json-lib:json-lib:jar:jdk15:2.4 [runtime]
+- commons-beanutils:commons-beanutils:jar:1.8.0 [runtime]
|  \- commons-logging:commons-logging:jar:1.1.1 [runtime] (nearer exists)
+- commons-collections:commons-collections:jar:3.2.1 [runtime]
+- commons-lang:commons-lang:jar:2.5 [runtime]
+- commons-logging:commons-logging:jar:1.1.1 [runtime]
\- net.sf.ezmorph:ezmorph:jar:1.0.6 [runtime]
   \- commons-lang:commons-lang:jar:2.3 [runtime] (conflicts with 2.5)
org.apache.parquet:parquet-common:jar:1.11.1 [runtime]
+- org.apache.parquet:parquet-format-structures:jar:1.11.1 [runtime]
|  +- org.slf4j:slf4j-api:jar:1.7.22 [runtime] (nearer exists)
|  \- javax.annotation:javax.annotation-api:jar:1.3.2 [runtime]
+- org.slf4j:slf4j-api:jar:1.7.22 [runtime]
\- org.apache.yetus:audience-annotations:jar:0.11.0 [runtime]
...
```