### PR TITLE
ci: Enable Local test examples on macOS

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -24,12 +24,12 @@ tasks:
     working_directory: examples/android_local_test
     test_targets:
       - "//..."
-#  android-local-test-macos:
-#    name: "Android Robolectric test example"
-#    platform: macos
-#    working_directory: examples/android_local_test
-#    test_targets:
-#      - "//..."
+ android-local-test-macos:
+   name: "Android Robolectric test example"
+   platform: macos
+   working_directory: examples/android_local_test
+   test_targets:
+     - "//..."
   android-local-test-windows:
     name: "Android Robolectric test example"
     platform: windows


### PR DESCRIPTION
A try to enable local test example running on macOS. Wait CI result.