### PR TITLE
Fix problems with Windows CI builds

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
@@ -10,7 +10,7 @@ java_library(
     ),
     data = [
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data:gradle_build_templates",
-        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin:plugin_deploy_jar_deploy.jar",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin:plugin.jar",
         "@bazel_tools//tools/jdk:host_jdk",
         "@gradle//:distribution",
         "@gradle//:gradle-bin/README",

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -712,7 +712,7 @@ public class GradleResolver implements Resolver {
           runfiles
               .withSourceRepository(AutoBazelRepository_GradleResolver.NAME)
               .rlocation(
-                  "rules_jvm_external/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin/plugin_deploy_jar_deploy.jar");
+                  "rules_jvm_external/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin/plugin.jar");
       if (!Files.exists(Paths.get(pluginJarPath))) {
         throw new IOException("Gradle Plugin jar not found at " + pluginJarPath);
       }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
@@ -27,9 +28,20 @@ java_library(
 java_binary(
     name = "plugin_deploy_jar",
     main_class = "does.not.Exist",
+    runtime_deps = [":plugin"],
+)
+
+# Wrap the implicit _deploy.jar output in an explicit rule so that it
+# has well-defined build ordering in the runfiles tree. Without this,
+# Windows builds hit a race condition where the runfiles SymlinkTreeAction
+# creates a dangling junction before the deploy jar is written
+# (https://github.com/bazelbuild/bazel/issues/19018).
+copy_file(
+    name = "plugin_jar",
+    src = ":plugin_deploy_jar_deploy.jar",
+    out = "plugin.jar",
     visibility = [
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle:__subpackages__",
         "//tests:__subpackages__",
     ],
-    runtime_deps = [":plugin"],
 )

--- a/tests/integration/override_targets/BUILD
+++ b/tests/integration/override_targets/BUILD
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@rules_android//android:rules.bzl", "aar_import")
 load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")


### PR DESCRIPTION
The plugin_deploy_jar_deploy.jar is an implicit output of a java_binary rule, referenced directly as a data dependency. On Windows, Bazel's runfiles tree construction has a race condition ([bazel#19018](https://github.com/bazelbuild/bazel/issues/19018), [bazel#3881](https://github.com/bazelbuild/bazel/issues/3881)) where the SymlinkTreeAction creates a dangling junction before the deploy jar build action completes. The Files.exists() check then fails because the junction points to nothing. This doesn't happen on Linux/macOS because POSIX symlinks resolve lazily.