### PR TITLE
Preserve Gradle test-fixtures variants

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGenerator.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGenerator.java
@@ -179,22 +179,9 @@ public class GradleBuildScriptGenerator {
                     map.put("forceVersion", true);
                     map.put("versionOnly", version); // Version without : prefix for strictly()
                   } else {
-                    if (version != null && !version.isEmpty()) {
-                      map.put("version", ":" + version);
-                    }
+                    map.put("forceVersion", false);
                   }
-                  if (dep.getClassifier() != null && !dep.getClassifier().isEmpty()) {
-                    map.put("classifier", ":" + dep.getClassifier());
-                  } else {
-                    map.put("classifier", "");
-                  }
-                  if (dep.getExtension() != null
-                      && dep.getClassifier() != null
-                      && !dep.getClassifier().isEmpty()) {
-                    map.put("extension", "@" + dep.getExtension());
-                  } else {
-                    map.put("extension", "");
-                  }
+                  map.put("notation", renderDependencyNotation(dep, version));
 
                   if (dep.getExclusions() != null && !dep.getExclusions().isEmpty()) {
                     map.put(
@@ -231,5 +218,35 @@ public class GradleBuildScriptGenerator {
     // Render the template and write the actual build file
     String output = template.apply(Context.newContext(contextMap)).trim();
     Files.writeString(outputGradleBuildScript, output);
+  }
+
+  private static String renderDependencyNotation(GradleDependency dep, String version) {
+    String coordinate =
+        dep.getGroup()
+            + ":"
+            + dep.getArtifact()
+            + ((version != null && !version.isEmpty()) ? ":" + version : "");
+
+    if (isTestFixturesDependency(dep)) {
+      return "testFixtures(\"" + coordinate + "\")";
+    }
+
+    StringBuilder notation = new StringBuilder().append(coordinate);
+    if (dep.getClassifier() != null && !dep.getClassifier().isEmpty()) {
+      notation.append(":").append(dep.getClassifier());
+    }
+    if (dep.getExtension() != null
+        && dep.getClassifier() != null
+        && !dep.getClassifier().isEmpty()) {
+      notation.append("@").append(dep.getExtension());
+    }
+    return "\"" + notation + "\"";
+  }
+
+  private static boolean isTestFixturesDependency(GradleDependency dep) {
+    return "test-fixtures".equals(dep.getClassifier())
+        && (dep.getExtension() == null
+            || dep.getExtension().isEmpty()
+            || "jar".equals(dep.getExtension()));
   }
 }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -182,7 +182,7 @@ public class GradleResolver implements Resolver {
 
     for (GradleResolvedDependency dependency : implementationDependencies) {
       Set<Coordinates> visited = new HashSet<>();
-      for (GradleResolvedArtifact artifact : dependency.getArtifacts()) {
+      for (GradleResolvedArtifact artifact : artifactsForGraph(dependency)) {
         GradleCoordinates gradleCoordinates =
             new GradleCoordinatesImpl(
                 dependency.getGroup(),
@@ -337,6 +337,31 @@ public class GradleResolver implements Resolver {
     return group + ":" + artifact + ":" + version;
   }
 
+  // A feature variant's node identity comes from its classified artifacts. The module's POM
+  // carries no classifier, so including it here would coerce the node back to the unclassified
+  // coordinates and recreate the main artifact's node from the feature variant's dependency.
+  private List<GradleResolvedArtifact> artifactsForGraph(GradleResolvedDependency dependency) {
+    if (!dependency.isFeatureVariant()) {
+      return dependency.getArtifacts();
+    }
+    boolean hasNonPomArtifact =
+        dependency.getArtifacts().stream().anyMatch(artifact -> !isPomArtifact(artifact));
+    if (!hasNonPomArtifact) {
+      return dependency.getArtifacts();
+    }
+    return dependency.getArtifacts().stream()
+        .filter(artifact -> !isPomArtifact(artifact))
+        .collect(Collectors.toList());
+  }
+
+  private boolean isPomArtifact(GradleResolvedArtifact artifact) {
+    File file = artifact.getFile();
+    if (file != null && file.getName().endsWith(".pom")) {
+      return true;
+    }
+    return "pom".equals(artifact.getExtension());
+  }
+
   private void addDependency(
       MutableGraph<Coordinates> graph,
       Coordinates parent,
@@ -353,7 +378,7 @@ public class GradleResolver implements Resolver {
 
     if (parentInfo.getChildren() != null) {
       for (GradleResolvedDependency childInfo : parentInfo.getChildren()) {
-        for (GradleResolvedArtifact childArtifact : childInfo.getArtifacts()) {
+        for (GradleResolvedArtifact childArtifact : artifactsForGraph(childInfo)) {
           GradleCoordinates childCoordinates =
               new GradleCoordinatesImpl(
                   childInfo.getGroup(),
@@ -376,6 +401,12 @@ public class GradleResolver implements Resolver {
           // Track artifact for child node
           artifactsByNode.computeIfAbsent(child, k -> new ArrayList<>()).add(childArtifact);
           graph.addNode(child);
+          // A variant may depend on another variant of the same module (test fixtures depend on
+          // the main jar). When both alias to the same coordinates, drop the self edge: it says
+          // nothing useful and the lock file cannot express it.
+          if (parent.equals(child)) {
+            continue;
+          }
           graph.putEdge(parent, child);
           // if there's a conflict and the conflicting version isn't one that's actually requested
           // then it's an actual conflict we want to report

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs
@@ -27,7 +27,7 @@ dependencies {
     implementation platform("{{group}}:{{artifact}}:{{version}}")
 {{~/each}}
 {{~#each dependencies}}
-    implementation("{{group}}:{{artifact}}{{version}}{{~#if classifier}}{{classifier}}{{~/if}}{{~#if extension}}{{extension}}{{~/if}}"){{~#if exclusions}}{{~#if forceVersion}} {
+    implementation({{{notation}}}){{~#if exclusions}}{{~#if forceVersion}} {
 {{~#each exclusions}}
         exclude group: "{{group}}", module: "{{module}}"
 {{~/each}}

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedArtifact.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedArtifact.java
@@ -15,6 +15,7 @@
 package com.github.bazelbuild.rules_jvm_external.resolver.gradle.models;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 
 /** Represents a Maven artifact fetched by Gradle using the ArtifactView API */
@@ -24,6 +25,9 @@ public interface GradleResolvedArtifact {
   String getExtension();
 
   File getFile();
+
+  /** The capabilities of the variant this artifact belongs to, as "group:name" strings. */
+  List<String> getVariantCapabilities();
 
   // Currently unused, but can be used in the future to model gradle variants associated with
   // artifacts
@@ -35,6 +39,8 @@ public interface GradleResolvedArtifact {
   void setExtension(String extension);
 
   void setFile(File file);
+
+  void setVariantCapabilities(List<String> variantCapabilities);
 
   void setVariantAttributes(Map<String, String> variantAttributes);
 }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedArtifactImpl.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedArtifactImpl.java
@@ -16,12 +16,15 @@ package com.github.bazelbuild.rules_jvm_external.resolver.gradle.models;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class GradleResolvedArtifactImpl implements Serializable, GradleResolvedArtifact {
   private String classifier;
   private String extension;
   private File file;
+  private List<String> variantCapabilities = new ArrayList<>();
   private Map<String, String> variantAttributes;
 
   public GradleResolvedArtifactImpl() {}
@@ -38,6 +41,10 @@ public class GradleResolvedArtifactImpl implements Serializable, GradleResolvedA
     return this.file;
   }
 
+  public List<String> getVariantCapabilities() {
+    return variantCapabilities;
+  }
+
   public Map<String, String> getVariantAttributes() {
     return variantAttributes;
   }
@@ -52,6 +59,11 @@ public class GradleResolvedArtifactImpl implements Serializable, GradleResolvedA
 
   public void setFile(File file) {
     this.file = file;
+  }
+
+  public void setVariantCapabilities(List<String> variantCapabilities) {
+    this.variantCapabilities =
+        variantCapabilities == null ? new ArrayList<>() : new ArrayList<>(variantCapabilities);
   }
 
   public void setVariantAttributes(Map<String, String> variantAttributes) {

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedDependency.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedDependency.java
@@ -34,6 +34,22 @@ public interface GradleResolvedDependency {
 
   void setVersion(String version);
 
+  /**
+   * The capabilities of the variant this dependency was resolved from, as "group:name" strings. A
+   * variant with no explicitly declared capabilities carries the module's implicit capability.
+   */
+  List<String> getVariantCapabilities();
+
+  void setVariantCapabilities(List<String> variantCapabilities);
+
+  /**
+   * A feature variant provides capabilities other than the module's own implicit "group:name"
+   * capability. Test fixtures are the most common example.
+   *
+   * @return whether this dependency was resolved from a feature variant
+   */
+  boolean isFeatureVariant();
+
   Set<String> getRequestedVersions();
 
   void addRequestedVersion(String requestedVersion);

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedDependencyImpl.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models/GradleResolvedDependencyImpl.java
@@ -18,6 +18,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /** Represents a single dependency resolved by gradle */
@@ -25,6 +26,7 @@ public class GradleResolvedDependencyImpl implements Serializable, GradleResolve
   private String group;
   private String name;
   private String version;
+  private List<String> variantCapabilities = new ArrayList<>();
   private Set<String> requestedVersions;
   private boolean conflict;
   private List<GradleResolvedDependency> children;
@@ -59,6 +61,22 @@ public class GradleResolvedDependencyImpl implements Serializable, GradleResolve
 
   public void setVersion(String version) {
     this.version = version;
+  }
+
+  @Override
+  public List<String> getVariantCapabilities() {
+    return variantCapabilities;
+  }
+
+  @Override
+  public void setVariantCapabilities(List<String> variantCapabilities) {
+    this.variantCapabilities =
+        variantCapabilities == null ? new ArrayList<>() : new ArrayList<>(variantCapabilities);
+  }
+
+  @Override
+  public boolean isFeatureVariant() {
+    return !variantCapabilities.isEmpty() && !variantCapabilities.contains(group + ":" + name);
   }
 
   public Set<String> getRequestedVersions() {
@@ -105,6 +123,18 @@ public class GradleResolvedDependencyImpl implements Serializable, GradleResolve
 
   @Override
   public void addArtifact(GradleResolvedArtifact artifact) {
+    if (artifact.getFile() != null) {
+      for (GradleResolvedArtifact existing : artifacts) {
+        if (existing.getFile() != null
+            && existing.getFile().equals(artifact.getFile())
+            && Objects.equals(existing.getClassifier(), artifact.getClassifier())
+            && Objects.equals(existing.getExtension(), artifact.getExtension())
+            && Objects.equals(
+                existing.getVariantCapabilities(), artifact.getVariantCapabilities())) {
+          return;
+        }
+      }
+    }
     this.artifacts.add(artifact);
   }
 }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin/GradleDependencyModelBuilder.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/plugin/GradleDependencyModelBuilder.java
@@ -16,7 +16,6 @@ package com.github.bazelbuild.rules_jvm_external.resolver.gradle.plugin;
 
 import static com.github.bazelbuild.rules_jvm_external.resolver.PackagingMappings.mapPackagingToExtension;
 
-import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependency;
 import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependencyImpl;
 import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependencyModel;
@@ -31,6 +30,7 @@ import com.google.common.collect.Streams;
 import com.google.common.io.Files;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +57,7 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
@@ -89,12 +90,12 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
     // which contains the resolved dependency information from the tooling API, additionally it'll
     // also
     // be used to attach the actual artifacts later
-    ConcurrentHashMap<Coordinates, GradleResolvedDependency>
-        coordinatesGradleResolvedDependencyMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, GradleResolvedDependency> variantGradleResolvedDependencyMap =
+        new ConcurrentHashMap<>();
     // We get the root nodes in the dependency graph (or rather forest here since there can be
     // disjoint trees)
     List<GradleResolvedDependency> resolvedRoots =
-        collectResolvedDependencies(cfg, coordinatesGradleResolvedDependencyMap);
+        collectResolvedDependencies(cfg, variantGradleResolvedDependencyMap);
 
     // Collect any unresolved dependencies from the runtimeClasspath configuration
     List<GradleUnresolvedDependency> unresolvedDependenciesRuntimeClasspath =
@@ -135,7 +136,7 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
     // build the updated dependency graph with the detached configuration for all the
     // dependencies that we couldn't resolve with the default configuration
     List<GradleResolvedDependency> resolvedDetachedRoots =
-        resolveDetachedGraph(detachedCfg, coordinatesGradleResolvedDependencyMap);
+        resolveDetachedGraph(detachedCfg, variantGradleResolvedDependencyMap);
 
     List<GradleResolvedDependency> roots =
         Streams.concat(resolvedRoots.stream(), resolvedDetachedRoots.stream())
@@ -144,7 +145,7 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
     // The ArtifactView API doesn't download some of the classifiers by default, so we handle that
     // here
     collectAllResolvedArtifacts(
-        project, cfg, detachedCfg, roots, coordinatesGradleResolvedDependencyMap, declaredDeps);
+        project, cfg, detachedCfg, variantGradleResolvedDependencyMap, declaredDeps);
     gradleDependencyModel.getResolvedDependencies().addAll(roots);
 
     // if anything is still unresolved, then add it for reporting
@@ -156,9 +157,8 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
 
   private List<GradleResolvedDependency> resolveDetachedGraph(
       Configuration detachedCfg,
-      ConcurrentHashMap<Coordinates, GradleResolvedDependency>
-          coordinatesGradleResolvedDependencyMap) {
-    return collectResolvedDependencies(detachedCfg, coordinatesGradleResolvedDependencyMap);
+      ConcurrentHashMap<String, GradleResolvedDependency> variantGradleResolvedDependencyMap) {
+    return collectResolvedDependencies(detachedCfg, variantGradleResolvedDependencyMap);
   }
 
   private List<GradleDependency> collectDeclaredDependencies(Configuration cfg) {
@@ -204,8 +204,7 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
   }
 
   private List<GradleResolvedDependency> collectResolvedDependencies(
-      Configuration cfg,
-      ConcurrentMap<Coordinates, GradleResolvedDependency> coordinatesGradleResolvedDependencyMap) {
+      Configuration cfg, ConcurrentMap<String, GradleResolvedDependency> variantDependencyMap) {
     List<GradleResolvedDependency> resolvedRoots = new ArrayList<>();
     ResolutionResult result = cfg.getIncoming().getResolutionResult();
     ResolvedComponentResult root = result.getRoot();
@@ -233,11 +232,15 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
           continue;
         }
 
-        Set<ComponentIdentifier> visited = new HashSet<>();
+        Set<String> visited = new HashSet<>();
         // walk the resolved component graph in depth-first manner
         // and collect all the resolved dependencies
         GradleResolvedDependency info =
-            walkResolvedComponent(selected, visited, coordinatesGradleResolvedDependencyMap, 1);
+            walkResolvedVariant(
+                selected, rdep.getResolvedVariant(), visited, variantDependencyMap, 1);
+        if (info == null) {
+          continue;
+        }
         if (rdep.getRequested() instanceof ModuleComponentSelector) {
           String requested = ((ModuleComponentSelector) rdep.getRequested()).getVersion();
           info.addRequestedVersion(requested);
@@ -295,45 +298,45 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
     return unresolvedDependencies;
   }
 
-  private GradleResolvedDependency walkResolvedComponent(
+  private GradleResolvedDependency walkResolvedVariant(
       ResolvedComponentResult component,
-      Set<ComponentIdentifier> visited,
-      Map<Coordinates, GradleResolvedDependency> coordinatesGradleResolvedDependencyMap,
+      ResolvedVariantResult variant,
+      Set<String> visited,
+      Map<String, GradleResolvedDependency> variantDependencyMap,
       int depth) {
-    Coordinates coordinates =
-        new Coordinates(
-            component.getModuleVersion().getGroup()
-                + ":"
-                + component.getModuleVersion().getName()
-                + ":"
-                + component.getModuleVersion().getVersion());
+    if (variant == null) {
+      return null;
+    }
+    String key = variantKey(component, variant);
 
     // Handle cycles as they can exist in resolution
-    if (visited.contains(component.getId())) {
-      return coordinatesGradleResolvedDependencyMap.get(coordinates);
+    if (visited.contains(key)) {
+      return variantDependencyMap.get(key);
     }
 
-    visited.add(component.getId());
+    visited.add(key);
     if (isVerbose()) {
-      System.err.println("  ".repeat(depth) + "→ " + coordinates);
+      System.err.println(
+          "  ".repeat(depth)
+              + "→ "
+              + componentKey(component)
+              + " ["
+              + variant.getDisplayName()
+              + "]");
     }
 
     // We might visit the same node multiple times through the graph, so check if we've visited
     // node before
-    GradleResolvedDependency info = coordinatesGradleResolvedDependencyMap.get(coordinates);
+    GradleResolvedDependency info = variantDependencyMap.get(key);
     if (info == null) {
-      // this is a new artifact yet unvisited
-      info = new GradleResolvedDependencyImpl();
-      info.setGroup(component.getModuleVersion().getGroup());
-      info.setName(component.getModuleVersion().getName());
-      info.setVersion(component.getModuleVersion().getVersion());
+      info = createResolvedVariant(component, variant);
     }
 
     info.addRequestedVersion(info.getVersion()); // add a new version that may have been requested
 
     List<GradleResolvedDependency> children = new ArrayList<>();
 
-    for (DependencyResult dep : component.getDependencies()) {
+    for (DependencyResult dep : component.getDependenciesForVariant(variant)) {
       if (!(dep instanceof ResolvedDependencyResult)) {
         continue;
       }
@@ -349,8 +352,8 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
       }
 
       GradleResolvedDependency child =
-          walkResolvedComponent(
-              selected, visited, coordinatesGradleResolvedDependencyMap, depth + 1);
+          walkResolvedVariant(
+              selected, resolvedDep.getResolvedVariant(), visited, variantDependencyMap, depth + 1);
       if (child == null) {
         continue;
       }
@@ -376,7 +379,7 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
 
     info.setChildren(children);
     info.setConflict(info.getRequestedVersions().size() > 1);
-    coordinatesGradleResolvedDependencyMap.put(coordinates, info);
+    variantDependencyMap.put(key, info);
     return info;
   }
 
@@ -415,9 +418,10 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
       Project project,
       Configuration runtimeClassPathCfg,
       Configuration detachedCfg,
-      List<GradleResolvedDependency> resolvedRoots,
-      Map<Coordinates, GradleResolvedDependency> coordinatesMap,
+      Map<String, GradleResolvedDependency> variantDependencyMap,
       List<GradleDependency> declaredDeps) {
+    Map<String, List<GradleResolvedDependency>> dependenciesByComponent =
+        indexByComponent(variantDependencyMap.values());
 
     // Collect JAR artifacts - we need to check both JAVA_API and JAVA_RUNTIME because some
     // libraries (like resilience4j) only publish runtime variants, while others might only
@@ -449,8 +453,8 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
                 });
 
     // collect JAR artifacts from both views
-    collectArtifactsFromArtifactView(apiJars, coordinatesMap);
-    collectArtifactsFromArtifactView(runtimeJars, coordinatesMap);
+    collectArtifactsFromArtifactView(apiJars, dependenciesByComponent);
+    collectArtifactsFromArtifactView(runtimeJars, dependenciesByComponent);
 
     ArtifactView aarView =
         detachedCfg
@@ -471,7 +475,7 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
                 });
 
     // Collect Android artifacts  (AARs)
-    collectArtifactsFromArtifactView(aarView, coordinatesMap);
+    collectArtifactsFromArtifactView(aarView, dependenciesByComponent);
 
     // Also collect JARs from the detached configuration, as it contains resolved versions
     // of dependencies that failed in the main runtimeClasspath (e.g. due to missing versions
@@ -500,87 +504,42 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
                               Usage.USAGE_ATTRIBUTE,
                               project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME)));
                 });
-    collectArtifactsFromArtifactView(detachedApiJars, coordinatesMap);
-    collectArtifactsFromArtifactView(detachedRuntimeJars, coordinatesMap);
+    collectArtifactsFromArtifactView(detachedApiJars, dependenciesByComponent);
+    collectArtifactsFromArtifactView(detachedRuntimeJars, dependenciesByComponent);
 
     // Collect POM files explicitly as gradle doesn't fetch them unless requested
-    collectPOMsForAllComponents(project, resolvedRoots, coordinatesMap, declaredDeps);
+    collectPOMsForAllComponents(project, dependenciesByComponent, declaredDeps);
     // Don't collect conflicting version artifacts - we only need artifacts for the resolved graph
     // The conflicts are tracked for reporting purposes only, we don't need to download rejected
     // versions
   }
 
-  private void collectConflictingVersionArtifacts(
-      Project project,
-      Map<Coordinates, GradleResolvedDependency> coordinatesGradleResolvedDependencyMap) {
-    for (Map.Entry<Coordinates, GradleResolvedDependency> entry :
-        coordinatesGradleResolvedDependencyMap.entrySet()) {
-      GradleResolvedDependency dependency = entry.getValue();
-      // Skip if no conflicts, or if dependency already has artifacts from main resolution
-      // (collecting via detached config would bypass resolutionStrategy and override force_version)
-      if (dependency.getRequestedVersions().size() <= 1) {
-        continue;
-      }
-      if (!dependency.getArtifacts().isEmpty()) {
-        continue; // Already has artifacts, don't re-resolve in detached config
-      }
-      {
-        dependency
-            .getRequestedVersions()
-            .forEach(
-                version -> {
-                  Coordinates coordinates =
-                      new Coordinates(
-                          dependency.getGroup() + ":" + dependency.getName() + ":" + version);
-
-                  Dependency dep = project.getDependencies().create(coordinates + "@jar");
-
-                  Configuration jarCfg = project.getConfigurations().detachedConfiguration(dep);
-
-                  ArtifactView view =
-                      jarCfg
-                          .getIncoming()
-                          .artifactView(
-                              spec -> {
-                                spec.setLenient(true); // avoid failure if a POM is missing
-                              });
-
-                  for (ResolvedArtifactResult artifact : view.getArtifacts().getArtifacts()) {
-                    GradleResolvedArtifact resolvedArtifact = new GradleResolvedArtifactImpl();
-                    if (artifact.getFile() != null) {
-                      resolvedArtifact.setFile(artifact.getFile());
-                      GradleResolvedDependency resolvedDependency =
-                          coordinatesGradleResolvedDependencyMap.get(entry.getKey());
-                      synchronized (resolvedDependency) {
-                        resolvedDependency.addArtifact(resolvedArtifact);
-                      }
-                    }
-                  }
-                });
-      }
-    }
-  }
-
   private void collectArtifactsFromArtifactView(
       ArtifactView artifactView,
-      Map<Coordinates, GradleResolvedDependency> coordinatesGradleResolvedDependencyMap) {
+      Map<String, List<GradleResolvedDependency>> dependenciesByComponent) {
     Set<ResolvedArtifactResult> resolvedArtifactResults =
         artifactView.getArtifacts().getArtifacts();
     for (ResolvedArtifactResult artifact : resolvedArtifactResults) {
       ComponentIdentifier identifier = artifact.getId().getComponentIdentifier();
+      if (!(identifier instanceof ModuleComponentIdentifier)) {
+        continue;
+      }
       ModuleComponentIdentifier module = (ModuleComponentIdentifier) identifier;
       if (artifact.getFile() != null) {
         GradleResolvedArtifact resolvedArtifact = new GradleResolvedArtifactImpl();
         resolvedArtifact.setFile(artifact.getFile());
         resolvedArtifact.setClassifier(extractClassifier(artifact.getFile(), identifier));
+        if (artifact.getVariant() != null) {
+          resolvedArtifact.setVariantCapabilities(capabilityKeys(artifact.getVariant()));
+        }
         String fileExtension = Files.getFileExtension(artifact.getFile().getName());
         resolvedArtifact.setExtension(mapPackagingToExtension(fileExtension));
 
-        Coordinates coordinates =
-            new Coordinates(
-                module.getGroup() + ":" + module.getModule() + ":" + module.getVersion());
         GradleResolvedDependency resolvedDependency =
-            coordinatesGradleResolvedDependencyMap.get(coordinates);
+            findOwningDependency(
+                dependenciesByComponent,
+                componentKey(module.getGroup(), module.getModule(), module.getVersion()),
+                resolvedArtifact.getVariantCapabilities());
         if (resolvedDependency != null) {
           synchronized (resolvedDependency) {
             resolvedDependency.addArtifact(resolvedArtifact);
@@ -592,15 +551,18 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
 
   private void collectPOMsForAllComponents(
       Project project,
-      List<GradleResolvedDependency> resolvedRoots,
-      Map<Coordinates, GradleResolvedDependency> coordinatesResolvedDependencyMap,
+      Map<String, List<GradleResolvedDependency>> dependenciesByComponent,
       List<GradleDependency> declaredDeps) {
 
     ArtifactResolutionQuery query = project.getDependencies().createArtifactResolutionQuery();
     query.withArtifacts(MavenModule.class, MavenPomArtifact.class);
 
     boolean hasItems = false;
-    for (GradleResolvedDependency dependency : coordinatesResolvedDependencyMap.values()) {
+    for (List<GradleResolvedDependency> variants : dependenciesByComponent.values()) {
+      GradleResolvedDependency dependency = choosePomCarrier(variants);
+      if (dependency == null) {
+        continue;
+      }
       boolean isDeclaredWithExplicitExtension =
           declaredDeps.stream()
               .anyMatch(
@@ -633,11 +595,10 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
         continue;
       }
       ModuleComponentIdentifier module = (ModuleComponentIdentifier) id;
-      Coordinates coordinates =
-          new Coordinates(module.getGroup() + ":" + module.getModule() + ":" + module.getVersion());
-
-      GradleResolvedDependency resolvedDependency =
-          coordinatesResolvedDependencyMap.get(coordinates);
+      List<GradleResolvedDependency> dependencies =
+          dependenciesByComponent.get(
+              componentKey(module.getGroup(), module.getModule(), module.getVersion()));
+      GradleResolvedDependency resolvedDependency = choosePomCarrier(dependencies);
       if (resolvedDependency == null) {
         continue;
       }
@@ -650,11 +611,117 @@ public class GradleDependencyModelBuilder implements ToolingModelBuilder {
             resolvedArtifact.setFile(resolvedArtifactResult.getFile());
             String packaging = PomUtil.extractPackagingFromPom(resolvedArtifactResult.getFile());
             resolvedArtifact.setExtension(mapPackagingToExtension(packaging));
+            resolvedArtifact.setVariantCapabilities(resolvedDependency.getVariantCapabilities());
             resolvedDependency.addArtifact(resolvedArtifact);
           }
         }
       }
     }
+  }
+
+  private String componentKey(ResolvedComponentResult component) {
+    return componentKey(
+        component.getModuleVersion().getGroup(),
+        component.getModuleVersion().getName(),
+        component.getModuleVersion().getVersion());
+  }
+
+  private String componentKey(String group, String module, String version) {
+    return group + ":" + module + ":" + version;
+  }
+
+  private String componentKey(GradleResolvedDependency dependency) {
+    return componentKey(dependency.getGroup(), dependency.getName(), dependency.getVersion());
+  }
+
+  // The display name distinguishes every selected variant of a component within a single
+  // resolution, which is exactly the granularity the graph walk needs.
+  private String variantKey(ResolvedComponentResult component, ResolvedVariantResult variant) {
+    return componentKey(component) + "::" + variant.getDisplayName();
+  }
+
+  private List<String> capabilityKeys(ResolvedVariantResult variant) {
+    return variant.getCapabilities().stream()
+        .map(capability -> capability.getGroup() + ":" + capability.getName())
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  private GradleResolvedDependency createResolvedVariant(
+      ResolvedComponentResult component, ResolvedVariantResult variant) {
+    GradleResolvedDependency info = new GradleResolvedDependencyImpl();
+    info.setGroup(component.getModuleVersion().getGroup());
+    info.setName(component.getModuleVersion().getName());
+    info.setVersion(component.getModuleVersion().getVersion());
+    info.setVariantCapabilities(capabilityKeys(variant));
+    return info;
+  }
+
+  private Map<String, List<GradleResolvedDependency>> indexByComponent(
+      Iterable<GradleResolvedDependency> dependencies) {
+    Map<String, List<GradleResolvedDependency>> grouped = new HashMap<>();
+    for (GradleResolvedDependency dependency : dependencies) {
+      grouped
+          .computeIfAbsent(componentKey(dependency), unused -> new ArrayList<>())
+          .add(dependency);
+    }
+    return grouped;
+  }
+
+  private GradleResolvedDependency findOwningDependency(
+      Map<String, List<GradleResolvedDependency>> dependenciesByComponent,
+      String componentKey,
+      List<String> artifactCapabilities) {
+    List<GradleResolvedDependency> dependencies = dependenciesByComponent.get(componentKey);
+    if (dependencies == null || dependencies.isEmpty()) {
+      return null;
+    }
+
+    // Capabilities are variant identity: api and runtime flavours of the same variant share
+    // them, so artifacts from either artifact view land on the node the graph walk created.
+    if (!artifactCapabilities.isEmpty()) {
+      for (GradleResolvedDependency dependency : dependencies) {
+        if (artifactCapabilities.equals(dependency.getVariantCapabilities())) {
+          return dependency;
+        }
+      }
+    }
+
+    for (GradleResolvedDependency dependency : dependencies) {
+      if (!dependency.isFeatureVariant()) {
+        return dependency;
+      }
+    }
+
+    return dependencies.get(0);
+  }
+
+  private GradleResolvedDependency choosePomCarrier(List<GradleResolvedDependency> dependencies) {
+    if (dependencies == null || dependencies.isEmpty()) {
+      return null;
+    }
+
+    for (GradleResolvedDependency dependency : dependencies) {
+      boolean hasUnclassifiedBinary =
+          dependency.getArtifacts().stream()
+              .anyMatch(
+                  artifact ->
+                      artifact.getFile() != null
+                          && !artifact.getFile().getName().endsWith(".pom")
+                          && (artifact.getClassifier() == null
+                              || artifact.getClassifier().isEmpty()));
+      if (hasUnclassifiedBinary) {
+        return dependency;
+      }
+    }
+
+    for (GradleResolvedDependency dependency : dependencies) {
+      if (!dependency.isFeatureVariant()) {
+        return dependency;
+      }
+    }
+
+    return dependencies.get(0);
   }
 
   private boolean isVerbose() {

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/MavenRepo.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/MavenRepo.java
@@ -83,6 +83,18 @@ public class MavenRepo {
     }
   }
 
+  public MavenRepo addArtifactOnly(Coordinates coords) {
+    try {
+      if (!"pom".equals(coords.getExtension())) {
+        writeFile(coords);
+      }
+
+      return this;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
   public MavenRepo writeMavenMetadata(
       String groupId, String artifactId, String releaseVersion, List<String> versions) {
     try {

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
@@ -16,6 +16,37 @@ java_test(
 )
 
 java_test(
+    name = "GradleResolvedDependencyImplTest",
+    srcs = ["GradleResolvedDependencyImplTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.gradle.GradleResolvedDependencyImplTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+    ],
+)
+
+java_test(
+    name = "GradleBuildScriptGeneratorTestFixturesTest",
+    srcs = ["GradleBuildScriptGeneratorTestFixturesTest.java"],
+    data = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data:gradle_build_templates",
+    ],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.gradle.GradleBuildScriptGeneratorTestFixturesTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+        "@bazel_tools//tools/java/runfiles",
+    ],
+)
+
+java_test(
     name = "GradleResolverTest",
     timeout = "eternal",
     srcs = [

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGeneratorTestFixturesTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGeneratorTestFixturesTest.java
@@ -1,0 +1,79 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.gradle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependency;
+import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependencyImpl;
+import com.google.devtools.build.runfiles.AutoBazelRepository;
+import com.google.devtools.build.runfiles.Runfiles;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Test;
+
+@AutoBazelRepository
+public class GradleBuildScriptGeneratorTestFixturesTest {
+
+  @Test
+  public void testFixturesClassifierUsesGradleTestFixturesNotation() throws Exception {
+    String script =
+        renderBuildScript(
+            List.of(
+                new GradleDependencyImpl(
+                    "com.example", "sample", "1.0", List.of(), "test-fixtures", "jar")));
+
+    assertTrue(script.contains("implementation(testFixtures(\"com.example:sample:1.0\"))"));
+    assertFalse(script.contains("com.example:sample:1.0:test-fixtures@jar"));
+  }
+
+  @Test
+  public void nonTestFixturesClassifierUsesClassifierNotation() throws Exception {
+    String script =
+        renderBuildScript(
+            List.of(
+                new GradleDependencyImpl(
+                    "com.example", "sample", "1.0", List.of(), "sources", "jar")));
+
+    assertTrue(script.contains("implementation(\"com.example:sample:1.0:sources@jar\")"));
+  }
+
+  private String renderBuildScript(List<GradleDependency> dependencies) throws Exception {
+    Runfiles runfiles =
+        Runfiles.preload()
+            .withSourceRepository(
+                AutoBazelRepository_GradleBuildScriptGeneratorTestFixturesTest.NAME);
+    Path template =
+        Paths.get(
+            runfiles.rlocation(
+                "rules_jvm_external/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs"));
+    Path output = Files.createTempFile("rje-build-script", ".gradle");
+
+    GradleBuildScriptGenerator.generateBuildScript(
+        template,
+        output,
+        List.of(new Repository(URI.create("https://repo1.maven.org/maven2"))),
+        dependencies,
+        List.of(),
+        List.of(),
+        false);
+
+    return Files.readString(output);
+  }
+}

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolvedDependencyImplTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolvedDependencyImplTest.java
@@ -1,0 +1,58 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.gradle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleResolvedDependencyImpl;
+import java.util.List;
+import org.junit.Test;
+
+public class GradleResolvedDependencyImplTest {
+
+  @Test
+  public void variantWithNoCapabilitiesIsNotAFeatureVariant() {
+    assertFalse(dependencyWithCapabilities(List.of()).isFeatureVariant());
+  }
+
+  @Test
+  public void variantWithOnlyTheImplicitCapabilityIsNotAFeatureVariant() {
+    assertFalse(dependencyWithCapabilities(List.of("com.example:sample")).isFeatureVariant());
+  }
+
+  @Test
+  public void variantWithADifferentCapabilityIsAFeatureVariant() {
+    assertTrue(
+        dependencyWithCapabilities(List.of("com.example:sample-test-fixtures")).isFeatureVariant());
+  }
+
+  @Test
+  public void variantDeclaringTheImplicitCapabilityAlongsideOthersIsNotAFeatureVariant() {
+    assertFalse(
+        dependencyWithCapabilities(
+                List.of("com.example:sample", "com.example:sample-test-fixtures"))
+            .isFeatureVariant());
+  }
+
+  private GradleResolvedDependencyImpl dependencyWithCapabilities(List<String> capabilities) {
+    GradleResolvedDependencyImpl dependency = new GradleResolvedDependencyImpl();
+    dependency.setGroup("com.example");
+    dependency.setName("sample");
+    dependency.setVersion("1.0");
+    dependency.setVariantCapabilities(capabilities);
+    return dependency;
+  }
+}

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolverTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolverTest.java
@@ -340,6 +340,54 @@ public class GradleResolverTest extends ResolverTestBase {
   }
 
   @Test
+  public void resolvesTestFixturesVariantWithDistinctDependenciesAndNoCycles()
+      throws IOException, XMLStreamException {
+    Coordinates sampleCoordinates = new Coordinates("com.example:sample:1.0");
+    Coordinates sampleTestFixturesCoordinates =
+        new Coordinates("com.example:sample:jar:test-fixtures:1.0");
+    Coordinates mainDepCoordinates = new Coordinates("com.example:main-dep:1.0");
+    Coordinates testFixturesDepCoordinates = new Coordinates("com.example:tf-dep:1.0");
+
+    MavenRepo mavenRepo =
+        MavenRepo.create().add(mainDepCoordinates).add(testFixturesDepCoordinates);
+    GradleModuleMetadataHelper moduleMetadataHelper = new GradleModuleMetadataHelper(mavenRepo);
+
+    Runfiles runfiles =
+        Runfiles.preload().withSourceRepository(AutoBazelRepository_GradleResolverTest.NAME);
+    Path metadataPath =
+        Paths.get(
+            runfiles.rlocation(
+                "rules_jvm_external/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/testFixturesVariant/sample-1.0.module"));
+    moduleMetadataHelper.addToMavenRepo(sampleCoordinates, Files.readString(metadataPath));
+
+    // The base helper only creates the main jar. Add just the classified artifact here; using
+    // add(...) would rewrite sample-1.0.pom and strip the Gradle metadata marker that makes
+    // variant-aware resolution work.
+    mavenRepo.addArtifactOnly(sampleTestFixturesCoordinates);
+
+    Graph<Coordinates> resolved =
+        resolver
+            .resolve(
+                prepareRequestFor(
+                    mavenRepo.getPath().toUri(), sampleCoordinates, sampleTestFixturesCoordinates))
+            .getResolution();
+
+    assertTrue(resolved.nodes().contains(sampleCoordinates));
+    assertTrue(resolved.nodes().contains(sampleTestFixturesCoordinates));
+    assertTrue(resolved.nodes().contains(mainDepCoordinates));
+    assertTrue(resolved.nodes().contains(testFixturesDepCoordinates));
+
+    assertEquals(Set.of(mainDepCoordinates), resolved.successors(sampleCoordinates));
+    assertEquals(
+        Set.of(sampleCoordinates, testFixturesDepCoordinates),
+        resolved.successors(sampleTestFixturesCoordinates));
+    assertFalse(resolved.successors(sampleCoordinates).contains(sampleCoordinates));
+    assertFalse(resolved.successors(sampleCoordinates).contains(sampleTestFixturesCoordinates));
+    assertFalse(
+        resolved.successors(sampleTestFixturesCoordinates).contains(sampleTestFixturesCoordinates));
+  }
+
+  @Test
   public void shouldRecordCorrectShaForResolvedVersionNotConflictingVersion() {
     // When there's a version conflict, the paths map should contain only the resolved version,
     // not the conflicting lower version. This ensures we record the correct SHA for the artifact.

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/BUILD
@@ -8,6 +8,7 @@ filegroup(
         "jvmAndAndroidVariants/sample-jvm-1.0.module",
         "simpleJvmVariant/sample-1.0.module",
         "simpleJvmVariant/sample-jvm-1.0.module",
+        "testFixturesVariant/sample-1.0.module",
     ],
     visibility = ["//tests/com/github/bazelbuild/rules_jvm_external:__subpackages__"],
 )

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/testFixturesVariant/sample-1.0.module
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/testFixturesVariant/sample-1.0.module
@@ -1,0 +1,141 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "sample",
+    "version": "1.0",
+    "attributes": { "org.gradle.status": "release" }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.environment": "standard-jvm",
+        "org.gradle.jvm.version": 11,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "main-dep",
+          "version": { "requires": "1.0" }
+        }
+      ],
+      "files": [
+        {
+          "name": "sample-1.0.jar",
+          "url": "sample-1.0.jar",
+          "size": 100,
+          "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "md5": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.environment": "standard-jvm",
+        "org.gradle.jvm.version": 11,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "main-dep",
+          "version": { "requires": "1.0" }
+        }
+      ],
+      "files": [
+        {
+          "name": "sample-1.0.jar",
+          "url": "sample-1.0.jar",
+          "size": 100,
+          "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "md5": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ]
+    },
+    {
+      "name": "testFixturesApiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 11,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "sample",
+          "version": { "requires": "1.0" }
+        },
+        {
+          "group": "com.example",
+          "module": "tf-dep",
+          "version": { "requires": "1.0" }
+        }
+      ],
+      "files": [
+        {
+          "name": "sample-1.0-test-fixtures.jar",
+          "url": "sample-1.0-test-fixtures.jar",
+          "size": 100,
+          "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "md5": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "capabilities": [
+        {
+          "group": "com.example",
+          "name": "sample-test-fixtures",
+          "version": "1.0"
+        }
+      ]
+    },
+    {
+      "name": "testFixturesRuntimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 11,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "sample",
+          "version": { "requires": "1.0" }
+        },
+        {
+          "group": "com.example",
+          "module": "tf-dep",
+          "version": { "requires": "1.0" }
+        }
+      ],
+      "files": [
+        {
+          "name": "sample-1.0-test-fixtures.jar",
+          "url": "sample-1.0-test-fixtures.jar",
+          "size": 100,
+          "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "md5": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "capabilities": [
+        {
+          "group": "com.example",
+          "name": "sample-test-fixtures",
+          "version": "1.0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The Gradle resolver was flattening selected variants of the same module into one dependency node. When a module is resolved as both its main jar and test fixtures, that can merge dependency sets and create incorrect edges or self-cycles.

We now:
- Preserve Gradle variant identity while walking resolved dependency graphs
- Resolve requested `test-fixtures` classifiers through Gradle's `testFixtures(...)` notation
- Attach artifacts and POMs to the matching resolved variant
- Add build-script generator coverage and a Gradle resolver fixture for distinct test-fixtures deps

🤖 Generated by my AI agent
