### PR TITLE
Derive jvm_import debug label from explicit attribute

### DIFF
--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -288,7 +288,29 @@ genrule(
     target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % t for t in target_visibilities])))
     alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % t for t in target_visibilities]))
 
-    # 9. Finish the java_import rule.
+    # 9. Add user-friendly repository name to support diagnostics.
+    #    Only supported by jvm_import.
+    #
+    # java_import(
+    #   name = "org_hamcrest_hamcrest_library",
+    #   jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
+    #   srcjar = "https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+    #   deps = [
+    #           ":org_hamcrest_hamcrest_core",
+    #   ],
+    #   tags = [
+    #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+    #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+    #       "maven:compile-only",
+    #   ],
+    #   neverlink = True,
+    #   testonly = True,
+    #   visibility = ["//visibility:public"],
+    #   user_provided_repo_name = "maven",
+    if import_rule == "jvm_import":
+        target_import_string.append("\tuser_provided_repo_name = \"%s\"," % repository_ctx.attr.user_provided_name)
+
+    # 10. Finish the java_import rule.
     #
     # java_import(
     # 	name = "org_hamcrest_hamcrest_library",
@@ -309,7 +331,7 @@ genrule(
 
     to_return.append("\n".join(target_import_string))
 
-    # 10. Create a versionless alias target
+    # 11. Create a versionless alias target
     #
     # alias(
     #   name = "org_hamcrest_hamcrest_library_1_3",
@@ -335,7 +357,7 @@ processor_class = "{processor_class}",
             ),
         )
 
-    # 11. If using maven_install.json, use a genrule to copy the file from the http_file
+    # 12. If using maven_install.json, use a genrule to copy the file from the http_file
     # repository into this repository.
     #
     # genrule(

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1336,7 +1336,7 @@ pinned_coursier_fetch = repository_rule(
     attrs = {
         "_compat_repository": attr.label(default = "//private:compat_repository.bzl"),
         "_outdated": attr.label(default = "//private:outdated.sh"),
-        "user_provided_name": attr.string(),
+        "user_provided_name": attr.string(mandatory = True),
         "resolver": attr.string(doc = "The resolver to use", values = ["coursier", "maven"], default = "coursier"),
         "repositories": attr.string_list(),  # list of repository objects, each as json
         "artifacts": attr.string_list(),  # list of artifact objects, each as json
@@ -1391,7 +1391,7 @@ coursier_fetch = repository_rule(
         "_pin": attr.label(default = "//private:pin.sh"),
         "_compat_repository": attr.label(default = "//private:compat_repository.bzl"),
         "_outdated": attr.label(default = "//private:outdated.sh"),
-        "user_provided_name": attr.string(),
+        "user_provided_name": attr.string(mandatory = True),
         "repositories": attr.string_list(),  # list of repository objects, each as json
         "artifacts": attr.string_list(),  # list of artifact objects, each as json
         "fail_on_missing_checksum": attr.bool(default = True),

--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -14,10 +14,10 @@ def _jvm_import_impl(ctx):
     if len(ctx.files.jars) != 1:
         fail("Please only specify one jar to import in the jars attribute.")
 
-    label = "@{workspace_name}//{package}:{name}".format(
+    label = "@{repo}//{package}:{name}".format(
         name = ctx.label.name,
         package = ctx.label.package,
-        workspace_name = ctx.attr.user_provided_repo_name,
+        repo = ctx.attr.user_provided_repo_name,
     )
 
     injar = ctx.files.jars[0]

--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -14,13 +14,10 @@ def _jvm_import_impl(ctx):
     if len(ctx.files.jars) != 1:
         fail("Please only specify one jar to import in the jars attribute.")
 
-    # With `bzlmod` enabled, workspace names end up being `~` separated. For the
-    # user-visible workspace name, we need the final part of the name
-    visible_name = ctx.label.workspace_name.rpartition("~")[2]
     label = "@{workspace_name}//{package}:{name}".format(
         name = ctx.label.name,
         package = ctx.label.package,
-        workspace_name = visible_name,
+        workspace_name = ctx.attr.user_provided_repo_name,
     )
 
     injar = ctx.files.jars[0]
@@ -99,6 +96,9 @@ jvm_import = rule(
         ),
         "neverlink": attr.bool(
             default = False,
+        ),
+        "user_provided_repo_name": attr.string(
+            mandatory = True,
         ),
         "_add_jar_manifest_entry": attr.label(
             executable = True,

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -123,6 +123,7 @@ def maven_install(
             # created from the maven_install.json file in the coursier_fetch
             # invocation after this.
             name = name if maven_install_json == None else "unpinned_" + name,
+            user_provided_name = name,
             pinned_repo_name = None if maven_install_json == None else name,
             repositories = repositories_json_strings,
             artifacts = artifacts_json_strings,
@@ -155,6 +156,7 @@ def maven_install(
         # Create the repository generated from a maven_install.json file.
         pinned_coursier_fetch(
             name = name,
+            user_provided_name = name,
             resolver = resolver,
             repositories = repositories_json_strings,
             artifacts = artifacts_json_strings,


### PR DESCRIPTION
The delimiter used in Bzlmod for repo names has never been stable and
will be changing soon.[^1] String-parsing to derive shorter,
user-friendly names for labels will be broken by this change and is
brittle in general. Instead, passing the right values down from the
contexts where the true values are known is preferred.
    
[^1]: https://github.com/bazelbuild/bazel/issues/23127