### PR TITLE
Upgrade rules_java to 7.10.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_java",
-    version = "7.4.0",
+    version = "7.10.0",
 )
 bazel_dep(
     name = "rules_kotlin",

--- a/examples/java-export/.bazelrc
+++ b/examples/java-export/.bazelrc
@@ -2,4 +2,3 @@
 build --java_runtime_version=remotejdk_11
 build --tool_java_language_version=11
 
-build --javacopt="--release 11"

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/BUILD
@@ -1,11 +1,6 @@
 java_library(
     name = "rules_jvm_external",
     srcs = glob(["*.java"]),
-    javacopts = [
-        "--release",
-        "11",
-        "-Xlint:-options",
-    ],
     visibility = [
         "//private/tools/java:__subpackages__",
         "//tests/com:__subpackages__",

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/coursier/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/coursier/BUILD
@@ -3,10 +3,6 @@ load("//private/rules:artifact.bzl", "artifact")
 java_library(
     name = "coursier",
     srcs = glob(["*.java"]),
-    javacopts = [
-        "--release",
-        "11",
-    ],
     visibility = [
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd:__pkg__",
         "//tests/com/github/bazelbuild/rules_jvm_external:__subpackages__",
@@ -23,10 +19,6 @@ java_library(
 
 java_binary(
     name = "LockFileConverter",
-    javacopts = [
-        "--release",
-        "11",
-    ],
     main_class = "com.github.bazelbuild.rules_jvm_external.coursier.LockFileConverter",
     visibility = ["//visibility:public"],
     runtime_deps = [

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
@@ -3,11 +3,6 @@ load("//private/rules:artifact.bzl", "artifact")
 java_library(
     name = "resolver",
     srcs = glob(["*.java"]),
-    javacopts = [
-        "--release",
-        "11",
-        "-Xlint:-options",
-    ],
     visibility = [
         "//private/tools/java:__subpackages__",
         "//tests/com/github/bazelbuild/rules_jvm_external:__subpackages__",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -41,7 +41,9 @@ def rules_jvm_external_deps(
         maybe(
             http_archive,
             name = "rules_java",
-            url = ["https://github.com/bazelbuild/rules_java/releases/download/7.10.0/rules_java-7.10.0.tar.gz"],
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/7.10.0/rules_java-7.10.0.tar.gz",
+            ],
             sha256 = "eb5447f019734b0c4284eaa5f8248415084da5445ba8201c935a211ab8af43a0",
         )
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -37,24 +37,13 @@ def rules_jvm_external_deps(
             sha256 = "73b88f34dc251bce7bc6c472eb386a6c2b312ed5b473c81fe46855c248f792e0",
         )
 
-    elif major_version == "6":
-        maybe(
-            http_archive,
-            name = "rules_java",
-            urls = [
-                "https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz",
-            ],
-            sha256 = "16bc94b1a3c64f2c36ceecddc9e09a643e80937076b97e934b96a8f715ed1eaa",
-        )
-
     else:
         maybe(
             http_archive,
             name = "rules_java",
-            urls = [
-                "https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz",
-            ],
-            sha256 = "976ef08b49c929741f201790e59e3807c72ad81f428c8bc953cdbeff5fed15eb",
+            url = "https://github.com/bazelbuild/rules_java/archive/30ecf3ff6ee8f30b4df505d9d3bde5bb1c25690b.tar.gz",
+            sha256 = "68844c3efdbfbec17404fc8cbcf786e2c9b9d66ad5f7cc2b1bc83816fc4e754d",
+            strip_prefix = "rules_java-30ecf3ff6ee8f30b4df505d9d3bde5bb1c25690b",
         )
 
     maven_install(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -41,9 +41,8 @@ def rules_jvm_external_deps(
         maybe(
             http_archive,
             name = "rules_java",
-            url = "https://github.com/bazelbuild/rules_java/archive/30ecf3ff6ee8f30b4df505d9d3bde5bb1c25690b.tar.gz",
-            sha256 = "68844c3efdbfbec17404fc8cbcf786e2c9b9d66ad5f7cc2b1bc83816fc4e754d",
-            strip_prefix = "rules_java-30ecf3ff6ee8f30b4df505d9d3bde5bb1c25690b",
+            url = ["https://github.com/bazelbuild/rules_java/releases/download/7.10.0/rules_java-7.10.0.tar.gz"],
+            sha256 = "eb5447f019734b0c4284eaa5f8248415084da5445ba8201c935a211ab8af43a0",
         )
 
     maven_install(


### PR DESCRIPTION
rules_java 7.10.0 work with Bazel 7 down to Bazel 6.2.0. This makes it possible to load symbols like JavaInfo from rules_java also on older Bazel versions (previous Java releases didn't have Java/common/java_info.bzl file). A single rules_java version for multiple Bazel releases should also simplify things.

Remove the flag --release, because it breaks on the combination of Bazel 6.x and rules_java 7.10.0, most likely because of incompatible changes in the turbine. The flag is not necessary, because the release is already controlled --java_release_version flag.