### PR TITLE
Since we now require Java 11 we don't need to check for java 8 when building an argsfile

### DIFF
--- a/private/java_utilities.bzl
+++ b/private/java_utilities.bzl
@@ -1,58 +1,6 @@
 #
-# Utilites for working with java versions
+# Utilites for working with java command line
 #
-
-def is_version_character(c):
-    """Returns True if the character is a version character, otherwise False."""
-    return c.isdigit() or c == "."
-
-def index_of_version_character(s):
-    """Determines index of 1st occurrence of version character in string."""
-    for i in range(len(s)):
-        if is_version_character(s[i]):
-            return i
-    return None
-
-def index_of_non_version_character_from(s, index):
-    """Determines index of 1st occurrence of non-version character in string."""
-    for i in range(index, len(s)):
-        if not is_version_character(s[i]):
-            return i
-    return None
-
-def get_major_version(java_version):
-    """Returns the major version from Java version string."""
-    if not java_version:
-        return None
-    elif "." not in java_version:
-        return int(java_version)
-    elif java_version.startswith("1."):
-        return int(java_version.split(".")[1])
-    else:
-        return int(java_version.split(".")[0])
-
-# Get numeric java version from `java -version` output e.g:
-#
-#     openjdk version "11.0.9" 2020-10-20
-#     OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
-#     OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
-#
-def parse_java_version(java_version_output):
-    version_lines = java_version_output.strip().split("\n")
-    if "_JAVA_OPTIONS" in version_lines[0]:
-        if len(version_lines) > 1:
-            first_version_line = version_lines[1]
-        else:
-            return None
-    else:
-        first_version_line = version_lines[0]
-    if not first_version_line:
-        return None
-    i = index_of_version_character(first_version_line)
-    if i == None:
-        return None
-    j = index_of_non_version_character_from(first_version_line, i + 1)
-    return get_major_version(first_version_line[i:j])
 
 # Build the contents of a java Command-Line Argument File from a list of
 # arguments.

--- a/tests/unit/java_utilities_test.bzl
+++ b/tests/unit/java_utilities_test.bzl
@@ -1,98 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//private:java_utilities.bzl", "build_java_argsfile_content", "parse_java_version")
-
-def _parse_java_version_test_impl(ctx):
-    env = unittest.begin(ctx)
-
-    asserts.equals(env, None, parse_java_version(""))
-    asserts.equals(env, None, parse_java_version("version "))
-    asserts.equals(env, None, parse_java_version("java\nversion\n\"1.7.0_44\""))
-    asserts.equals(env, None, parse_java_version("Picked up _JAVA_OPTIONS:  -Djava.awt.headless=true"))
-
-    asserts.equals(
-        env,
-        7,
-        parse_java_version("""
-java version "1.7.0_55"
-Java(TM) SE Runtime Environment (build 1.7.0_55-b13)
-Java HotSpot(TM) 64-Bit Server VM (build 24.55-b03, mixed mode)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        8,
-        parse_java_version("""
-java version "1.8.0_202"
-Java(TM) SE Runtime Environment (build 1.8.0_202-b08)
-Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        9,
-        parse_java_version("""
-java version "9"
-Java(TM) SE Runtime Environment (build 9+181)
-Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        10,
-        parse_java_version("""
-java version "10.0.1" 2018-04-17
-Java(TM) SE Runtime Environment 18.3 (build 10.0.1+10)
-Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.1+10, mixed mode)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        11,
-        parse_java_version("""
-openjdk version "11.0.9" 2020-10-20
-OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
-OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        15,
-        parse_java_version("""
-openjdk version "15" 2020-09-15
-OpenJDK Runtime Environment (build 15+36-1562)
-OpenJDK 64-Bit Server VM (build 15+36-1562, mixed mode, sharing)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        21,
-        parse_java_version("""
-Picked up _JAVA_OPTIONS:  -Djava.awt.headless=true -Duser.timezone=UTC
-openjdk version "21.0.2" 2024-01-16 LTS
-OpenJDK Runtime Environment Temurin-21.0.2+13 (build 21.0.2+13-LTS)
-OpenJDK 64-Bit Server VM Temurin-21.0.2+13 (build 21.0.2+13-LTS, mixed mode, sharing)
-"""),
-    )
-
-    asserts.equals(
-        env,
-        22,
-        parse_java_version("""
-openjdk 22-ea 2024-03-19
-OpenJDK Runtime Environment (Red_Hat-22.0.0.0.36-1) (build 22-ea+36)
-OpenJDK 64-Bit Server VM (Red_Hat-22.0.0.0.36-1) (build 22-ea+36, mixed mode, sharing)
-"""),
-    )
-
-    return unittest.end(env)
-
-parse_java_version_test = unittest.make(_parse_java_version_test_impl)
+load("//private:java_utilities.bzl", "build_java_argsfile_content")
 
 def _build_java_argsfile_content_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -120,6 +27,5 @@ build_java_argsfile_content_test = unittest.make(_build_java_argsfile_content_te
 def java_utilities_test_suite():
     unittest.suite(
         "java_utilities_tests",
-        parse_java_version_test,
         build_java_argsfile_content_test,
     )


### PR DESCRIPTION
Since we moved the [minimum supported Java version to 11 ](https://github.com/bazelbuild/rules_jvm_external/pull/972)we no longer need to check for argsfile support on Java version 8.