### PR TITLE
[resolver] Allow gradle resolver to have self loops

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -149,7 +149,7 @@ public class GradleResolver implements Resolver {
   private ResolutionResult parseDependencies(
       List<GradleDependency> requestedDeps, GradleDependencyModel resolved)
       throws GradleDependencyResolutionException {
-    MutableGraph<Coordinates> graph = GraphBuilder.directed().allowsSelfLoops(false).build();
+    MutableGraph<Coordinates> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
 
     Set<Conflict> conflicts = new HashSet<>();
     List<GradleResolvedDependency> implementationDependencies = resolved.getResolvedDependencies();


### PR DESCRIPTION
Sometimes dependencies have a direct dependency upon themselves. We handle this situation cleanly in `rules_jvm_external` (we don't create a cycle), but the resolver also needs to allow self loops in order for us to get to the point where we can generate the lock file.