### PR TITLE
feat: Pass additional coursier cli options

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -109,6 +109,7 @@ _install = tag_class(
         ),
         "ignore_empty_files": attr.bool(default = False, doc = "Treat jars that are empty as if they were not found."),
         "repin_instructions": attr.string(doc = "Instructions to re-pin the repository if required. Many people have wrapper scripts for keeping dependencies up to date, and would like to point users to that instead of the default. Only honoured for the root module."),
+        "additional_coursier_options": attr.string_list(doc = "Additional options that will be passed to coursier."),
     },
 )
 
@@ -220,6 +221,7 @@ def _maven_impl(mctx):
     # - use_starlark_android_rules: bool. A logical OR over all `use_starlark_android_rules` for all `install` tags with the same name.
     # - version_conflict_policy: string. Fails build if different and not a default.
     # - ignore_empty_files: Treat jars that are empty as if they were not found.
+    # - additional_coursier_options: Additional options that will be passed to coursier.
 
     # Mapping of `name`s to `bazel_module.name` This will allow us to warn users when more than
     # module attempts to update a maven repo (which is normally undesired behaviour)
@@ -338,6 +340,8 @@ def _maven_impl(mctx):
             if mod.is_root:
                 repo["repin_instructions"] = install.repin_instructions
 
+            repo["additional_coursier_options"] = repo.get("additional_coursier_options", []) + getattr(install, "additional_coursier_options", [])
+
             repos[install.name] = repo
 
     # Breaking out the logic for picking lock files, because it's not terribly simple
@@ -426,6 +430,7 @@ def _maven_impl(mctx):
                 aar_import_bzl_label = repo.get("aar_import_bzl_label"),
                 duplicate_version_warning = repo.get("duplicate_version_warning"),
                 ignore_empty_files = repo.get("ignore_empty_files"),
+                additional_coursier_options = repo.get("additional_coursier_options"),
             )
         else:
             # Only the coursier resolver allows the lock file to be omitted.

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -794,7 +794,7 @@ def make_coursier_dep_tree(
         fetch_sources,
         fetch_javadoc,
         timeout,
-        additional_options,
+        additional_coursier_options,
         report_progress_prefix = ""):
     # Set up artifact exclusion, if any. From coursier fetch --help:
     #
@@ -882,7 +882,7 @@ def make_coursier_dep_tree(
         # https://github.com/coursier/coursier/blob/1cbbf39b88ee88944a8d892789680cdb15be4714/modules/paths/src/main/java/coursier/paths/CoursierPaths.java#L29-L56
         environment = {"COURSIER_CACHE": str(repository_ctx.path(coursier_cache_location))}
 
-    cmd.extend(additional_options)
+    cmd.extend(additional_coursier_options)
 
     # Use an argsfile to avoid command line length limits, requires Java version > 8
     java_cmd = cmd[0]
@@ -990,7 +990,7 @@ def _coursier_fetch_impl(repository_ctx):
         repository_ctx.attr.fetch_sources,
         repository_ctx.attr.fetch_javadoc,
         repository_ctx.attr.resolve_timeout,
-        repository_ctx.attr.additional_options,
+        repository_ctx.attr.additional_coursier_options,
     )
 
     files_to_inspect = []
@@ -1432,7 +1432,7 @@ coursier_fetch = repository_rule(
             ],
         ),
         "ignore_empty_files": attr.bool(default = False, doc = "Treat jars that are empty as if they were not found."),
-        "additional_options": attr.string_list(doc = "Additional options that will be passed to coursier."),
+        "additional_coursier_options": attr.string_list(doc = "Additional options that will be passed to coursier."),
     },
     environ = [
         "JAVA_HOME",

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -794,6 +794,7 @@ def make_coursier_dep_tree(
         fetch_sources,
         fetch_javadoc,
         timeout,
+        additional_options,
         report_progress_prefix = ""):
     # Set up artifact exclusion, if any. From coursier fetch --help:
     #
@@ -880,6 +881,8 @@ def make_coursier_dep_tree(
         # https://github.com/bazelbuild/rules_jvm_external/issues/301
         # https://github.com/coursier/coursier/blob/1cbbf39b88ee88944a8d892789680cdb15be4714/modules/paths/src/main/java/coursier/paths/CoursierPaths.java#L29-L56
         environment = {"COURSIER_CACHE": str(repository_ctx.path(coursier_cache_location))}
+
+    cmd.extend(additional_options)
 
     # Use an argsfile to avoid command line length limits, requires Java version > 8
     java_cmd = cmd[0]
@@ -987,6 +990,7 @@ def _coursier_fetch_impl(repository_ctx):
         repository_ctx.attr.fetch_sources,
         repository_ctx.attr.fetch_javadoc,
         repository_ctx.attr.resolve_timeout,
+        repository_ctx.attr.additional_options,
     )
 
     files_to_inspect = []
@@ -1428,6 +1432,7 @@ coursier_fetch = repository_rule(
             ],
         ),
         "ignore_empty_files": attr.bool(default = False, doc = "Treat jars that are empty as if they were not found."),
+        "additional_options": attr.string_list(doc = "Additional options that will be passed to coursier."),
     },
     environ = [
         "JAVA_HOME",

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -27,7 +27,8 @@ def maven_install(
         aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
         duplicate_version_warning = "warn",
         repin_instructions = None,
-        ignore_empty_files = False):
+        ignore_empty_files = False,
+        resolver_additional_options = []):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -78,6 +79,7 @@ def maven_install(
         is "warn".
       repin_instructions: Instructions to re-pin dependencies in your repository. Will be shown when re-pinning is required.
       ignore_empty_files: Treat jars that are empty as if they were not found.
+      resolver_additional_options: Additional options that will be passed to the resolver. Only supports `coursier` resolver for now.
     """
     if boms and resolver == "coursier":
         fail("The coursier resolver does not support resolving Maven BOMs. Please use another resolver.")
@@ -139,6 +141,7 @@ def maven_install(
             aar_import_bzl_label = aar_import_bzl_label,
             duplicate_version_warning = duplicate_version_warning,
             ignore_empty_files = ignore_empty_files,
+            additional_options = resolver_additional_options,
         )
 
     else:

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -28,7 +28,7 @@ def maven_install(
         duplicate_version_warning = "warn",
         repin_instructions = None,
         ignore_empty_files = False,
-        resolver_additional_options = []):
+        additional_coursier_options = []):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -79,7 +79,7 @@ def maven_install(
         is "warn".
       repin_instructions: Instructions to re-pin dependencies in your repository. Will be shown when re-pinning is required.
       ignore_empty_files: Treat jars that are empty as if they were not found.
-      resolver_additional_options: Additional options that will be passed to the resolver. Only supports `coursier` resolver for now.
+      additional_coursier_options: Additional options that will be passed to coursier.
     """
     if boms and resolver == "coursier":
         fail("The coursier resolver does not support resolving Maven BOMs. Please use another resolver.")
@@ -141,7 +141,7 @@ def maven_install(
             aar_import_bzl_label = aar_import_bzl_label,
             duplicate_version_warning = duplicate_version_warning,
             ignore_empty_files = ignore_empty_files,
-            additional_options = resolver_additional_options,
+            additional_coursier_options = additional_coursier_options,
         )
 
     else:


### PR DESCRIPTION
The primary use case this change tries to solve is passing down `--max-iterations` to coursier because the default value could be too small for certain artifacts.