### PR TITLE
fix: resolve concurrent NPE in ErrorReportingListener (#1152)

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/ErrorReportingListener.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/ErrorReportingListener.java
@@ -15,6 +15,7 @@
 package com.github.bazelbuild.rules_jvm_external.resolver.maven;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import org.eclipse.aether.AbstractRepositoryListener;
@@ -22,30 +23,33 @@ import org.eclipse.aether.RepositoryEvent;
 
 class ErrorReportingListener extends AbstractRepositoryListener {
 
-  private final List<Exception> exceptions = new LinkedList<>();
+  private final List<Exception> exceptions = Collections.synchronizedList(new LinkedList<>());
 
   @Override
   public void artifactDescriptorInvalid(RepositoryEvent event) {
-    if (event.getException() != null) {
-      exceptions.add(event.getException());
-    }
+    addExceptionIfPresent(event);
   }
 
   @Override
   public void artifactDescriptorMissing(RepositoryEvent event) {
-    if (event.getException() != null) {
-      exceptions.add(event.getException());
-    }
+    addExceptionIfPresent(event);
   }
 
   @Override
   public void metadataInvalid(RepositoryEvent event) {
-    if (event.getException() != null) {
+    addExceptionIfPresent(event);
+  }
+
+  private void addExceptionIfPresent(RepositoryEvent event) {
+    if (event != null && event.getException() != null) {
       exceptions.add(event.getException());
     }
   }
 
   public List<Exception> getExceptions() {
-    return ImmutableList.copyOf(exceptions);
+    // https://www.baeldung.com/java-synchronized-collections#the-synchronizedList-method
+    synchronized (exceptions) {
+      return ImmutableList.copyOf(exceptions);
+    }
   }
 }

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
@@ -41,6 +41,24 @@ java_test(
 )
 
 java_test(
+    name = "ErrorReportingListenerTest",
+    size = "small",
+    srcs = ["ErrorReportingListenerTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.maven.ErrorReportingListenerTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+        artifact(
+            "org.apache.maven.resolver:maven-resolver-api",
+            repository_name = "rules_jvm_external_deps",
+        ),
+    ],
+)
+
+java_test(
     name = "MavenResolverTest",
     size = "medium",
     srcs = ["MavenResolverTest.java"],

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/ErrorReportingListenerTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/ErrorReportingListenerTest.java
@@ -1,0 +1,49 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.maven;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositoryEvent;
+import org.junit.Test;
+
+public class ErrorReportingListenerTest {
+
+  @Test
+  public void getExceptionsShouldBeThreadSafe() throws Exception {
+    ErrorReportingListener listener = new ErrorReportingListener();
+    int threadCount = 8;
+    int eventsPerThread = 500;
+    Thread[] threads = new Thread[threadCount];
+
+    for (int t = 0; t < threadCount; t++) {
+      threads[t] = new Thread(() -> {
+        for (int i = 0; i < eventsPerThread; i++) {
+          RepositoryEvent.Builder builder = new RepositoryEvent.Builder(
+              new DefaultRepositorySystemSession(),
+              RepositoryEvent.EventType.ARTIFACT_DESCRIPTOR_MISSING);
+          builder.setException(new RuntimeException("err"));
+          listener.artifactDescriptorMissing(builder.build());
+        }
+      });
+    }
+
+    for (Thread thread : threads) thread.start();
+    for (Thread thread : threads) thread.join();
+
+    assertEquals(threadCount * eventsPerThread, listener.getExceptions().size());
+  }
+}


### PR DESCRIPTION
Use Collections.synchronizedList and synchronized block in getExceptions() to prevent NullPointerException when multiple threads add exceptions concurrently during Maven resolution.

Extract common addExceptionIfPresent method with null-safe event check. Add ErrorReportingListenerTest to verify thread safety.

Closes #1152