### PR TITLE
fix: Use customized repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ for more information.
 
 `rules_jvm_external_deps` uses a default list of maven repositories to download
  `rules_jvm_external`'s own dependencies from. Should you wish to change this,
- use the `repositories` parameter:
+ use the `repositories` parameter, generate your own `rules_jvm_external_deps_install.json` by
+ running `REPIN=1 bazel run @unpinned_rules_jvm_external_deps//:pin` and commit the file to your
+ version control system (note that at this point you will need to maintain your customized
+ `rules_jvm_external_deps_install.json`):
 
  ```python
 rules_jvm_external_deps(repositories = ["https://mycorp.com/artifacts"])

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -87,7 +87,7 @@ def rules_jvm_external_deps(repositories = _DEFAULT_REPOSITORIES):
             "org.slf4j:slf4j-simple:2.0.12",
             "software.amazon.awssdk:s3:2.25.23",
         ],
-        maven_install_json = "@rules_jvm_external//:rules_jvm_external_deps_install.json",
+        maven_install_json = "@rules_jvm_external//:rules_jvm_external_deps_install.json" if repositories == _DEFAULT_REPOSITORIES else "@//:rules_jvm_external_deps_install.json",
         fail_if_repin_required = True,
         strict_visibility = True,
         fetch_sources = True,


### PR DESCRIPTION
It seems setting `repositories` is not sufficient to use customized repository because `@rules_jvm_external//:rules_jvm_external_deps_install.json` will always be picked up.