### PR TITLE
skip non-class files in the exclusions processing for MergeJars

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
@@ -110,8 +110,7 @@ public class MergeJars {
     manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
     Map<String, Set<String>> allServices = new TreeMap<>();
-    Set<String> excludedPaths = readExcludedFileNames(excludes);
-    Set<String> duplicateExceptions = Set.of("COPYRIGHT", "LICENSE", "NOTICE");
+    Set<String> excludedPaths = readExcludedClassNames(excludes);
 
     // Ultimately, we want the entries in the output zip to be sorted
     // so that we have a deterministic output.
@@ -132,7 +131,6 @@ public class MergeJars {
 
           if ("META-INF/".equals(entry.getName())
               || (!entry.getName().startsWith("META-INF/")
-                  && !duplicateExceptions.contains(entry.getName())
                   && excludedPaths.contains(entry.getName()))) {
             continue;
           }
@@ -295,7 +293,7 @@ public class MergeJars {
     }
   }
 
-  private static Set<String> readExcludedFileNames(Set<Path> excludes) throws IOException {
+  private static Set<String> readExcludedClassNames(Set<Path> excludes) throws IOException {
     Set<String> paths = new HashSet<>();
 
     for (Path exclude : excludes) {
@@ -305,6 +303,9 @@ public class MergeJars {
         ZipEntry entry;
         while ((entry = jis.getNextEntry()) != null) {
           if (entry.isDirectory()) {
+            continue;
+          }
+          if (!entry.getName().endsWith(".class")) {
             continue;
           }
 

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
@@ -553,6 +553,35 @@ public class MergeJarsTest {
     }
   }
 
+  @Test
+  public void mergedJarKeepsNonClassFiles() throws IOException {
+    Path inputOne = temp.newFile("one.jar").toPath();
+    createJar(
+        inputOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR,stdout")
+    );
+
+    Path excludeOne = temp.newFile("two.jar").toPath();
+    createJar(
+        excludeOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR")
+    );
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(
+        new String[] {
+            "--output", outputJar.toAbsolutePath().toString(),
+            "--sources", inputOne.toAbsolutePath().toString(),
+            "--exclude", excludeOne.toAbsolutePath().toString(),
+        });
+
+    Map<String, String> contents = readJar(outputJar);
+
+    assertEquals("log4j.rootLogger=ERROR,stdout", contents.get("log4j.properties"));
+
+  }
+
   private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
     try (OutputStream os = Files.newOutputStream(outputTo);
         ZipOutputStream zos = new ZipOutputStream(os)) {

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
@@ -579,7 +579,75 @@ public class MergeJarsTest {
     Map<String, String> contents = readJar(outputJar);
 
     assertEquals("log4j.rootLogger=ERROR,stdout", contents.get("log4j.properties"));
+  }
 
+  @Test
+  public void mergedJarKeepsNonClassFilesDefaultDuplicateStrategy() throws IOException {
+    Path inputOne = temp.newFile("one.jar").toPath();
+    createJar(
+        inputOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR,stdout")
+    );
+    Path inputTwo = temp.newFile("two.jar").toPath();
+    createJar(
+        inputTwo,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR,stdout,stderr")
+    );
+
+    Path excludeOne = temp.newFile("three.jar").toPath();
+    createJar(
+        excludeOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR")
+    );
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(
+        new String[] {
+            "--output", outputJar.toAbsolutePath().toString(),
+            "--sources", inputOne.toAbsolutePath().toString(),
+            "--sources", inputTwo.toAbsolutePath().toString(),
+            "--exclude", excludeOne.toAbsolutePath().toString(),
+        });
+
+    Map<String, String> contents = readJar(outputJar);
+
+    assertEquals("log4j.rootLogger=ERROR,stdout,stderr", contents.get("log4j.properties"));
+  }
+
+  @Test
+  public void mergedJarKeepsNonClassFilesFirstWinsStrategy() throws IOException {
+    Path inputOne = temp.newFile("one.jar").toPath();
+    createJar(
+        inputOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR,stdout")
+    );
+    Path inputTwo = temp.newFile("two.jar").toPath();
+    createJar(
+        inputTwo,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR,stdout,stderr")
+    );
+
+    Path excludeOne = temp.newFile("three.jar").toPath();
+    createJar(
+        excludeOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR")
+    );
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(
+        new String[] {
+            "--output", outputJar.toAbsolutePath().toString(),
+            "--sources", inputOne.toAbsolutePath().toString(),
+            "--sources", inputTwo.toAbsolutePath().toString(),
+            "--duplicates", "first-wins",
+            "--exclude", excludeOne.toAbsolutePath().toString(),
+        });
+
+    Map<String, String> contents = readJar(outputJar);
+
+    assertEquals("log4j.rootLogger=ERROR,stdout", contents.get("log4j.properties"));
   }
 
   private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {


### PR DESCRIPTION
This is sort of an addendum to https://github.com/bazelbuild/rules_jvm_external/issues/1106 and https://github.com/bazelbuild/rules_jvm_external/pull/1107
In the previous PR, I added an exception for `COPYRIGHT` and `NOTICE` since it was the same kind of use case as the existing `LICENSE` exception.

The issue that I am having is that I have files that should be present in all of the jars being published in a repo that are not `COPYRIGHT`, `NOTICE`, or `LICENSE`. For example a `project-version.properties` file that contains info about the build.

Changing the `readExcludedFileNames` function to only process `*.class` files allows for these files to propagate to the final jar. It also still passes all existing test cases.

The only test for this functionality is specifically looking at `.class` files.https://github.com/bazelbuild/rules_jvm_external/blob/master/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java#L221

I am open to other solutions, but this seems to have fixed a lot of issues for my use case without breaking any existing functionality that is being tested for.