### PR TITLE
maven_install: fail if 'repositories' attribute is empty

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -795,6 +795,10 @@ def make_coursier_dep_tree(
         fetch_javadoc,
         timeout,
         report_progress_prefix = ""):
+
+    if not repositories:
+        fail("repositories cannot be empty")
+
     # Set up artifact exclusion, if any. From coursier fetch --help:
     #
     # Path to the local exclusion file. Syntax: <org:name>--<org:name>. `--` means minus. Example file content:


### PR DESCRIPTION
Coursier fails with a cryptic error in case someone tries to use `maven_install()` without specifying any `repositories`, which is a small silly thing I did when trying to extract internal corporate code into a public proof-of-concept on how to do something with Bazel that took me 10 minutes to hunt down :)

When `repositories` is empty, Coursier fails with an error like:

```
  Dependencies:
org.junit.jupiter:junit-jupiter-engine:5.10.2:
Resolution error: Error downloading org.junit.jupiter:junit-jupiter-engine:5.10.2
```

this was for a `maven_install()` block with a single artifact to install; otherwise the error message will contain one `Resolution error` per artifact. The problem though is that Coursier doesn't say what the error is, just that one occurred.

The root-cause is that `coursier_fetch` etc will invoke coursier with arguments like

```
coursier fetch <artifacts> ... --no-default ...
```

which disables default repositories like Maven Central.

So as a simple fix to prevent people from configuring `maven_install` in a way that doesn't make sense like I did, this commit adds a check inside `make_coursier_dep_tree` (where the arguments to coursier are constructed) to fail if the list/dict of repositories is empty.
