### PR TITLE
Fix GitHub search query in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can find examples in the [`examples/`](./examples/) directory.
 ### Projects using rules_jvm_external
 
 Find other GitHub projects using `rules_jvm_external`
-[with this search query](https://github.com/search?q=rules_jvm_external+filename%3AMODULE.bazel&type=Code).
+[with this search query](https://github.com/search?q=rules_jvm_external+path%3A**%2FMODULE.bazel&type=code).
 
 ## Prerequisites
 


### PR DESCRIPTION
The `filename:` query was a part of a legacy implementation of code search. The current equivalent is `path:` [1].

[1] https://github.com/github/docs/issues/24666