### PR TITLE
feat: Support `COURSIER_SHA256` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,17 @@ $ bazel build @maven_with_unsafe_shared_cache//... --repo_env=COURSIER_URL='http
 
 Please note it still requires the SHA to match.
 
+To use a different Coursier version entirely, you can override both the URL and SHA256:
+
+```shell
+$ bazel build @maven//... \
+  --repo_env=COURSIER_URL='https://github.com/coursier/coursier/releases/download/v2.1.25-M23/coursier.jar' \
+  --repo_env=COURSIER_SHA256='<sha256-of-the-jar>'
+```
+
+Note: rules_jvm_external is tested against a specific Coursier version. Using a
+different version is not officially supported and compatibility is not guaranteed.
+
 ### `artifact` helper macro
 
 The `artifact` macro translates the artifact's `group:artifact` coordinates to

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -889,6 +889,9 @@ def _check_artifacts_are_unique(artifacts, duplicate_version_warning):
         else:
             print("\n".join(msg_parts))
 
+def get_coursier_sha256(environ, default_sha256):
+    return environ.get("COURSIER_SHA256", default_sha256)
+
 # Get the path to the cache directory containing Coursier-downloaded artifacts.
 #
 # This method is public for testing.
@@ -1160,7 +1163,8 @@ def _coursier_fetch_impl(repository_ctx):
     if coursier_url_from_env != None:
         coursier_download_urls.insert(0, coursier_url_from_env)
 
-    repository_ctx.download(coursier_download_urls, "coursier", sha256 = COURSIER_CLI_SHA256, executable = True)
+    coursier_sha256 = get_coursier_sha256(repository_ctx.os.environ, COURSIER_CLI_SHA256)
+    repository_ctx.download(coursier_download_urls, "coursier", sha256 = coursier_sha256, executable = True)
 
     # Try running coursier once
     cmd = _generate_java_jar_command(repository_ctx, repository_ctx.path("coursier"))
@@ -1683,6 +1687,7 @@ coursier_fetch = repository_rule(
         "NO_PROXY",
         "COURSIER_CACHE",
         "COURSIER_OPTS",
+        "COURSIER_SHA256",
         "COURSIER_URL",
         "RJE_VERBOSE",
         "XDG_CACHE_HOME",

--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -4,6 +4,7 @@ load(
     "//private/rules:coursier.bzl",
     "compute_dependency_inputs_signature",
     "get_coursier_cache_or_default",
+    "get_coursier_sha256",
     "get_direct_dependencies",
     "get_netrc_lines_from_entries",
     infer = "infer_artifact_path_from_primary_and_repos",
@@ -445,6 +446,28 @@ def _get_coursier_cache_or_default_enabled_with_custom_location_test(ctx):
     return unittest.end(env)
 
 get_coursier_cache_or_default_enabled_with_custom_location_test = add_test(_get_coursier_cache_or_default_enabled_with_custom_location_test)
+
+def _get_coursier_sha256_default_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "default_sha256_value",
+        get_coursier_sha256({}, "default_sha256_value"),
+    )
+    return unittest.end(env)
+
+get_coursier_sha256_default_test = add_test(_get_coursier_sha256_default_test_impl)
+
+def _get_coursier_sha256_from_env_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "custom_sha256_from_env",
+        get_coursier_sha256({"COURSIER_SHA256": "custom_sha256_from_env"}, "default_sha256_value"),
+    )
+    return unittest.end(env)
+
+get_coursier_sha256_from_env_test = add_test(_get_coursier_sha256_from_env_test_impl)
 
 def _mock_which_true(path):
     return True


### PR DESCRIPTION
Allows users to specify a different Coursier version by overriding the SHA256 checksum, complementing the existing `COURSIER_URL` env var.

## Summary

- Add `get_coursier_sha256()` helper function (testable)
- Use env var override in `_coursier_fetch_impl`
- Add `COURSIER_SHA256` to environ list
- Add 2 unit tests
- Update README with usage and compatibility note

## Changes

```python
# New helper function
def get_coursier_sha256(environ, default_sha256):
    return environ.get("COURSIER_SHA256", default_sha256)

# Usage in _coursier_fetch_impl
coursier_sha256 = get_coursier_sha256(repository_ctx.os.environ, COURSIER_CLI_SHA256)
repository_ctx.download(coursier_download_urls, "coursier", sha256 = coursier_sha256, executable = True)
```

## Usage

```bash
bazel build @maven//... \
  --repo_env=COURSIER_URL='https://github.com/coursier/coursier/releases/download/v2.1.25-M23/coursier.jar' \
  --repo_env=COURSIER_SHA256='<sha256-of-the-jar>'
```

Closes #1526