### PR TITLE
Add an `implementation_deps` argument to java_export

### DIFF
--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -158,7 +158,7 @@ def _has_maven_deps_impl(target, ctx):
     dep_infos = gathered.dep_infos
     label_to_javainfo = gathered.label_to_javainfo
     maven_deps = depset(transitive = [i.as_maven_dep for i in all_infos])
-    maven_runtime_deps = depset(direct = gathered.runtime_infos)
+    maven_runtime_deps = depset(transitive = [i.as_maven_dep for i in gathered.runtime_infos])
 
     transitive_exports_from_exports = depset()
     if hasattr(ctx.rule.attr, "exports"):

--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -5,6 +5,7 @@ MavenInfo = provider(
         # Fields to do with maven coordinates
         "coordinates": "Maven coordinates for the project, which may be None",
         "maven_deps": "Depset of first-order maven dependencies",
+        "maven_runtime_deps": "Depset of first-order maven runtime dependencies",
         "as_maven_dep": "Depset of this project if used as a maven dependency",
 
         # Fields used for generating artifacts
@@ -93,6 +94,7 @@ def calculate_artifact_source_jars(maven_info):
 _gathered = provider(
     fields = [
         "all_infos",
+        "runtime_infos",
         "label_to_javainfo",
         "artifact_infos",
         "transitive_exports",
@@ -100,10 +102,14 @@ _gathered = provider(
     ],
 )
 
-def _extract_from(gathered, maven_info, dep, include_transitive_exports):
+def _extract_from(gathered, maven_info, dep, include_transitive_exports, is_runtime_dep):
     java_info = dep[JavaInfo] if dep and JavaInfo in dep else None
 
     gathered.all_infos.append(maven_info)
+
+    if is_runtime_dep:
+        gathered.runtime_infos.append(maven_info)
+
     gathered.label_to_javainfo.update(maven_info.label_to_javainfo)
     if java_info:
         if maven_info.coordinates:
@@ -127,6 +133,7 @@ def _has_maven_deps_impl(target, ctx):
 
     gathered = _gathered(
         all_infos = [],
+        runtime_infos = [],
         artifact_infos = [target[JavaInfo]],
         transitive_exports = [],
         dep_infos = [],
@@ -137,13 +144,13 @@ def _has_maven_deps_impl(target, ctx):
         for dep in getattr(ctx.rule.attr, attr, []):
             if MavenHintInfo in dep:
                 for info in dep[MavenHintInfo].maven_infos.to_list():
-                    _extract_from(gathered, info, None, attr == "exports")
+                    _extract_from(gathered, info, None, attr == "exports", attr == "runtime_deps")
 
             if not MavenInfo in dep:
                 continue
 
             info = dep[MavenInfo]
-            _extract_from(gathered, info, dep, attr == "exports")
+            _extract_from(gathered, info, dep, attr == "exports", attr == "runtime_deps")
 
     all_infos = gathered.all_infos
     artifact_infos = gathered.artifact_infos
@@ -151,6 +158,7 @@ def _has_maven_deps_impl(target, ctx):
     dep_infos = gathered.dep_infos
     label_to_javainfo = gathered.label_to_javainfo
     maven_deps = depset(transitive = [i.as_maven_dep for i in all_infos])
+    maven_runtime_deps = depset(direct = gathered.runtime_infos)
 
     transitive_exports_from_exports = depset()
     if hasattr(ctx.rule.attr, "exports"):
@@ -163,6 +171,7 @@ def _has_maven_deps_impl(target, ctx):
     info = MavenInfo(
         coordinates = coordinates,
         maven_deps = maven_deps,
+        maven_runtime_deps = maven_runtime_deps,
         as_maven_dep = depset([coordinates]) if coordinates else maven_deps,
         artifact_infos = depset(direct = artifact_infos),
         dep_infos = depset(direct = dep_infos, transitive = [i.dep_infos for i in all_infos]),

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -10,7 +10,6 @@ def java_export(
         manifest_entries = {},
         deploy_env = [],
         excluded_workspaces = {name: None for name in DEFAULT_EXCLUDED_WORKSPACES},
-        implementation_deps = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -71,8 +70,6 @@ def java_export(
         that should not be included in the maven jar to a `Label` pointing to the dependency
         that workspace should be replaced by, or `None` if the exclusion shouldn't be replaced
         with an extra dependency.
-      implementation_deps: A list of labels of Java targets to include as 'implementation' dependencies. These are given
-        runtime scope on the generated pom file.
       classifier_artifacts: A dict of classifier -> artifact of additional artifacts to publish to Maven.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
@@ -107,7 +104,6 @@ def java_export(
         manifest_entries = manifest_entries,
         deploy_env = deploy_env,
         excluded_workspaces = excluded_workspaces,
-        implementation_deps = implementation_deps,
         pom_template = pom_template,
         visibility = visibility,
         tags = tags,
@@ -126,7 +122,6 @@ def maven_export(
         manifest_entries = {},
         deploy_env = [],
         excluded_workspaces = {},
-        implementation_deps = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -190,8 +185,6 @@ def maven_export(
         that should not be included in the maven jar to a `Label` pointing to the dependency
         that workspace should be replaced by, or `None` if the exclusion shouldn't be replaced
         with an extra dependency.
-      implementation_deps: A list of labels of Java targets to include as 'implementation' dependencies. These are given
-        runtime scope on the generated pom file.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
       doc_url: The URL at which the generated `javadoc` will be hosted (if not using
@@ -283,7 +276,6 @@ def maven_export(
         tags = tags,
         testonly = testonly,
         toolchains = toolchains,
-        implementation_deps = implementation_deps,
     )
 
     maven_publish(

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -10,6 +10,7 @@ def java_export(
         manifest_entries = {},
         deploy_env = [],
         excluded_workspaces = {name: None for name in DEFAULT_EXCLUDED_WORKSPACES},
+        implementation_deps = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -70,6 +71,8 @@ def java_export(
         that should not be included in the maven jar to a `Label` pointing to the dependency
         that workspace should be replaced by, or `None` if the exclusion shouldn't be replaced
         with an extra dependency.
+      implementation_deps: A list of labels of Java targets to include as 'implementation' dependencies. These are given
+        runtime scope on the generated pom file.
       classifier_artifacts: A dict of classifier -> artifact of additional artifacts to publish to Maven.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
@@ -104,6 +107,7 @@ def java_export(
         manifest_entries = manifest_entries,
         deploy_env = deploy_env,
         excluded_workspaces = excluded_workspaces,
+        implementation_deps = implementation_deps,
         pom_template = pom_template,
         visibility = visibility,
         tags = tags,
@@ -122,6 +126,7 @@ def maven_export(
         manifest_entries = {},
         deploy_env = [],
         excluded_workspaces = {},
+        implementation_deps = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -185,6 +190,8 @@ def maven_export(
         that should not be included in the maven jar to a `Label` pointing to the dependency
         that workspace should be replaced by, or `None` if the exclusion shouldn't be replaced
         with an extra dependency.
+      implementation_deps: A list of labels of Java targets to include as 'implementation' dependencies. These are given
+        runtime scope on the generated pom file.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
       doc_url: The URL at which the generated `javadoc` will be hosted (if not using
@@ -276,6 +283,7 @@ def maven_export(
         tags = tags,
         testonly = testonly,
         toolchains = toolchains,
+        implementation_deps = implementation_deps,
     )
 
     maven_publish(

--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -85,8 +85,8 @@ def generate_pom(
         parent = None,
         versioned_dep_coordinates = [],
         unversioned_dep_coordinates = [],
-        indent = 8,
-        implementation_deps = []):
+        runtime_deps = [],
+        indent = 8):
     unpacked_coordinates = unpack_coordinates(coordinates)
     substitutions = {
         "{groupId}": unpacked_coordinates.groupId,
@@ -115,7 +115,7 @@ def generate_pom(
     for dep in sorted(versioned_dep_coordinates) + sorted(unversioned_dep_coordinates):
         include_version = dep in versioned_dep_coordinates
         unpacked = unpack_coordinates(dep)
-        new_scope = "runtime" if dep in implementation_deps else unpacked.scope
+        new_scope = "runtime" if dep in runtime_deps else unpacked.scope
         unpacked = struct(
             groupId = unpacked.groupId,
             artifactId = unpacked.artifactId,


### PR DESCRIPTION
We are migrating a Gradle project to Bazel and can't break compatibility with other Java repos that import the Maven artifacts.

[Gradle has a concept](https://developer.android.com/build/dependencies#dependency_configurations) of `implementation` dependencies. These dependencies are available at compile time when building the library, but are given a `runtime` scope in the generated `pom.xml` file for consumers of the library to avoid leaking the dependency to the consumers at compile time.

This adds a list to `java_export` called `implementation_deps`. The targets passed here and in `deps` will be given a `runtime` scope on the generated `pom.xml`, but will still be available at compile time to the java_library like normal `deps`. It only impacts pom generation.

This is different than `runtime_deps` because we still need the dependencies at compile time.