### PR TITLE
Mark `maven` extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,10 @@ module(
 )
 
 bazel_dep(
+    name = "bazel_features",
+    version = "1.11.0",
+)
+bazel_dep(
     name = "bazel_skylib",
     version = "1.4.2",
 )


### PR DESCRIPTION
This avoids unnecessary duplication between the `maven_install.json` lockfile and `MODULE.bazel.lock`.