### PR TITLE
Allow `rules_jvm_external`'s own deps's lock file to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,24 @@ for more information.
 
 `rules_jvm_external_deps` uses a default list of maven repositories to download
  `rules_jvm_external`'s own dependencies from. Should you wish to change this,
- use the `repositories` parameter:
+ use the `repositories` parameter, and also set the path to the lock file:
 
  ```python
-rules_jvm_external_deps(repositories = ["https://mycorp.com/artifacts"])
+rules_jvm_external_deps(
+    repositories = ["https://mycorp.com/artifacts"],
+    deps_lock_file = "@//:rules_jvm_external_deps_install.json")
 rules_jvm_external_setup()
+```
+
+If you are using `bzlmod`, define an `install` tag in your root 
+`MODULE.bazel` which overrides the values:
+
+```python
+maven.install(
+    name = "rules_jvm_external_deps",
+    repositories = ["https://mycorp.com/artifacts"],
+    lock_file = "@//:rules_jvm_external_deps_install.json",
+)
 ```
 
 Next, reference the artifacts in the BUILD file with their versionless label:

--- a/README.md
+++ b/README.md
@@ -122,10 +122,7 @@ for more information.
 
 `rules_jvm_external_deps` uses a default list of maven repositories to download
  `rules_jvm_external`'s own dependencies from. Should you wish to change this,
- use the `repositories` parameter, generate your own `rules_jvm_external_deps_install.json` by
- running `REPIN=1 bazel run @unpinned_rules_jvm_external_deps//:pin` and commit the file to your
- version control system (note that at this point you will need to maintain your customized
- `rules_jvm_external_deps_install.json`):
+ use the `repositories` parameter:
 
  ```python
 rules_jvm_external_deps(repositories = ["https://mycorp.com/artifacts"])

--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ maven.install(
 )
 ```
 
+Once these changes have been made, repin using `REPIN=1 bazel run
+@rules_jvm_external_deps//:pin` and commit the file to your version 
+control system (note that at this point you will need to maintain your
+customized `rules_jvm_external_deps_install.json`):
+
 Next, reference the artifacts in the BUILD file with their versionless label:
 
 ```python

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -11,7 +11,9 @@ _DEFAULT_REPOSITORIES = [
 _MAVEN_VERSION = "3.9.6"
 _MAVEN_RESOLVER_VERSION = "1.9.18"
 
-def rules_jvm_external_deps(repositories = _DEFAULT_REPOSITORIES):
+def rules_jvm_external_deps(
+        repositories = _DEFAULT_REPOSITORIES,
+        deps_lock_file = "@rules_jvm_external//:rules_jvm_external_deps_install.json"):
     maybe(
         http_archive,
         name = "bazel_skylib",
@@ -87,7 +89,7 @@ def rules_jvm_external_deps(repositories = _DEFAULT_REPOSITORIES):
             "org.slf4j:slf4j-simple:2.0.12",
             "software.amazon.awssdk:s3:2.25.23",
         ],
-        maven_install_json = "@rules_jvm_external//:rules_jvm_external_deps_install.json" if repositories == _DEFAULT_REPOSITORIES else "@//:rules_jvm_external_deps_install.json",
+        maven_install_json = deps_lock_file,
         fail_if_repin_required = True,
         strict_visibility = True,
         fetch_sources = True,


### PR DESCRIPTION
This allows people to repin these deps locally if needed, assuming they don't want to use Bazel's `--experimental_downloader_config` flag.

`bzlmod` users can achieve the same result by specifying an `install` tag in their root level module and overriding the required fields.