### PR TITLE
Upload artifacts in parallel (address artifactorys "Maven Snapshot Version Behaviour")

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -125,7 +125,7 @@ public class MavenPublisher {
         new SigningMetadata(gpgSign, useInMemoryPgpKeys, signingKey, signingPassword);
 
     final ExecutorService executorService = Executors.newFixedThreadPool(
-      Optional.of(System.getenv("RJE_MAX_THREADS")).map(Integer::parseInt).orElse(8)
+      Optional.ofNullable(System.getenv("RJE_MAX_THREADS")).map(Integer::parseInt).orElse(8)
     );
 
     try {


### PR DESCRIPTION
(This PR is in part a discussion starter)

## Problem

I stumbled upon an unfortunate interaction between MavenPublisher and artifactory, latter being deployed with configuration `Maven Snapshot Version Behaviour` set to `Unique` (Version number is based on a time-stamp)

The unfortunate behaviour is the following - when sequentially (code uses `Executors.newSingleThreadExecutor()`) uploading a group of snapshot artifacts (`.pom`, `-sources.jar`, `.jar` and checksums) it seems like at some point enough time passes and part of the artifacts is getting treated as belonging to a newer group of artifacts. This results in the following (epoch timestamp and commit hash are part of the version we configure, `YYYYMMDD.HHmmss` I assume is added by artifactory):

```
my-library-1767713090-cccc1111bbbb-20260116.114815-1-sources.jar 
my-library-1767713090-cccc1111bbbb-20260116.114815-1-sources.jar.sha512
my-library-1767713090-cccc1111bbbb-20260116.114815-1.pom
# notice the suffix for rest of artifacts is `-2` and the date appended by artifactory is 2 seconds later
my-library-1767713090-cccc1111bbbb-20260116.114817-2.jar
my-library-1767713090-cccc1111bbbb-20260116.114817-2.jar.sha512
my-library-1767713090-cccc1111bbbb-20260116.114817-2.pom.sha512
```

According to maven-metadata.xml the jar in second group is the latest and gets downloaded by maven project and when doing so - unable to find `.pom` file, hence missing dependencies information, hence leading to `NoClassDefFoundError`. 

## Possible solution

I tried replacing single-threaded executor and that seemed to have helped as results are the following (multiple invocations tested):

```
my-library-1767713090-cccc1111bbbb-20260116.115010-1-sources.jar 
my-library-1767713090-cccc1111bbbb-20260116.115010-1-sources.jar.sha512
my-library-1767713090-cccc1111bbbb-20260116.115010-1.pom
# notice the suffix for rest of artifacts is `-1` (as expected) and the date appended by artifactory is only 1 second later
my-library-1767713090-cccc1111bbbb-20260116.115011-1.jar
my-library-1767713090-cccc1111bbbb-20260116.115011-1.jar.sha512
my-library-1767713090-cccc1111bbbb-20260116.115011-1.pom.sha512
```

I presume since less time pass due to parallel upload - artifactory considers them to belong to same group of artifacts and tags them accordingly. 

What other and/or better solutions do you think could be employed to address that issue? 

## Other considerations

Fair to say that the problem would be solved if artifactory was configured with another setting, but I believe MavenPublisher should work with whatever configuration is chosen