### PR TITLE
Fix java version parsing when _JAVA_OPTIONS are returned from 'java -version'

### DIFF
--- a/coursier.bzl
+++ b/coursier.bzl
@@ -886,7 +886,14 @@ def make_coursier_dep_tree(
         exec_result = _execute(repository_ctx, [java_path, "-version"])
         if (exec_result.return_code != 0):
             fail("Error while running java -version: " + exec_result.stderr)
-        if parse_java_version(exec_result.stdout + exec_result.stderr) > 8:
+        java_version_output = exec_result.stdout + exec_result.stderr
+        java_version = parse_java_version(java_version_output)
+        if _is_verbose(repository_ctx):
+            print("Parsed java version [{}] from java version output [{}]".format(
+                java_version,
+                java_version_output,
+            ))
+        if java_version > 8:
             java_cmd = cmd[0]
             java_args = cmd[1:]
 

--- a/private/java_utilities.bzl
+++ b/private/java_utilities.bzl
@@ -38,14 +38,21 @@ def get_major_version(java_version):
 #     OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
 #
 def parse_java_version(java_version_output):
-    first_line = java_version_output.strip().split("\n")[0]
-    if not first_line:
+    version_lines = java_version_output.strip().split("\n")
+    if "_JAVA_OPTIONS" in version_lines[0]:
+        if len(version_lines) > 1:
+            first_version_line = version_lines[1]
+        else:
+            return None
+    else:
+        first_version_line = version_lines[0]
+    if not first_version_line:
         return None
-    i = index_of_version_character(first_line)
+    i = index_of_version_character(first_version_line)
     if i == None:
         return None
-    j = index_of_non_version_character_from(first_line, i + 1)
-    return get_major_version(first_line[i:j])
+    j = index_of_non_version_character_from(first_version_line, i + 1)
+    return get_major_version(first_version_line[i:j])
 
 # Build the contents of a java Command-Line Argument File from a list of
 # arguments.

--- a/tests/unit/java_utilities_test.bzl
+++ b/tests/unit/java_utilities_test.bzl
@@ -7,6 +7,7 @@ def _parse_java_version_test_impl(ctx):
     asserts.equals(env, None, parse_java_version(""))
     asserts.equals(env, None, parse_java_version("version "))
     asserts.equals(env, None, parse_java_version("java\nversion\n\"1.7.0_44\""))
+    asserts.equals(env, None, parse_java_version("Picked up _JAVA_OPTIONS:  -Djava.awt.headless=true"))
 
     asserts.equals(
         env,
@@ -65,6 +66,17 @@ OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
 openjdk version "15" 2020-09-15
 OpenJDK Runtime Environment (build 15+36-1562)
 OpenJDK 64-Bit Server VM (build 15+36-1562, mixed mode, sharing)
+"""),
+    )
+
+    asserts.equals(
+        env,
+        21,
+        parse_java_version("""
+Picked up _JAVA_OPTIONS:  -Djava.awt.headless=true -Duser.timezone=UTC
+openjdk version "21.0.2" 2024-01-16 LTS
+OpenJDK Runtime Environment Temurin-21.0.2+13 (build 21.0.2+13-LTS)
+OpenJDK 64-Bit Server VM Temurin-21.0.2+13 (build 21.0.2+13-LTS, mixed mode, sharing)
 """),
     )
 


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jvm_external/pull/1069 broke the case where `java -version` returns 
```
Picked up _JAVA_OPTIONS:
```
in the first line of the version string