### PR TITLE
Fix bzlmod lockfile always not up-to-date

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1375,7 +1375,7 @@ pinned_coursier_fetch = repository_rule(
             doc = "Instructions to re-pin the repository if required. Many people have wrapper scripts for keeping dependencies up to date, and would like to point users to that instead of the default.",
         ),
         "excluded_artifacts": attr.string_list(default = []),  # only used for hash generation
-        "_workspace_label": attr.label(default = Label("@//does/not:exist")),
+        "_workspace_label": attr.label(default = "@//does/not:exist"),
     },
     implementation = _pinned_coursier_fetch_impl,
 )


### PR DESCRIPTION
The below error will be gone with the fix.
```
MODULE.bazel.lock is no longer up-to-date because: The implementation of the extension 'ModuleExtensionId{bzlFileLabel=@@rules_jvm_external~//:extensions.bzl, extensionName=maven, isolationKey=Optional.empty}' or one of its transitive .bzl files has changed,The repo mappings of certain repos used by the extension 'ModuleExtensionId{bzlFileLabel=@@rules_jvm_external~//:extensions.bzl, extensionName=maven, isolationKey=Optional.empty}' have changed. Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.
```