### PR TITLE
Remove repositories attr from maven.artifact

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -33,7 +33,6 @@ _artifact = tag_class(
         "neverlink": attr.bool(),
         "testonly": attr.bool(),
         "exclusions": attr.string_list(doc = "Maven artifact tuples, in `artifactId:groupId` format", allow_empty = True),
-        "repositories": attr.string_list(default = DEFAULT_REPOSITORIES),
     },
 )
 


### PR DESCRIPTION
This input is entirely ignored. The `maven.install` tag is the only place repositories may be specified.

Closes #1200