### PR TITLE
Add support for resources in javadoc jars and make variable substitution in javadoc arguments

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -86,6 +86,7 @@ def java_export(
     javadocopts = kwargs.pop("javadocopts", [])
     doc_deps = kwargs.pop("doc_deps", [])
     doc_url = kwargs.pop("doc_url", "")
+    doc_resources = kwargs.pop("doc_resources", [])
     toolchains = kwargs.pop("toolchains", [])
 
     # Construct the java_library we'll export from here.
@@ -112,6 +113,7 @@ def java_export(
         classifier_artifacts = classifier_artifacts,
         doc_deps = doc_deps,
         doc_url = doc_url,
+        doc_resources = doc_resources,
         toolchains = toolchains,
     )
 
@@ -131,6 +133,7 @@ def maven_export(
         *,
         doc_deps = [],
         doc_url = "",
+        doc_resources = [],
         toolchains = None):
     """
     All arguments are the same as java_export with the addition of:
@@ -189,6 +192,7 @@ def maven_export(
         (if not using `tags = ["no-javadoc"]`)
       doc_url: The URL at which the generated `javadoc` will be hosted (if not using
         `tags = ["no-javadoc"]`).
+      doc_resources: Resources to be included in the javadoc jar.
       visibility: The visibility of the target
       kwargs: These are passed to [`java_library`](https://bazel.build/reference/be/java#java_library),
         and so may contain any valid parameter for that rule.
@@ -258,6 +262,7 @@ def maven_export(
             javadocopts = javadocopts,
             doc_deps = doc_deps,
             doc_url = doc_url,
+            doc_resources = doc_resources,
             excluded_workspaces = excluded_workspaces.keys(),
             additional_dependencies = additional_dependencies,
             visibility = visibility,

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
@@ -58,6 +58,7 @@ public class JavadocJarMaker {
 
   public static void main(String[] args) throws IOException {
     Set<Path> sourceJars = new HashSet<>();
+    Set<Path> resources = new HashSet<>();
     Path out = null;
     Path elementList = null;
     Set<Path> classpath = new HashSet<>();
@@ -86,6 +87,11 @@ public class JavadocJarMaker {
         case "--element-list":
           next = args[++i];
           elementList = Paths.get(next);
+          break;
+
+        case "--resources":
+          next = args[++i];
+          resources.add(Paths.get(next));
           break;
 
         default:
@@ -175,6 +181,12 @@ public class JavadocJarMaker {
       options.addAll(Arrays.asList("-d", outputTo.toAbsolutePath().toString()));
 
       sources.forEach(obj -> options.add(obj.getName()));
+
+      for (Path resource : resources) {
+        Path target = outputTo.resolve(resource.getFileName());
+        Files.createDirectories(target.getParent());
+        Files.copy(resource, target);
+      }
 
       Writer writer = new StringWriter();
       DocumentationTool.DocumentationTask task =

--- a/tests/com/github/bazelbuild/rules_jvm_external/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/BUILD
@@ -105,3 +105,14 @@ java_test(
         artifact("org.hamcrest:hamcrest"),
     ],
 )
+
+java_library(
+    name = "JarUtils",
+    testonly = 1,
+    srcs = ["JarUtils.java"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        artifact("com.google.guava:guava"),
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
+    ],
+)

--- a/tests/com/github/bazelbuild/rules_jvm_external/JarUtils.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/JarUtils.java
@@ -1,0 +1,52 @@
+package com.github.bazelbuild.rules_jvm_external;
+
+import com.github.bazelbuild.rules_jvm_external.zip.StableZipEntry;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class JarUtils {
+  public static void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
+    try (OutputStream os = Files.newOutputStream(outputTo);
+         ZipOutputStream zos = new ZipOutputStream(os)) {
+
+      for (Map.Entry<String, String> entry : pathToContents.entrySet()) {
+        ZipEntry ze = new StableZipEntry(entry.getKey());
+        zos.putNextEntry(ze);
+        if (!ze.isDirectory()) {
+          zos.write(entry.getValue().getBytes(UTF_8));
+        }
+        zos.closeEntry();
+      }
+    }
+  }
+
+  public static Map<String, String> readJar(Path jar) throws IOException {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+    try (InputStream is = Files.newInputStream(jar);
+         ZipInputStream zis = new ZipInputStream(is)) {
+
+      for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
+        if (entry.isDirectory()) {
+          continue;
+        }
+
+        builder.put(entry.getName(), new String(ByteStreams.toByteArray(zis), UTF_8));
+      }
+    }
+
+    return builder.build();
+  }
+}

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -49,6 +49,7 @@ java_test(
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:MergeJars",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
+        "//tests/com/github/bazelbuild/rules_jvm_external:JarUtils",
         artifact("com.google.guava:guava"),
         artifact(
             "junit:junit",

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -48,7 +48,6 @@ java_test(
     deps = [
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:MergeJars",
-        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
         "//tests/com/github/bazelbuild/rules_jvm_external:JarUtils",
         artifact("com.google.guava:guava"),
         artifact(

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
@@ -14,13 +14,12 @@
 
 package com.github.bazelbuild.rules_jvm_external.jar;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.*;
-
-import com.github.bazelbuild.rules_jvm_external.zip.StableZipEntry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,9 +36,13 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+
+import static com.github.bazelbuild.rules_jvm_external.JarUtils.createJar;
+import static com.github.bazelbuild.rules_jvm_external.JarUtils.readJar;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MergeJarsTest {
 
@@ -551,39 +554,6 @@ public class MergeJarsTest {
       assertFalse(
           jar.getManifest().getMainAttributes().containsKey(new Attributes.Name("Target-Label")));
     }
-  }
-
-  private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
-    try (OutputStream os = Files.newOutputStream(outputTo);
-        ZipOutputStream zos = new ZipOutputStream(os)) {
-
-      for (Map.Entry<String, String> entry : pathToContents.entrySet()) {
-        ZipEntry ze = new StableZipEntry(entry.getKey());
-        zos.putNextEntry(ze);
-        if (!ze.isDirectory()) {
-          zos.write(entry.getValue().getBytes(UTF_8));
-        }
-        zos.closeEntry();
-      }
-    }
-  }
-
-  private Map<String, String> readJar(Path jar) throws IOException {
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-
-    try (InputStream is = Files.newInputStream(jar);
-        ZipInputStream zis = new ZipInputStream(is)) {
-
-      for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
-        if (entry.isDirectory()) {
-          continue;
-        }
-
-        builder.put(entry.getName(), new String(ByteStreams.toByteArray(zis), UTF_8));
-      }
-    }
-
-    return builder.build();
   }
 
   private Map<String, Long> readJarTimeStamps(Path jar) throws IOException {

--- a/tests/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
@@ -14,3 +14,21 @@ java_test(
         artifact("org.hamcrest:hamcrest-core"),
     ],
 )
+
+java_test(
+    name = "ResourceTest",
+    srcs = ["ResourceTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.javadoc.ResourceTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc",
+        "//tests/com/github/bazelbuild/rules_jvm_external:JarUtils",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+        artifact("org.hamcrest:hamcrest"),
+        artifact("org.hamcrest:hamcrest-core"),
+        artifact("com.google.guava:guava"),
+    ],
+)

--- a/tests/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
@@ -27,8 +27,6 @@ java_test(
             "junit:junit",
             repository_name = "regression_testing_coursier",
         ),
-        artifact("org.hamcrest:hamcrest"),
-        artifact("org.hamcrest:hamcrest-core"),
         artifact("com.google.guava:guava"),
     ],
 )

--- a/tests/com/github/bazelbuild/rules_jvm_external/javadoc/ResourceTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/javadoc/ResourceTest.java
@@ -47,6 +47,6 @@ public class ResourceTest {
     });
 
     Map<String, String> contents = readJar(outputJar);
-    assertEquals("Apache License 2.0\n", contents.get("LICENSE"));
+    assertEquals("Apache License 2.0".strip(), contents.get("LICENSE").strip());
   }
 }

--- a/tests/com/github/bazelbuild/rules_jvm_external/javadoc/ResourceTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/javadoc/ResourceTest.java
@@ -1,0 +1,52 @@
+package com.github.bazelbuild.rules_jvm_external.javadoc;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.bazelbuild.rules_jvm_external.JarUtils.createJar;
+import static com.github.bazelbuild.rules_jvm_external.JarUtils.readJar;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+public class ResourceTest {
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void shouldIncludeResourceFiles() throws Exception {
+    Path inputJar = temp.newFile("in.jar").toPath();
+    Path outputJar = temp.newFile("out.jar").toPath();
+    Path elementList = temp.newFile("element-list").toPath();
+    // deleting the file since JavadocJarMaker fails on existing files, we just need to supply the path.
+    elementList.toFile().delete();
+
+    Path license = temp.newFile("LICENSE").toPath();
+    Files.write(license, List.of("Apache License 2.0"), UTF_8);
+
+    createJar(
+        inputJar,
+        ImmutableMap.of("com/example/Main.java", "public class Main { public static void main(String[] args) {} }")
+    );
+
+    JavadocJarMaker.main(new String[]{
+        "--resources",
+        license.toAbsolutePath().toString(),
+        "--in",
+        inputJar.toAbsolutePath().toString(),
+        "--out",
+        outputJar.toAbsolutePath().toString(),
+        "--element-list",
+        elementList.toAbsolutePath().toString()
+    });
+
+    Map<String, String> contents = readJar(outputJar);
+    assertEquals("Apache License 2.0\n", contents.get("LICENSE"));
+  }
+}


### PR DESCRIPTION
There's two use cases I'm trying to account for here.

1. I need to add resources to the javadoc jar such as a `LICENSE` file.
2. I need to send a `--define` variable to the javadoc generator so that the `maven_version` variable I have set will appear in the `<title>` of the generated html. rules_jvm_external already supports the same type of substitution on the `coordinates` attribute.

```
java_export(
    name = "lib",
    maven_coordinates="com.example:lib:$(maven_version)",
    ...
    javadocopts=["-windowtitle", "$(maven_version)"],
    doc_resources = ["//:LICENSE"]
)
```