### PR TITLE
fix(pom_file): exclusions referenced before assignment

### DIFF
--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -6,6 +6,7 @@ def _pom_file_impl(ctx):
     # Ensure the target has coordinates
     expanded_maven_deps = []
     expanded_export_deps = []
+    exclusions = {}
     if ctx.attr.target:
         if not ctx.attr.target[MavenInfo].coordinates:
             fail("pom_file target must have maven coordinates.")
@@ -58,7 +59,6 @@ def _pom_file_impl(ctx):
                         exclusions_unsorted[maven_info.coordinates] = []
                     exclusions_unsorted[maven_info.coordinates].append(exclusion)
 
-        exclusions = {}
         for coords in exclusions_unsorted:
             exclusions[coords] = sorted(exclusions_unsorted[coords])
 

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -183,6 +183,18 @@ function test_m2local_testing_found_local_artifact_after_build_copy() {
   expect_log "Assuming maven local for artifact: com.example:kt:1.0.0"
 }
 
+function test_publish_java_binary_jar_with_maven_export {
+  m2local_dir="${HOME}/.m2/repository"
+  jar_dir="${m2local_dir}/com/example_binary/exe/1.0.0"
+  rm -rf ${jar_dir}
+  mkdir -p ${m2local_dir}
+
+  # should run successfully
+  bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/java_export:some-java-binary-export.publish >> "$TEST_LOG" 2>&1
+
+  rm -rf ${jar_dir}
+}
+
 function test_found_artifact_with_plus_through_pin_and_build() {
   bazel clean --expunge >> "$TEST_LOG" 2>&1 # for https://github.com/bazelbuild/rules_jvm_external/issues/800
   bazel run @artifact_with_plus//:pin >> "$TEST_LOG" 2>&1
@@ -367,6 +379,7 @@ TESTS=(
   "test_transitive_dependency_with_type_of_pom"
   "test_when_both_pom_and_jar_artifact_are_available_jar_artifact_is_present"
   "test_when_both_pom_and_jar_artifact_are_dependencies_jar_artifact_is_present"
+  "test_publish_java_binary_jar_with_maven_export"
   # "test_gradle_metadata_is_resolved_correctly_for_aar_artifact"
   "test_gradle_metadata_is_resolved_correctly_for_jvm_artifact"
   "test_gradle_versions_catalog"

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
-load("@rules_java//java:defs.bzl", "java_library")
-load("//:defs.bzl", "artifact", "java_export")
+load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("//:defs.bzl", "artifact", "java_export", "maven_export")
 load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
 
 java_test(
@@ -232,4 +232,19 @@ diff_test(
     name = "check-manifest-lines-added",
     file1 = "check-manifest-lines-added-MANIFEST.MF.golden",
     file2 = ":extract-extra-manifest-lines",
+)
+
+java_binary(
+    name = "some-java-binary",
+    srcs = ["Main.java", "Dependency.java"],
+    main_class = "com.jvm.external.jvm_export.Main",
+    deps = [
+        artifact("com.google.guava:guava"),
+    ]
+)
+
+maven_export(
+    name = "some-java-binary-export",
+    maven_coordinates = "com.example_binary:exe:1.0.0",
+    target = "some-java-binary_deploy.jar",
 )


### PR DESCRIPTION
Under specific circumstances, the exclusions variable inside _pom_file_impl ends up being referenced before assignment. Moving it outside the if block fixes this.

More specifically, this happens when a maven_export has the target parameter set (to point to a jar file) instead of a lib_name. I have also added a test case that triggers this to prevent regression.