### PR TITLE
Update protobuf to version that does not define @maven repo in it's MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -138,7 +138,12 @@ http_file(
 
 bazel_dep(
     name = "protobuf",
-    version = "21.7",
+    # Note: we use 27.2 in MODULE.bazel to avoid the warning:
+    #   The maven repository 'maven' is used in two different bazel modules, originally in 'rules_jvm_external' and now in 'protobuf'
+    # But we use 21.7 in WORKSPACE because protobuf 27.2 doesn't work with Bazel 5.x
+    # https://github.com/protocolbuffers/protobuf/commit/a80daa2a2caaaac9ebe9ae6bb1b639c2771c5c55
+    # This should be ok because we only use the protobuf dep to pull in the google/protobuf/wrappers.proto for testing
+    version = "27.2",
     dev_dependency = True,
 )
 bazel_dep(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
@@ -420,8 +420,8 @@ public class MavenResolver implements Resolver {
     //    },
     //
     // In order to keep the version consistent across all classifiers we use the first version for
-    // the
-    // artifact in the dependency list as the version for all of the classifiers of the artifact.
+    // the artifact in the dependency list as the version for all of the classifiers of the
+    // artifact.
     //
     // Note: This is different from the coursier resolver which will use the last artifact in the
     // dependency list for the version of all of that dependency with classifiers.


### PR DESCRIPTION
This was inspired by https://github.com/bazelbuild/rules_jvm_external/issues/1168

Unfortunately it doesn't it fix it for all uses since the real fix is updating all of the bazel dependencies that use protobuf 21.7, but it does fix it for rules_jvm_external development and testing.