### PR TITLE
Make our extension implementation and tag classes public

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -21,7 +21,7 @@ DEFAULT_NAME = "maven"
 
 _DEFAULT_RESOLVER = "coursier"
 
-_artifact = tag_class(
+artifact = tag_class(
     attrs = {
         "name": attr.string(default = DEFAULT_NAME),
         "group": attr.string(mandatory = True),
@@ -36,7 +36,7 @@ _artifact = tag_class(
     },
 )
 
-_install = tag_class(
+install = tag_class(
     attrs = {
         "name": attr.string(default = DEFAULT_NAME),
 
@@ -113,7 +113,7 @@ _install = tag_class(
     },
 )
 
-_override = tag_class(
+override = tag_class(
     attrs = {
         "name": attr.string(default = DEFAULT_NAME),
         "coordinates": attr.string(doc = "Maven artifact tuple in `artifactId:groupId` format", mandatory = True),
@@ -194,7 +194,7 @@ def _generate_compat_repos(name, existing_compat_repos, artifacts):
 
     return seen
 
-def _maven_impl(mctx):
+def maven_impl(mctx):
     repos = {}
     overrides = {}
     exclusions = {}
@@ -509,10 +509,10 @@ def _maven_impl(mctx):
         return None
 
 maven = module_extension(
-    _maven_impl,
+    maven_impl,
     tag_classes = {
-        "artifact": _artifact,
-        "install": _install,
-        "override": _override,
+        "artifact": artifact,
+        "install": install,
+        "override": override,
     },
 )


### PR DESCRIPTION
This allows other people to extend them as necessary, which is useful for meta-rulesets that aggregate other rulesets.