### PR TITLE
Fix MavenPublisher to support POM-only publications

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -176,15 +176,17 @@ public class MavenPublisher {
     List<CompletableFuture<Void>> futures = new ArrayList<>();
     futures.add(upload(repo, credentials, coords, ".pom", pom, signingMetadata, executor));
 
-    futures.add(
-        upload(
-            repo,
-            credentials,
-            coords,
-            "." + getFileExtension(mainArtifactPath),
-            Paths.get(mainArtifactPath),
-            signingMetadata,
-            executor));
+    if (!mainArtifactPath.isEmpty()) {
+      futures.add(
+          upload(
+              repo,
+              credentials,
+              coords,
+              "." + getFileExtension(mainArtifactPath),
+              Paths.get(mainArtifactPath),
+              signingMetadata,
+              executor));
+    }
 
     if (!Strings.isNullOrEmpty(extraArtifacts)) {
       List<String> extraArtifactTuples = Splitter.onPattern(",").splitToList(extraArtifacts);

--- a/tests/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisherTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisherTest.java
@@ -46,6 +46,30 @@ public class MavenPublisherTest {
   }
 
   @Test
+  public void testPublishLocalPomOnly() throws Exception {
+    File pom = File.createTempFile("pom", ".xml");
+    final Path root = Paths.get(System.getenv("TEST_TMPDIR"));
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    MavenPublisher.run(
+        "com.example:example-bom:1.0.0",
+        pom.getAbsolutePath(),
+        "",
+        true,
+        null,
+        root.toUri().toString(),
+        null,
+        SigningMetadata.noSigner(),
+        executor);
+    executor.shutdown();
+
+    Path repoRoot = root.resolve("com/example/example-bom/1.0.0");
+    assertTrue(Files.exists(repoRoot.resolve("example-bom-1.0.0.pom")));
+    assertTrue(Files.exists(repoRoot.resolve("example-bom-1.0.0.pom.md5")));
+    assertTrue(Files.exists(repoRoot.resolve("example-bom-1.0.0.pom.sha1")));
+  }
+
+  @Test
   public void testPublishHttp() throws Exception {
     final Path root = Paths.get(System.getenv("TEST_TMPDIR"));
     HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);


### PR DESCRIPTION
  - Guard the main-artifact upload in `MavenPublisher.run` with `!mainArtifactPath.isEmpty()`, mirroring the `Strings.isNullOrEmpty(extraArtifacts)` check immediately below it.
  - Add `testPublishLocalPomOnly` covering the POM-only publish path.

maven_publish.bzl declares artifact as optional (line 125-127) and encodes "no artifact" as an empty string when generating the publisher script (line 43). maven_bom relies on this — both <name>.publish and <name>-dependencies.publish invoke maven_publish with only a pom (maven_bom.bzl:215, :238), since BOMs are <packaging>pom</packaging> with no jar.

Paths.get("") resolves to the working directory, and Files.readAllBytes(...) on a directory throws java.io.IOException: Is a directory, so every maven_bom publish failed.
