### PR TITLE
fix: handle skipped artifacts in calculateArtifactHash to prevent NPE

### DIFF
--- a/private/rules/v3_lock_file.bzl
+++ b/private/rules/v3_lock_file.bzl
@@ -151,10 +151,12 @@ def _compute_lock_file_hash_v3(lock_file_contents):
 
     for repo, artifacts in lock_file_contents["repositories"].items():
         for artifact in artifacts:
-            all_infos[artifact]["repository"] = repo
+            if artifact in all_infos:
+                all_infos[artifact]["repository"] = repo
 
     for dep, dep_info in lock_file_contents["dependencies"].items():
-        all_infos[dep]["dependencies"] = sorted(dep_info)
+        if dep in all_infos:
+            all_infos[dep]["dependencies"] = sorted(dep_info)
 
     return _compute_final_hash(all_infos)
 

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
@@ -345,14 +345,20 @@ public abstract class AbstractMain {
     for (Map.Entry<String, Iterable<String>> repo : repositories.entrySet()) {
       Iterable<String> repoArtifacts = repo.getValue();
       for (String art : repoArtifacts) {
-        allInfos.get(art).put("repository", repo.getKey());
+        Map<String, Object> info = allInfos.get(art);
+        if (info != null) {
+          info.put("repository", repo.getKey());
+        }
       }
     }
 
     Map<String, Set<String>> dependencies =
         sortMapRecursively((Map<?, ?>) rendered.get("dependencies"));
     for (Map.Entry<String, Set<String>> dep : dependencies.entrySet()) {
-      allInfos.get(dep.getKey()).put("dependencies", dep.getValue());
+      Map<String, Object> info = allInfos.get(dep.getKey());
+      if (info != null) {
+        info.put("dependencies", dep.getValue());
+      }
     }
 
     Map<String, Integer> finalHash = new TreeMap<>();

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFileTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFileTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.Conflict;
@@ -250,6 +251,68 @@ public class V3LockFileTest {
 
       assertEquals(String.format("Hash mismatch for artifact '%s'", key), expectedHash, actualHash);
     }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void calculateArtifactHashShouldHandleSkippedArtifacts() {
+    Coordinates mainCoords = new Coordinates("com.example:item:1.0.0");
+    Coordinates depCoords = new Coordinates("com.example:dep:1.0.0");
+    Coordinates sourcesCoords = mainCoords.setClassifier("sources");
+    String sourcesKey = sourcesCoords.asKey();
+
+    DependencyInfo dep =
+        new DependencyInfo(
+            depCoords,
+            repos,
+            Optional.empty(),
+            Optional.of("deadbeef"),
+            Set.of(),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+
+    DependencyInfo mainJar =
+        new DependencyInfo(
+            mainCoords,
+            repos,
+            Optional.empty(),
+            Optional.of("cafebabe"),
+            Set.of(depCoords),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+
+    DependencyInfo skippedSources =
+        new DependencyInfo(
+            sourcesCoords,
+            repos,
+            Optional.empty(),
+            Optional.empty(),
+            Set.of(depCoords),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+
+    Map<String, Object> rendered =
+        new V3LockFile(repos, Set.of(mainJar, dep, skippedSources), Set.of(), true).render();
+
+    Set<String> skipped = (Set<String>) rendered.get("skipped");
+    assertTrue("sources artifact should be skipped", skipped.contains(sourcesKey));
+
+    Map<String, Set<String>> renderedRepos =
+        (Map<String, Set<String>>) rendered.get("repositories");
+    boolean foundInRepos =
+        renderedRepos.values().stream().anyMatch(arts -> arts.contains(sourcesKey));
+    assertTrue("skipped artifact should still appear in repositories", foundInRepos);
+
+    Map<String, Set<String>> renderedDeps =
+        (Map<String, Set<String>>) rendered.get("dependencies");
+    assertTrue(
+        "skipped artifact should still appear in dependencies",
+        renderedDeps.containsKey(sourcesKey));
+
+    AbstractMain.calculateArtifactHash(rendered);
   }
 
   private V3LockFile roundTrip(V3LockFile lockFile) {


### PR DESCRIPTION
Skipped artifacts (missing sha256/path) appear in the lock file's repositories and dependencies maps but have no shasums entry, so calculateArtifactHash never creates an allInfos entry for them. Looking up these keys in allInfos returned null, causing a NullPointerException.

Guard the repository and dependency lookups in calculateArtifactHash with null checks to gracefully skip artifacts not present in allInfos.