### PR TITLE
Remove hardcoded javadocopts

### DIFF
--- a/private/rules/javadoc.bzl
+++ b/private/rules/javadoc.bzl
@@ -8,6 +8,15 @@ _JavadocInfo = provider(
     },
 )
 
+_default_javadocopts = [
+    "-notimestamp",
+    "-use",
+    "-quiet",
+    "-Xdoclint:-missing",
+    "-encoding",
+    "UTF8",
+]
+
 def generate_javadoc(
         ctx,
         javadoc,
@@ -65,12 +74,14 @@ def _javadoc_impl(ctx):
     # `None` https://github.com/bazelbuild/bazel/issues/10170). For this
     # reason we allow people to set javadocopts via the rule attrs.
 
+    javadocopts = ctx.attr.javadocopts if ctx.attr.javadocopts else _default_javadocopts
+
     generate_javadoc(
         ctx,
         ctx.executable._javadoc,
         sources,
         classpath,
-        ctx.attr.javadocopts,
+        javadocopts,
         ctx.attr.doc_deps,
         jar_file,
         element_list,
@@ -107,7 +118,7 @@ javadoc = rule(
         "javadocopts": attr.string_list(
             doc = """javadoc options.
             Note sources and classpath are derived from the deps. Any additional
-            options can be passed here.
+            options can be passed here. If nothing is passed, a default list of options is used.
             """,
         ),
         "doc_deps": attr.label_list(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
@@ -154,10 +154,6 @@ public class JavadocJarMaker {
       }
       Version version = Version.parse(System.getProperty("java.version"));
 
-      options.addAll(
-          Arrays.asList(
-              "-notimestamp", "-use", "-quiet", "-Xdoclint:-missing", "-encoding", "UTF8"));
-
       // Generate frames if we can. Java prior to v9 generates frames automatically.
       // In Java 13, the flag was removed.
       if (version.compareTo(JAVA_9) > 0 && version.compareTo(JAVA_13) < 0) {


### PR DESCRIPTION
I have a situation where I need to disable `-use`, but it was hardcoded into JavadocJarMaker.java`.

I changed the way javadoc options work by making the `javadocopts` attribute completely replace the default options instead of adding to them.

This is not completely backwards compatible. I thought about making it backwards compatible by adding some other flag like `override_default_javadocopts`, but wasn't sure how people would feel about adding additional attributes.

Open to changing this implementation or closing the PR if its not valuable enough.