### PR TITLE
Update kt_android_library load statements

### DIFF
--- a/examples/android_kotlin_app/src/BUILD
+++ b/examples/android_kotlin_app/src/BUILD
@@ -1,4 +1,4 @@
-load("@rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
+load("@rules_kotlin//kotlin:android.bzl", "kt_android_library")
 
 kt_android_library(
     name = "lib",

--- a/examples/kt_android_local_test/src/main/BUILD
+++ b/examples/kt_android_local_test/src/main/BUILD
@@ -1,5 +1,5 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("@rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
+load("@rules_kotlin//kotlin:android.bzl", "kt_android_library")
 
 kt_android_library(
     name = "my_lib",


### PR DESCRIPTION
Fix
```
DEBUG: rules_kotlin~/kotlin/kotlin.bzl:126:10: kt_android_library should be loaded from //kotlin:android.bzl
```
