### PR TITLE
rules_java: add rules loads to fix autoload on Bazel 9

### DIFF
--- a/examples/bzlmod/java/src/com/github/rules_jvm_external/examples/bzlmod/BUILD
+++ b/examples/bzlmod/java/src/com/github/rules_jvm_external/examples/bzlmod/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_binary(

--- a/gradle.BUILD.bazel
+++ b/gradle.BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import", "java_library")
+
 java_library(
     name = "gradle",
     exports = [

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//private/rules:artifact.bzl", "artifact")
 
 java_library(

--- a/tests/com/github/bazelbuild/rules_jvm_external/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("//:defs.bzl", "artifact")
 
 java_test(

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_test")
 load("//:defs.bzl", "artifact")
 
 java_test(

--- a/tests/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_test")
 load("//:defs.bzl", "artifact")
 
 java_test(

--- a/tests/com/github/bazelbuild/rules_jvm_external/maven/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/maven/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_test")
 load("//:defs.bzl", "artifact")
 
 java_test(

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_test")
 load("//:defs.bzl", "artifact")
 
 java_test(

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_test")
 load("//:defs.bzl", "artifact")
 
 java_test(

--- a/tests/integration/duplicates_in_java_export/BUILD
+++ b/tests/integration/duplicates_in_java_export/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("//:defs.bzl", "artifact", "java_export")
 
 java_test(

--- a/tests/integration/pom_file/BUILD
+++ b/tests/integration/pom_file/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("//:defs.bzl", "artifact", "java_export")
 


### PR DESCRIPTION
Autoload is disabled for rules_java by default on Bazel 9. Many of these were already fixed in #1271, but some more are still left.