### PR TITLE
fix: Do not use import scope in dependencies

### DIFF
--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -114,7 +114,7 @@ def generate_pom(
         # Bazel `exports` -> Maven `compile`
         # For boms, it seems the best practice is to use the default `compile` scope, unless the dependency is a BOM itself.
         new_scope = "compile" if dep in versioned_export_dep_coordinates_set or is_bom else "runtime"
-        if unpacked.packaging == "pom":
+        if unpacked.packaging == "pom" and is_bom:
             new_scope = "import"
 
         deps.append(format_dep(unpacked, scope = new_scope, indent = indent, include_version = include_version))


### PR DESCRIPTION
As commented https://github.com/bazel-contrib/rules_jvm_external/commit/911fd0926ac669844a9fdf5e6cd79c7cd3a91709#r163767173, the usage of `import` scope doesn't seem to be correct for non-bom `pom.xml` generation.

This is what Maven says:

> import
This scope is only supported on a dependency of type pom in the <dependencyManagement> section. It indicates the dependency is to be replaced with the effective list of dependencies in the specified POM's <dependencyManagement> section. Since they are replaced, dependencies with a scope of import do not actually participate in limiting the transitivity of a dependency.

The generated `pom.xml`, when depended on, the `import` scoped dependencies are ignored by Maven. The same behaviour is exhibited by `maven.install` extension where `import` scoped dependencies are not present in generated `jvm_import`.