### PR TITLE
Prefer getenv to env.get

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -604,9 +604,8 @@ def maven_impl(mctx):
     # Second pass: merge and deduplicate repositories
     all_repo_names = {name: True for name in root_module_repos.keys() + non_root_module_repos.keys()}.keys()
 
-    os_env = mctx.os.environ
-    repin_env_var = os_env.get("REPIN")
-    rje_verbose_env_var = os_env.get("RJE_VERBOSE")
+    repin_env_var = mctx.getenv("REPIN")
+    rje_verbose_env_var = mctx.getenv("RJE_VERBOSE")
 
     for repo_name in all_repo_names:
         root_repo = root_module_repos.get(repo_name, {})

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -539,8 +539,9 @@ def _add_direct_deps_files(repository_ctx, direct_deps):
     )
 
 def is_repin_required(repository_ctx):
-    env_var_names = repository_ctx.os.environ.keys()
-    return "RULES_JVM_EXTERNAL_REPIN" not in env_var_names and "REPIN" not in env_var_names
+    repin_env_var = repository_ctx.getenv("REPIN")
+    rules_jvm_external_repin_env_var = repository_ctx.getenv("RULES_JVM_EXTERNAL_REPIN")
+    return rules_jvm_external_repin_env_var == None and repin_env_var == None
 
 def _get_fail_if_repin_required(repository_ctx):
     if not repository_ctx.attr.fail_if_repin_required:


### PR DESCRIPTION
I was having an issue with the value of `REPIN` being cached between invocations and I think using the `rctx/mctx.getenv` is preferrable because it explicitly watches that environment variable, so in case the value of the environment variable changes or it's removed from the client env, the repository gets re-fetched.

https://bazel.build/rules/lib/builtins/repository_ctx#getenv
https://bazel.build/rules/lib/builtins/module_ctx#getenv