### PR TITLE
Handle maven artifact not found

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/events/EventListener.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/events/EventListener.java
@@ -21,5 +21,7 @@ public interface EventListener extends Closeable {
   void onEvent(Event event);
 
   @Override
-  void close();
+  default void close() {
+    // no-op
+  }
 }

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/BUILD.bazel
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/BUILD.bazel
@@ -54,5 +54,9 @@ java_test(
             "junit:junit",
             repository_name = "regression_testing_coursier",
         ),
+        artifact(
+            "org.apache.maven.resolver:maven-resolver-api",
+            repository_name = "rules_jvm_external_deps",
+        ),
     ],
 )

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/DelegatingListener.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/DelegatingListener.java
@@ -1,0 +1,25 @@
+package com.github.bazelbuild.rules_jvm_external.resolver;
+
+import com.github.bazelbuild.rules_jvm_external.resolver.events.Event;
+import com.github.bazelbuild.rules_jvm_external.resolver.events.EventListener;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DelegatingListener implements EventListener {
+
+  private final List<EventListener> listeners = new ArrayList<>();
+
+  public void addListener(EventListener listener) {
+    listeners.add(listener);
+  }
+
+  @Override
+  public void onEvent(Event event) {
+    listeners.forEach(l -> l.onEvent(event));
+  }
+
+  @Override
+  public void close() {
+    listeners.forEach(EventListener::close);
+  }
+}

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/MavenResolverTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/MavenResolverTest.java
@@ -14,12 +14,15 @@
 
 package com.github.bazelbuild.rules_jvm_external.resolver;
 
+import static org.junit.Assert.fail;
+
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.cmd.ResolverConfig;
 import com.github.bazelbuild.rules_jvm_external.resolver.events.EventListener;
 import com.github.bazelbuild.rules_jvm_external.resolver.maven.MavenResolver;
 import com.github.bazelbuild.rules_jvm_external.resolver.netrc.Netrc;
 import java.nio.file.Path;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.junit.Test;
 
 public class MavenResolverTest extends ResolverTestBase {
@@ -38,5 +41,20 @@ public class MavenResolverTest extends ResolverTestBase {
 
     // There should be no cycle detected by this dependency
     resolver.resolve(prepareRequestFor(repo.toUri(), main));
+  }
+
+  @Test
+  public void shouldErrorOnMissingTopLevelDependency() {
+    Coordinates missing = new Coordinates("com.example:missing:1.0.0");
+    Path repo = MavenRepo.create().getPath();
+
+    try {
+      resolver.resolve(prepareRequestFor(repo.toUri(), missing)).getResolution();
+      fail("Expected ArtifactNotFoundException");
+    } catch (Exception e) {
+      if (!(e.getCause() instanceof ArtifactNotFoundException)) {
+        fail("Expected ArtifactNotFoundException");
+      }
+    }
   }
 }


### PR DESCRIPTION
Maven does not fail when a transitive dependency is missing.  It prints out a warning similar to
```
[WARNING] The POM for org.mortbay.jetty:jetty:jar:6.1.26.cloudera.2 is missing, no dependency information available
```
this PR implements the same behavior for the maven resolver.

This changes the manageDependencies generation to match on all artifact fields groupId:artifactId:extension:version:classifier instead of just groupId:artifactId