### PR TITLE
Use persistent gradle home between invocations

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -348,14 +348,12 @@ def process_gradle_versions_file(parsed, bom_modules):
         # Case 1: Simple string notation: "group:artifact:version"
         if type(value) == "string":
             coords = value
-            # Case 2: Map notation
-
+        # Case 2: Map notation
         elif type(value) == "dict":
             # Case 2a: Map with "module" key
             if "module" in value.keys():
                 coords = value["module"]
-                # Case 2b: Map with "group" and "name" keys
-
+            # Case 2b: Map with "group" and "name" keys
             elif "group" in value.keys() and "name" in value.keys():
                 coords = "%s:%s" % (value["group"], value["name"])
             else:

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -439,11 +439,13 @@ public class GradleResolver implements Resolver {
             .orElse(System.getenv("TEST_SRCDIR"));
 
     // If none are set, just return null so we fall back to the isolated cache
-    if (workspaceRoot == null) return null;
+    if (workspaceRoot == null) {
+      return null;
+    }
 
     // We want gradle home to be persistent but unique for each repo under which we're running
     // so we compute a MD5 hash, similiar to Bazel's output base and use that in the persistent
-    // directory name
+    // directory nameaz
     String md5 = Hashing.md5().hashString(workspaceRoot, StandardCharsets.UTF_8).toString();
 
     return Paths.get(System.getProperty("java.io.tmpdir"), "rje-gradle-" + md5);


### PR DESCRIPTION
By default, we create a isolated temp dir for each run of lockfile pinning for the gradle resolver for `gradle.home`. This means a ton of stuff is redundantly downloaded and is slow on incremental runs too without using `RJE_UNSAFE_CACHE`.

For the coursier resolver, we seem to be using a directory under `external/` by default https://github.com/bazel-contrib/rules_jvm_external/blob/master/private/rules/coursier.bzl#L801 so incremental runs are pretty fast.

~Instead we could use a directory within the runfiles of this binary so that we still keep some level of hermeticity by having this isolated but continue to leverage it on incremental runs (reuse the gradle daemon and the caches)~. We can chose a unique directory under `/tmp` that's persistent between invocations by hashing the workspace root from where the `bazel run` command runs and use that in the generated directory names.  Doing this delivers a pretty significant performance benefit on the second and further runs. Note that temp directories are wiped out between restarts on mac, but this should provide a health improvement.

Before (2nd run), about ~2 min
```
REPIN=1 bazel run @regression_testing_gradle//:pin  7.39s user 1.02s system 7% cpu 1:52.79 total
```

After (2nd run and every run after until `bazel clean` is run), ~30 seconds
```
REPIN=1 bazel run @regression_testing_gradle//:pin  6.25s user 0.77s system 25% cpu 27.258 total
```

The gradle home will be in a directory like this

```
smocherla@NLC2L54QQY rules_jvm_external % ls /private/var/tmp/_bazel_smocherla/536b5c8af4e86fad57fc24f39380ac8a/execroot/_main/bazel-out/_main~maven~regression_testing_gradle/darwin_arm64-fastbuild/bin/pin.runfiles/.gradle
caches  daemon  native
```

Additonally this speedens the up the unit tests significantly because the gradle daemon is re-used between tests.

Before

```
//tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle:GradleResolverTest PASSED in 380.6s
```

Now
```
//tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle:GradleResolverTest PASSED in 35.1s
```

I realize this could be controversial perhaps, so opening it in draft for comment.

Note that `RJE_UNSAFE_CACHE` will still be respected and it will use the gradle cache under `user.home`.
