### PR TITLE
Support  plus as repo name delimiter in query-result normalization logic

### DIFF
--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -35,7 +35,7 @@ genrule(
     testonly = 1,
     srcs = [":testonly-deps"],
     outs = ["testonly-deps-sorted.txt"],
-    cmd = "cat $< | sed -e 's|@@|@|g; s|\r||g' | sed -e 's|@.*~|@|g; s|\r||g' | sort > $@",
+    cmd = "cat $< | sed -e 's|^@@|@|g; s|\r||g' | sed -e 's|^@[^/]*[+~]|@|g; s|\r||g' | sort > $@",
 )
 
 diff_test(
@@ -62,7 +62,7 @@ genrule(
     testonly = 1,
     srcs = [":version_interval_deps"],
     outs = ["version-interval-deps-sorted.txt"],
-    cmd = "cat $< | sed -e 's|@@|@|g; s|\r||g' | sed -e 's|@.*~|@|g; s|\r||g' | sort > $@",
+    cmd = "cat $< | sed -e 's|^@@|@|g; s|\r||g' | sed -e 's|^@[^/]*[+~]|@|g; s|\r||g' | sort > $@",
 )
 
 diff_test(
@@ -86,7 +86,7 @@ genrule(
     testonly = 1,
     srcs = [":forced-versions-deps"],
     outs = ["forced-versions-deps-sorted.txt"],
-    cmd = "cat $< | sed -e 's|@@|@|g; s|\r||g' | sed -e 's|@.*~|@|g; s|\r||g' | sort > $@",
+    cmd = "cat $< | sed -e 's|^@@|@|g; s|\r||g' | sed -e 's|^@[^/]*[+~]|@|g; s|\r||g' | sort > $@",
 )
 
 diff_test(

--- a/tests/integration/override_targets/override_contains_additional_deps.sh
+++ b/tests/integration/override_targets/override_contains_additional_deps.sh
@@ -18,8 +18,8 @@ function clean_up_workspace_names() {
   local target="$2"
   # The first `sed` command replaces `@@` with `@`. The second extracts the visible name
   # from the bzlmod mangled workspace name
-  cat "$file_name" | sed -e 's|@@|@|g; s|\r||g' | sed -e 's|@.*~|@|g; s|\r||g' | grep "$target"
-  cat "$file_name" | sed -e 's|@@|@|g; s|\r||g' | sed -e 's|@.*~|@|g; s|\r||g' | grep -q "$target"
+  cat "$file_name" | sed -e 's|^@@|@|g; s|\r||g' | sed -e 's|^@[^/]*[+~]|@|g; s|\r||g' | grep "$target"
+  cat "$file_name" | sed -e 's|^@@|@|g; s|\r||g' | sed -e 's|^@[^/]*[+~]|@|g; s|\r||g' | grep -q "$target"
 }
 
 # we should contain the original target


### PR DESCRIPTION
The delimiter used in canonical repo names is changing from `~` to `+`.[^1] In this logic, which tries to normalize query results for the purposes of diff-testing against golden results, label parsing seems unavoidable. So we fall back to the non-preferred approach of supporting both delimiters in our patterns.

Also, refine the patterns to be more exact and better reflect the intent to only act agaisnt the repo-name part of each label:
  * anchor the patterns to match only at start of each label
  * only operate before the first `/`

[^1]: https://github.com/bazelbuild/bazel/issues/23127