### PR TITLE
Restore bazel 6.x support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,8 @@
 module(
     name = "rules_jvm_external",
-    bazel_compatibility = [">=7.0.0"],
-    compatibility_level = 2,
     version = "6.1",
+    bazel_compatibility = [">=6.0.0"],
+    compatibility_level = 2,
 )
 
 bazel_dep(
@@ -31,13 +31,12 @@ bazel_dep(
 )
 bazel_dep(
     name = "stardoc",
-    repo_name = "io_bazel_stardoc",
     version = "0.5.6",
+    repo_name = "io_bazel_stardoc",
 )
 
 # Remove this once rules_android has rolled out official Bzlmod support
 remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-
 use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
 maven = use_extension(":extensions.bzl", "maven")
@@ -84,69 +83,24 @@ maven.install(
     fetch_sources = True,
     lock_file = "//:rules_jvm_external_deps_install.json",
 )
-
 use_repo(
     maven,
     "rules_jvm_external_deps",
     "unpinned_rules_jvm_external_deps",
 )
 
-http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-
-_COURSIER_CLI_VERSION = "v2.1.8"
-
-COURSIER_CLI_HTTP_FILE_NAME = ("coursier_cli_" + _COURSIER_CLI_VERSION).replace(".", "_").replace("-", "_")
-
-COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/download/{COURSIER_CLI_VERSION}/coursier.jar".format(COURSIER_CLI_VERSION = _COURSIER_CLI_VERSION)
-
-# Run 'bazel run //:mirror_coursier' to upload a copy of the jar to the Bazel mirror.
-COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
-
-COURSIER_CLI_SHA256 = "2b78bfdd3ef13fd1f42f158de0f029d7cbb1f4f652d51773445cf2b6f7918a87"
-
-http_file(
-    name = "coursier_cli",
-    sha256 = COURSIER_CLI_SHA256,
-    urls = [COURSIER_CLI_GITHUB_ASSET_URL],
-)
-
-http_file(
-    name = "buildifier-linux-arm64",
-    sha256 = "917d599dbb040e63ae7a7e1adb710d2057811902fdc9e35cce925ebfd966eeb8",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-arm64"],
-)
-
-http_file(
-    name = "buildifier-linux-x86_64",
-    sha256 = "52bf6b102cb4f88464e197caac06d69793fa2b05f5ad50a7e7bf6fbd656648a3",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64"],
-)
-
-http_file(
-    name = "buildifier-macos-arm64",
-    sha256 = "745feb5ea96cb6ff39a76b2821c57591fd70b528325562486d47b5d08900e2e4",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64"],
-)
-
-http_file(
-    name = "buildifier-macos-x86_64",
-    sha256 = "c9378d9f4293fc38ec54a08fbc74e7a9d28914dae6891334401e59f38f6e65dc",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64"],
-)
-
 ############# Dev dependencies below here
 
 bazel_dep(
     name = "protobuf",
-    dev_dependency = True,
     version = "21.7",
+    dev_dependency = True,
 )
 bazel_dep(
     name = "bzlmod_lock_files",
-    dev_dependency = True,
     version = "0.0.0",
+    dev_dependency = True,
 )
-
 local_path_override(
     module_name = "bzlmod_lock_files",
     path = "tests/integration/bzlmod_lock_files",
@@ -157,7 +111,6 @@ dev_maven = use_extension(
     "maven",
     dev_dependency = True,
 )
-
 dev_maven.install(
     artifacts = [
         "com.google.guava:guava:31.1-jre",
@@ -166,7 +119,6 @@ dev_maven.install(
     lock_file = "@rules_jvm_external//:maven_install.json",
     resolver = "coursier",
 )
-
 dev_maven.install(
     name = "duplicate_version_warning",
     artifacts = [
@@ -181,7 +133,6 @@ dev_maven.install(
         "https://maven.google.com",
     ],
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning",
     artifact = "jffi",
@@ -189,7 +140,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.3",
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning",
     artifact = "jffi",
@@ -197,7 +147,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.2",
 )
-
 dev_maven.install(
     name = "duplicate_version_warning_same_version",
     artifacts = [
@@ -209,7 +158,6 @@ dev_maven.install(
         "https://maven.google.com",
     ],
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning_same_version",
     artifact = "jffi",
@@ -217,7 +165,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.3",
 )
-
 dev_maven.artifact(
     name = "duplicate_version_warning_same_version",
     artifact = "jffi",
@@ -225,7 +172,6 @@ dev_maven.artifact(
     group = "com.github.jnr",
     version = "1.3.3",
 )
-
 dev_maven.artifact(
     name = "exclusion_testing",
     artifact = "guava",
@@ -236,7 +182,6 @@ dev_maven.artifact(
     group = "com.google.guava",
     version = "27.0-jre",
 )
-
 dev_maven.install(
     name = "forcing_versions",
     artifacts = [
@@ -254,7 +199,6 @@ dev_maven.artifact(
     group = "com.google.guava",
     version = "23.3-jre",
 )
-
 dev_maven.install(
     name = "global_exclusion_testing",
     artifacts = [
@@ -267,7 +211,6 @@ dev_maven.install(
         "org.codehaus.mojo:animal-sniffer-annotations",
     ],
 )
-
 dev_maven.install(
     name = "java_export_exclusion_testing",
     artifacts = [
@@ -309,14 +252,12 @@ dev_maven.install(
     ],
     lock_file = "//tests/custom_maven_install:service_indexing_testing.json",
 )
-
 dev_maven.install(
     name = "jvm_import_test",
     artifacts = [
         "com.google.code.findbugs:jsr305:3.0.2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing",
     artifacts = [
@@ -330,7 +271,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_ignore_empty_files",
     artifacts = [
@@ -345,7 +285,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_ignore_empty_files_repin",
     artifacts = [
@@ -361,7 +300,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_repin",
     artifacts = [
@@ -375,7 +313,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "m2local_testing_without_checksum",
     artifacts = [
@@ -390,7 +327,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "artifact_with_plus",
     artifacts = [
@@ -400,7 +336,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "artifact_with_plus_repin",
     artifacts = [
@@ -411,7 +346,6 @@ dev_maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-
 dev_maven.install(
     name = "manifest_stamp_testing",
     artifacts = [
@@ -422,20 +356,17 @@ dev_maven.install(
     ],
     lock_file = "//tests/custom_maven_install:manifest_stamp_testing_install.json",
 )
-
 dev_maven.install(
     name = "maven_install_in_custom_location",
     artifacts = ["com.google.guava:guava:27.0-jre"],
     lock_file = "//tests/custom_maven_install:maven_install.json",
 )
-
 dev_maven.install(
     # This name matches the one in `tests/integration/bzlmod_lock_files`
     name = "multiple_lock_files",
     artifacts = ["org.zeromq:jeromq:0.5.4"],
     lock_file = "//tests/custom_maven_install:multiple_lock_files_install.json",
 )
-
 dev_maven.install(
     name = "maven_resolved_with_boms",
     # Before adding a dependency here, add a reduced test case to `ResolverTestBase`
@@ -460,7 +391,6 @@ dev_maven.install(
     ],
     resolver = "maven",
 )
-
 dev_maven.artifact(
     name = "maven_resolved_with_boms",
     testonly = True,
@@ -471,7 +401,6 @@ dev_maven.artifact(
     group = "com.google.auto.value",
     version = "1.6.3",
 )
-
 dev_maven.artifact(
     name = "maven_resolved_with_boms",
     artifact = "json-lib",
@@ -479,7 +408,6 @@ dev_maven.artifact(
     group = "net.sf.json-lib",
     version = "2.4",
 )
-
 dev_maven.install(
     name = "override_target_in_deps",
     artifacts = [
@@ -488,13 +416,11 @@ dev_maven.install(
     ],
     lock_file = "@rules_jvm_external//tests/custom_maven_install:override_target_in_deps_install.json",
 )
-
 dev_maven.override(
     name = "override_target_in_deps",
     coordinates = "io.opentelemetry:opentelemetry-api",
     target = "@//tests/integration/override_targets:additional_deps",
 )
-
 dev_maven.install(
     name = "policy_pinned_testing",
     artifacts = [
@@ -574,7 +500,6 @@ dev_maven.install(
         "https://packages.confluent.io/maven/",
     ],
 )
-
 dev_maven.override(
     name = "regression_testing_coursier",
     coordinates = "com.google.ar.sceneform:rendering",
@@ -630,7 +555,6 @@ dev_maven.install(
     ],
     resolver = "maven",
 )
-
 dev_maven.install(
     name = "starlark_aar_import_test",
     # Not actually necessary since this is the default value, but useful for
@@ -646,7 +570,6 @@ dev_maven.install(
     ],
     use_starlark_android_rules = True,
 )
-
 dev_maven.install(
     name = "starlark_aar_import_with_sources_test",
     # Not actually necessary since this is the default value, but useful for
@@ -662,7 +585,6 @@ dev_maven.install(
     ],
     use_starlark_android_rules = True,
 )
-
 dev_maven.install(
     name = "strict_visibility_testing",
     artifacts = [
@@ -680,7 +602,6 @@ dev_maven.artifact(
     group = "org.eclipse.jetty",
     version = "9.4.20.v20190813",
 )
-
 dev_maven.install(
     name = "strict_visibility_with_compat_testing",
     artifacts = [
@@ -690,14 +611,12 @@ dev_maven.install(
     generate_compat_repositories = True,
     strict_visibility = True,
 )
-
 dev_maven.artifact(
     name = "testonly_testing",
     artifact = "guava",
     group = "com.google.guava",
     version = "27.0-jre",
 )
-
 dev_maven.artifact(
     name = "testonly_testing",
     testonly = True,
@@ -713,7 +632,6 @@ dev_maven.install(
         "io.grpc:grpc-netty-shaded:1.29.0",
     ],
 )
-
 dev_maven.install(
     name = "v1_lock_file_format",
     artifacts = [
@@ -818,68 +736,4 @@ use_repo(
     "unpinned_v1_lock_file_format",
     "v1_lock_file_format",
     "version_interval_testing",
-)
-
-http_file(
-    name = "com.google.ar.sceneform_rendering",
-    downloaded_file_path = "rendering-1.10.0.aar",
-    sha256 = "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
-    urls = [
-        "https://dl.google.com/android/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
-    ],
-)
-
-http_file(
-    name = "hamcrest_core_for_test",
-    downloaded_file_path = "hamcrest-core-1.3.jar",
-    sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
-    urls = [
-        "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
-    ],
-)
-
-http_file(
-    name = "hamcrest_core_srcs_for_test",
-    downloaded_file_path = "hamcrest-core-1.3-sources.jar",
-    sha256 = "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df",
-    urls = [
-        "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
-    ],
-)
-
-http_file(
-    name = "gson_for_test",
-    downloaded_file_path = "gson-2.9.0.jar",
-    sha256 = "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d",
-    urls = [
-        "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar",
-    ],
-)
-
-http_file(
-    name = "junit_platform_commons_for_test",
-    downloaded_file_path = "junit-platform-commons-1.8.2.jar",
-    sha256 = "d2e015fca7130e79af2f4608dc54415e4b10b592d77333decb4b1a274c185050",
-    urls = [
-        "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.2/junit-platform-commons-1.8.2.jar",
-    ],
-)
-
-# https://github.com/bazelbuild/rules_jvm_external/issues/865
-http_file(
-    name = "google_api_services_compute_javadoc_for_test",
-    downloaded_file_path = "google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
-    sha256 = "b03be5ee8effba3bfbaae53891a9c01d70e2e3bd82ad8889d78e641b22bd76c2",
-    urls = [
-        "https://repo1.maven.org/maven2/com/google/apis/google-api-services-compute/v1-rev235-1.25.0/google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
-    ],
-)
-
-http_file(
-    name = "lombok_for_test",
-    downloaded_file_path = "lombok-1.18.22.jar",
-    sha256 = "ecef1581411d7a82cc04281667ee0bac5d7c0a5aae74cfc38430396c91c31831",
-    urls = [
-        "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.22/lombok-1.18.22.jar",
-    ],
 )

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,5 +1,108 @@
 workspace(name = "rules_jvm_external")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 # Use this until we can use some pure-bzlmod approach
 android_sdk_repository(name = "androidsdk")
+
 android_ndk_repository(name = "androidndk")
+
+_COURSIER_CLI_VERSION = "v2.1.8"
+
+COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/download/{COURSIER_CLI_VERSION}/coursier.jar".format(COURSIER_CLI_VERSION = _COURSIER_CLI_VERSION)
+
+COURSIER_CLI_SHA256 = "2b78bfdd3ef13fd1f42f158de0f029d7cbb1f4f652d51773445cf2b6f7918a87"
+
+http_file(
+    name = "coursier_cli",
+    sha256 = COURSIER_CLI_SHA256,
+    urls = [COURSIER_CLI_GITHUB_ASSET_URL],
+)
+
+http_file(
+    name = "buildifier-linux-arm64",
+    sha256 = "917d599dbb040e63ae7a7e1adb710d2057811902fdc9e35cce925ebfd966eeb8",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-arm64"],
+)
+
+http_file(
+    name = "buildifier-linux-x86_64",
+    sha256 = "52bf6b102cb4f88464e197caac06d69793fa2b05f5ad50a7e7bf6fbd656648a3",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64"],
+)
+
+http_file(
+    name = "buildifier-macos-arm64",
+    sha256 = "745feb5ea96cb6ff39a76b2821c57591fd70b528325562486d47b5d08900e2e4",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64"],
+)
+
+http_file(
+    name = "buildifier-macos-x86_64",
+    sha256 = "c9378d9f4293fc38ec54a08fbc74e7a9d28914dae6891334401e59f38f6e65dc",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64"],
+)
+
+http_file(
+    name = "com.google.ar.sceneform_rendering",
+    downloaded_file_path = "rendering-1.10.0.aar",
+    sha256 = "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
+    urls = [
+        "https://dl.google.com/android/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+    ],
+)
+
+http_file(
+    name = "hamcrest_core_for_test",
+    downloaded_file_path = "hamcrest-core-1.3.jar",
+    sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+    urls = [
+        "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+    ],
+)
+
+http_file(
+    name = "hamcrest_core_srcs_for_test",
+    downloaded_file_path = "hamcrest-core-1.3-sources.jar",
+    sha256 = "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df",
+    urls = [
+        "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
+    ],
+)
+
+http_file(
+    name = "gson_for_test",
+    downloaded_file_path = "gson-2.9.0.jar",
+    sha256 = "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d",
+    urls = [
+        "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar",
+    ],
+)
+
+http_file(
+    name = "junit_platform_commons_for_test",
+    downloaded_file_path = "junit-platform-commons-1.8.2.jar",
+    sha256 = "d2e015fca7130e79af2f4608dc54415e4b10b592d77333decb4b1a274c185050",
+    urls = [
+        "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.2/junit-platform-commons-1.8.2.jar",
+    ],
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/865
+http_file(
+    name = "google_api_services_compute_javadoc_for_test",
+    downloaded_file_path = "google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
+    sha256 = "b03be5ee8effba3bfbaae53891a9c01d70e2e3bd82ad8889d78e641b22bd76c2",
+    urls = [
+        "https://repo1.maven.org/maven2/com/google/apis/google-api-services-compute/v1-rev235-1.25.0/google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
+    ],
+)
+
+http_file(
+    name = "lombok_for_test",
+    downloaded_file_path = "lombok-1.18.22.jar",
+    sha256 = "ecef1581411d7a82cc04281667ee0bac5d7c0a5aae74cfc38430396c91c31831",
+    urls = [
+        "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.22/lombok-1.18.22.jar",
+    ],
+)


### PR DESCRIPTION
As far as I can tell all the uses of http_file in the MODULE.bazel are dev dependencies, therefore they're easy to move to the WORKSPACE.bzlmod to avoid using the bazel 7.x only API. I submitted this despite the conversation in the linked issue because rules_jvm_external is sa transitive dependency of tons of repos which are still pinning bazel 6.x. This stems from the fact that protobuf and grpc have this as a dependency.

Fixes https://github.com/bazelbuild/rules_jvm_external/issues/1055