### PR TITLE
Add support for BOM priotization

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
@@ -404,7 +404,7 @@ public class MavenResolver implements Resolver {
       RepositorySystemSession session,
       List<RemoteRepository> repositories,
       List<Dependency> boms) {
-    Set<Dependency> managedDependencies = new HashSet<>();
+    Set<Dependency> managedDependencies = new LinkedHashSet<>();
 
     for (Dependency bom : boms) {
       ArtifactDescriptorRequest request =


### PR DESCRIPTION
With the current code, if multiple BOMs have the same coords, the coordinates would be resolved through all the BOMs when we try to resolve the artifact versions. ~When two or more versions were present, Maven resolver would resort to the lower version (IIUC, default Maven behavior).~ The issue was that the set that was created was not ordered, so it would not give priority to the first defined BOM.

~With these changes, we will ignore the artifact if it was previously found, thus giving priority to the BOM that was defined first.~

We now have a `LinkedHashSet` that will maintain the ordering so that the BOMs will be given priority based on the order they were defined.

---

Closes https://github.com/bazelbuild/rules_jvm_external/issues/1146.