### PR TITLE
update environment variable handling for pinning

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -604,7 +604,7 @@ def maven_impl(mctx):
     # Second pass: merge and deduplicate repositories
     all_repo_names = {name: True for name in root_module_repos.keys() + non_root_module_repos.keys()}.keys()
 
-    repin_env_var = mctx.getenv("REPIN")
+    repin_env_var = mctx.getenv("REPIN") or mctx.getenv("RULES_JVM_EXTERNAL_REPIN")
     rje_verbose_env_var = mctx.getenv("RJE_VERBOSE")
 
     for repo_name in all_repo_names:
@@ -861,4 +861,5 @@ maven = module_extension(
         "install": install,
         "override": override,
     },
+    environ = ["REPIN", "RULES_JVM_EXTERNAL_REPIN", "RJE_VERBOSE"],
 )

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1737,6 +1737,8 @@ coursier_fetch = repository_rule(
         "COURSIER_OPTS",
         "COURSIER_SHA256",
         "COURSIER_URL",
+        "REPIN",
+        "RULES_JVM_EXTERNAL_REPIN",
         "RJE_VERBOSE",
         "XDG_CACHE_HOME",
     ],


### PR DESCRIPTION
When CI restores Bazel's external repo state from cache, the `@unpinned_maven` repository directory (materialized by `coursier_fetch`) can survive across runs. That directory contains `unsorted_deps.json`, which is the artifact list `bazel run @maven//:pin` reads to decide what to resolve.

If `coursier_fetch` isn't re-evaluated, that JSON is stale — and pin happily resolves the old artifact list and writes it to maven_install.json. Artifacts that should have been removed silently persist. Locally with a clean cache it works correctly; in CI with a warm cache it doesn't.
  
`REPIN=1` is the documented solution but neither the module extension nor `coursier_fetch` declares `REPIN`/`RULES_JVM_EXTERNAL_REPIN` in its environ. Without that declaration, Bazel doesn't treat the env var as part of the cache fingerprint, so flipping it doesn't  invalidate anything. There's no way to force re-evaluation from outside.
  
What this PR does
1. declares `environ = ["REPIN", "RULES_JVM_EXTERNAL_REPIN", "RJE_VERBOSE"]` on the maven module extension. The extension already reads all three via mctx.getenv(), but needs environ declarations
2. extends the extension's repin check to honor `RULES_JVM_EXTERNAL_REPIN` in addition to `REPIN`. The repo rule (`is_repin_required` in `coursier.bzl:541-544`) and the `README` already treat them as interchangeable; the extension was the lone holdout.
3. adds REPIN and RULES_JVM_EXTERNAL_REPIN to `coursier_fetch` environ. The rule already reads both via `repository_ctx.getenv()` in `is_repin_required`, but they were not declared. This is the change that makes `REPIN=1 bazel run @maven//:pin` actually force `coursier_fetch` to re-run in a cached-CI environment, regenerating `unsorted_deps.json` and producing a correct lockfile.