### PR TITLE
fix: use forward slash separator in Maven purl format

### DIFF
--- a/private/lib/coordinates.bzl
+++ b/private/lib/coordinates.bzl
@@ -172,7 +172,7 @@ def to_purl(coords, repository):
     to_return = "pkg:maven/"
 
     unpacked = unpack_coordinates(coords)
-    to_return += "{group}:{artifact}@{version}".format(
+    to_return += "{group}/{artifact}@{version}".format(
         artifact = unpacked.artifact,
         group = unpacked.group,
         version = unpacked.version,

--- a/tests/unit/jvm_import/jvm_import_test.bzl
+++ b/tests/unit/jvm_import/jvm_import_test.bzl
@@ -119,7 +119,7 @@ def _does_jvm_import_export_a_package_provider_impl(ctx):
 
     asserts.true(env, PackageInfo in ctx.attr.src)
     package_info = ctx.attr.src[PackageInfo]
-    asserts.equals(env, "pkg:maven/com.google.code.findbugs:jsr305@3.0.2", package_info.purl)
+    asserts.equals(env, "pkg:maven/com.google.code.findbugs/jsr305@3.0.2", package_info.purl)
 
     # The metadata is applied directly to the target in this case, so there should
     # not be any transitive metadata. Apparently.


### PR DESCRIPTION
Update the Maven package URL (purl) format to use forward slash (/) instead of colon (:) as the separator between group and artifact, following the correct purl specification for Maven packages.

The format now correctly generates:
  pkg:maven/group/artifact@version
instead of:
  pkg:maven/group:artifact@version

https://github.com/package-url/purl-spec/blob/main/types-doc/maven-definition.md