### PR TITLE
Run jvm_import jar tools with exec Java

### DIFF
--- a/private/rules/jvm_import.bzl
+++ b/private/rules/jvm_import.bzl
@@ -7,7 +7,7 @@
 # [0]: https://github.com/square/bazel_maven_repository/pull/48
 # [1]: https://github.com/bazelbuild/bazel/issues/4549
 
-load("@compatibility_proxy//:proxy.bzl", "JavaInfo")
+load("@compatibility_proxy//:proxy.bzl", "JavaInfo", "java_common")
 load("@rules_license//rules:providers.bzl", "PackageInfo")
 load("//private/lib:coordinates.bzl", "to_external_form", "to_purl", "unpack_coordinates")
 load("//private/lib:urls.bzl", "scheme_and_host")
@@ -26,6 +26,8 @@ def _jvm_import_impl(ctx):
     if not ctx.attr.jar:
         print(ctx.attr.name, "The `jars` attribute is deprecated and will be removed in `rules_jvm_external` 7.0. Please use the `jar` attribute instead.")
 
+    java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
+    add_jar_manifest_entry = ctx.file._add_jar_manifest_entry
     injar = ctx.file.jar if ctx.attr.jar else ctx.files.jars[0]
 
     if ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:
@@ -33,11 +35,14 @@ def _jvm_import_impl(ctx):
         args = ctx.actions.args()
         args.add_all(["--source", injar, "--output", outjar])
         args.add("--manifest-entry", ctx.label, format = "Target-Label:%s")
+        java_args = ctx.actions.args()
+        java_args.add_all(["-jar", add_jar_manifest_entry])
         ctx.actions.run(
-            executable = ctx.executable._add_jar_manifest_entry,
-            arguments = [args],
+            executable = java_runtime.java_executable_exec_path,
+            arguments = [java_args, args],
             inputs = [injar],
             outputs = [outjar],
+            tools = [add_jar_manifest_entry, java_runtime.files],
             mnemonic = "StampJarManifest",
             progress_message = "Stamping the manifest of %{label}",
         )
@@ -59,13 +64,16 @@ def _jvm_import_impl(ctx):
     # Make sure the compile jar is safe to compile with
     args.add("--make-safe")
 
+    java_args = ctx.actions.args()
+    java_args.add_all(["-jar", add_jar_manifest_entry])
     ctx.actions.run(
-        executable = ctx.executable._add_jar_manifest_entry,
-        arguments = [args],
+        executable = java_runtime.java_executable_exec_path,
+        arguments = [java_args, args],
         inputs = [outjar],
         outputs = [compilejar],
+        tools = [add_jar_manifest_entry, java_runtime.files],
         mnemonic = "CreateCompileJar",
-        progress_message = "Creating compile jar for %s" % ctx.label,
+        progress_message = "Creating compile jar for %{label}",
     )
 
     additional_providers = []
@@ -129,9 +137,14 @@ jvm_import = rule(
             doc = "URL from where `jar` will be downloaded from.",
         ),
         "_add_jar_manifest_entry": attr.label(
-            executable = True,
+            allow_single_file = True,
             cfg = "exec",
-            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry",
+            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry_deploy.jar",
+        ),
+        "_java_runtime": attr.label(
+            default = "@rules_java//toolchains:current_java_runtime",
+            providers = [java_common.JavaRuntimeInfo],
+            cfg = "exec",
         ),
         "_stamp_manifest": attr.label(
             default = "@rules_jvm_external//settings:stamp_manifest",

--- a/tests/unit/jvm_import/BUILD
+++ b/tests/unit/jvm_import/BUILD
@@ -16,6 +16,14 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_java//java:java_import.bzl", "java_import")
 load(":jvm_import_test.bzl", "jvm_import_test_suite")
 
+platform(
+    name = "android_s390x_target_platform",
+    constraint_values = [
+        "@platforms//cpu:s390x",
+        "@platforms//os:android",
+    ],
+)
+
 java_import(
     name = "java_import_that_consumes_the_downloaded_file_directly",
     # Will produce an error if the downloaded file does not have the `.jar` file extension

--- a/tests/unit/jvm_import/jvm_import_test.bzl
+++ b/tests/unit/jvm_import/jvm_import_test.bzl
@@ -140,6 +140,30 @@ does_jvm_import_export_a_package_provider_test = analysistest.make(
     },
 )
 
+def _jvm_import_uses_execution_platform_java_runtime_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    actions = analysistest.target_actions(env)
+    for mnemonic in ["StampJarManifest", "CreateCompileJar"]:
+        matching_actions = [action for action in actions if action.mnemonic == mnemonic]
+        asserts.equals(env, 1, len(matching_actions))
+
+        argv = matching_actions[0].argv
+        asserts.true(env, "remotejdk11_" in argv[0], "Expected %s to use the execution-platform Java runtime, got %s" % (mnemonic, argv[0]))
+        asserts.true(env, "-jar" in argv)
+        deploy_jar_args = [arg for arg in argv if arg.endswith("AddJarManifestEntry_deploy.jar")]
+        asserts.equals(env, 1, len(deploy_jar_args))
+
+    return analysistest.end(env)
+
+jvm_import_uses_execution_platform_java_runtime_test = analysistest.make(
+    _jvm_import_uses_execution_platform_java_runtime_impl,
+    config_settings = {
+        "//command_line_option:platforms": "@@//tests/unit/jvm_import:android_s390x_target_platform",
+        "//command_line_option:tool_java_runtime_version": "remotejdk_11",
+    },
+)
+
 def _does_non_jvm_import_target_carry_metadata(ctx):
     env = analysistest.begin(ctx)
 
@@ -178,6 +202,10 @@ def jvm_import_test_suite(name):
         target_under_test = "@jvm_import_test//:com_google_code_findbugs_jsr305",
         src = "@jvm_import_test//:com_google_code_findbugs_jsr305",
     )
+    jvm_import_uses_execution_platform_java_runtime_test(
+        name = "jvm_import_uses_execution_platform_java_runtime_test",
+        target_under_test = "@jvm_import_test//:com_google_code_findbugs_jsr305_3_0_2",
+    )
 
     # TODO: restore once https://github.com/bazelbuild/rules_license/issues/154 is resolved
     #    does_non_jvm_import_target_carry_metadata_test(
@@ -189,5 +217,6 @@ def jvm_import_test_suite(name):
         name = name,
         tests = [
             ":does_jvm_import_have_tags_test",
+            ":jvm_import_uses_execution_platform_java_runtime_test",
         ],
     )


### PR DESCRIPTION
## Summary

- invoke `AddJarManifestEntry_deploy.jar` with `current_java_runtime` in the exec configuration instead of executing the generated `AddJarManifestEntry` launcher
- declare `AddJarManifestEntry_deploy.jar` and `JavaRuntimeInfo.files` as action tools
- add `jvm_import_uses_execution_platform_java_runtime_test` with an Android s390x target platform

## Context

This restores the intent of [#1059](https://github.com/bazel-contrib/rules_jvm_external/pull/1059), which was reverted by [#1061](https://github.com/bazel-contrib/rules_jvm_external/pull/1061) because downstream Bazel could select a tool Java runtime with command-line flags. The generated `java_binary` launcher is still unsuitable when the host and execution operating systems differ: a Windows host can attempt to execute the Bash launcher before Java starts.

Invoking `AddJarManifestEntry_deploy.jar` avoids the Bash launcher. `runtime_toolchain_type` cannot be resolved directly by `jvm_import`, because Java runtime toolchains are constrained by the target platform. In [bazelbuild/bazel#29764](https://github.com/bazelbuild/bazel/pull/29764), a Windows ARM64 target on an x86-64 Windows execution platform selected `remotejdk25_win_arm64` and failed with Windows error 216. Resolving `current_java_runtime` through a private `cfg = "exec"` attribute preserves `--tool_java_runtime_version` while selecting Java for the execution platform.

`jvm_import_uses_execution_platform_java_runtime_test` uses an Android s390x target platform, which has no Java runtime toolchain, and verifies that both `StampJarManifest` and `CreateCompileJar` use the execution-platform `remotejdk_11` runtime and receive `AddJarManifestEntry_deploy.jar`.

## Validation

- Bazel 7.7.1: `bazel test //tests/unit/jvm_import:jvm_import_tests`
- Bazel 9.0.0: `bazel test //tests/unit/jvm_import:jvm_import_tests`
- Bazel 9.1.1 downstream checkout, with `-XX:-UsePerfData` removed and action caches disabled: `bazel build --platforms=//:windows_arm64 @maven//:org_brotli_dec`
- Bazel 9.1.1 downstream checkout, with `-XX:-UsePerfData` removed and action caches disabled: `bazel build //src/main/java/com/google/devtools/build/docgen/release:toc_updater`