### PR TITLE
Use a more recent rules_android

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,11 @@ build --explicit_java_test_deps
 
 build --experimental_sibling_repository_layout
 
+# For rules_android
+# Delete these once https://github.com/bazelbuild/rules_android/issues/219 is resolved.
+common --experimental_google_legacy_api
+common --experimental_enable_android_migration_apis
+
 # Make sure we get something helpful when tests fail
 test --verbose_failures
 test --test_output=errors

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,7 +27,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_android",
-    version = "0.1.1",
+    version = "0.2.0",
 )
 bazel_dep(
     name = "stardoc",
@@ -35,8 +35,15 @@ bazel_dep(
     repo_name = "io_bazel_stardoc",
 )
 
+# Use a more recent rules_android
+git_override(
+    module_name = "rules_android",
+    remote = "https://github.com/bazelbuild/rules_android.git",
+    commit = "1124b494b30b5626c934a6644ac8236cdcd34645",
+)
+
 # Remove this once rules_android has rolled out official Bzlmod support
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
+remote_android_extensions = use_extension("@rules_android//bzlmod_extensions:android_extensions.bzl", "remote_android_tools_extensions")
 use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
 maven = use_extension(":extensions.bzl", "maven")

--- a/tests/unit/aar_import/BUILD
+++ b/tests/unit/aar_import/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_android//rules:rules.bzl", "aar_import")
 load(":aar_import_test.bzl", "aar_import_test_suite")
 
 aar_import(


### PR DESCRIPTION
Necessary to avoid loading the `@bazel_tools//tools/android` package, which relies on bind()s to work, which rules_android HEAD has deleted.