### PR TITLE
Restore Target Uniqueness Guard in dependency_tree_parser.bzl

### DIFF
--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -454,6 +454,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             ))
 
         elif artifact_path != None:
+            seen_imports[target_label] = True
             all_imports.extend(_generate_target(
                 repository_ctx,
                 jar_versionless_target_labels,


### PR DESCRIPTION
I noticed the refactor of `dependency_tree_parser.bzl` in https://github.com/bazelbuild/rules_jvm_external/pull/994 might have unintentionally omitted a line that added target labels to the set of `seen_imports`. This line is present in [v5.3](https://github.com/bazelbuild/rules_jvm_external/blob/5.3/private/dependency_tree_parser.bzl#L155-L156), but then removed in [v6.1](https://github.com/bazelbuild/rules_jvm_external/blob/6.1/private/dependency_tree_parser.bzl#L457).

I believe this removal was accidental, as it is now possible for `maven_install` to create a generated BUILD file which contains multiple copies of a target with the same name, which is an invalid state.

This PR restores the missing call to `seen_imports[target_label] = True`.