### PR TITLE
Enable --experimental_sibling_repository_layout in bazelrc 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,8 @@ build --tool_java_runtime_version=remotejdk_11
 build --experimental_strict_java_deps=strict
 build --explicit_java_test_deps
 
+build --experimental_sibling_repository_layout
+
 # Make sure we get something helpful when tests fail
 test --verbose_failures
 test --test_output=errors

--- a/private/pin.sh
+++ b/private/pin.sh
@@ -13,8 +13,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 
 set -euo pipefail
 # Workaround lack of rlocationpath, see comment on _BUILD_PIN in coursier.bzl
-readonly maven_unsorted_file=$(rlocation "${1#external\/}")
-if [[ ! -e $maven_unsorted_file ]]; then (echo >&2 "Failed to locate $1 in runfiles" && exit 1) fi
+maven_unsorted_file=$(rlocation "${1#external\/}")
+if [[ ! -e $maven_unsorted_file ]]; then
+  # for --experimental_sibling_repository_layout
+  maven_unsorted_file="${1#..\/}"
+fi
+if [[ ! -e $maven_unsorted_file ]]; then (echo >&2 "Failed to locate the unsorted_deps.json file: $1" && exit 1) fi
 readonly maven_install_json_loc={maven_install_location}
 
 cp "$maven_unsorted_file" "$maven_install_json_loc"

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -65,11 +65,7 @@ sh_binary(
     name = "pin",
     srcs = ["pin.sh"],
     args = [
-        # TODO: change to rlocationpath once rules_jvm_external drops support for Bazel <5.4.0
-        # "$(rlocationpath :unsorted_deps.json)",
-        # We can use execpath in the meantime, because we know this file is always a source file
-        # in that external repo.
-        "$(execpath :unsorted_deps.json)",
+        "$(rlocationpath :unsorted_deps.json)",
     ],
     data = [
         ":unsorted_deps.json",


### PR DESCRIPTION
Bazel upstream is planning to flip `--experimental_sibling_repository_layout` to True, which moves the external repositories from `execroot/_main/external/<repo>` to `execroot/<repo>`, thereby freeing up `//external` as a package name.

This change adds the flag to RJE's own bazelrc. The only failure found so far is the `external/` hardcode in `pin.sh`. 

TEST: `tests/bazel_run_tests.sh`.

```
$ ./tests/bazel_run_tests.sh
Running bazel run tests:
  test_maven_resolution PASSED
  test_dependency_aggregation PASSED
  test_duplicate_version_warning PASSED
  test_duplicate_version_warning_same_version PASSED
  test_outdated PASSED
  test_outdated_no_external_runfiles PASSED
  test_m2local_testing_found_local_artifact_through_pin_and_build PASSED
  test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build PASSED
  test_m2local_testing_found_local_artifact_through_build PASSED
  test_m2local_testing_found_local_artifact_after_build_copy PASSED
  test_m2local_testing_ignore_empty_files PASSED
  test_unpinned_m2local_testing_ignore_empty_files PASSED
  test_found_artifact_with_plus_through_pin_and_build PASSED
  test_unpinned_found_artifact_with_plus_through_pin_and_build PASSED
  test_v1_lock_file_format PASSED
  test_dependency_pom_exclusion PASSED
```