### PR TITLE
Enable RJE_UNSAFE_CACHE by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,11 +1032,11 @@ variables are honoured:
 | Environment variable | Meaning                                                                                                                                                        |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `RJE_ASSUME_PRESENT` | Prevents the resolver from checking remote repositories to see if a dependency is present, and just assumes it is                                              |
-| `RJE_UNSAFE_CACHE`   | Uses your `$HOME/.m2/repository` directory to speed up dependency resolution. Enabled by default; set to `0` or `false` to disable.                            |
+| `RJE_UNSAFE_CACHE`   | By default, the shared `$HOME/.m2/repository` directory is used to speed up dependency resolution. Set to `0` or `false` to use an isolated cache instead.     |
 
-The unsafe cache option uses your local `$HOME/.m2/repository` as
-a source for dependency resolutions, but will not include any local paths in
-the generated lock file unless the `repositories` attribute contains `m2local`.
+Although your local `$HOME/.m2/repository` is used as a source for
+dependency resolutions, no local paths are included in the generated
+lock file unless the `repositories` attribute contains `m2local`.
 
 The Maven-backed resolver will use credentials stored in a `$HOME/.netrc`
 file when performing dependency resolution
@@ -1053,7 +1053,7 @@ be an empty file.
 | Environment variable | Meaning                                                                                                          |
 |----------------------|------------------------------------------------------------------------------------------------------------------|
 | `RJE_ASSUME_PRESENT` | Prevents the resolver from checking remote repositories to see if a dependency is present, and just assumes it is |
-| `RJE_UNSAFE_CACHE`   | Uses your `$HOME/.gradle` directory to speed up dependency resolution. Enabled by default; set to `0` or `false` to disable. |
+| `RJE_UNSAFE_CACHE`   | By default, your shared `$HOME/.gradle` caches are used to speed up dependency resolution. Set to `0` or `false` to use an isolated cache instead. |
 
 ## IPv6 support
 

--- a/README.md
+++ b/README.md
@@ -1032,9 +1032,9 @@ variables are honoured:
 | Environment variable | Meaning                                                                                                                                                        |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `RJE_ASSUME_PRESENT` | Prevents the resolver from checking remote repositories to see if a dependency is present, and just assumes it is                                              |
-| `RJE_UNSAFE_CACHE`   | When set to `1` will use your `$HOME/.m2/repository` directory to speed up dependency resolution                                                               |
+| `RJE_UNSAFE_CACHE`   | Uses your `$HOME/.m2/repository` directory to speed up dependency resolution. Enabled by default; set to `0` or `false` to disable.                            |
 
-Using the unsafe cache option will use your local `$HOME/.m2/repository` as
+The unsafe cache option uses your local `$HOME/.m2/repository` as
 a source for dependency resolutions, but will not include any local paths in
 the generated lock file unless the `repositories` attribute contains `m2local`.
 
@@ -1053,7 +1053,7 @@ be an empty file.
 | Environment variable | Meaning                                                                                                          |
 |----------------------|------------------------------------------------------------------------------------------------------------------|
 | `RJE_ASSUME_PRESENT` | Prevents the resolver from checking remote repositories to see if a dependency is present, and just assumes it is |
-| `RJE_UNSAFE_CACHE`   | When set to `1` will use your `$HOME/.gradle` directory to speed up dependency resolution              |
+| `RJE_UNSAFE_CACHE`   | Uses your `$HOME/.gradle` directory to speed up dependency resolution. Enabled by default; set to `0` or `false` to disable. |
 
 ## IPv6 support
 

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -861,5 +861,11 @@ maven = module_extension(
         "install": install,
         "override": override,
     },
-    environ = ["REPIN", "RULES_JVM_EXTERNAL_REPIN", "RJE_VERBOSE"],
+    environ = [
+        "HOME",
+        "REPIN",
+        "RULES_JVM_EXTERNAL_REPIN",
+        "RJE_VERBOSE",
+        "USERPROFILE",
+    ],
 )

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1654,6 +1654,12 @@ pinned_coursier_fetch = repository_rule(
         # Use @@// to refer to the main repo with Bzlmod.
         "_workspace_label": attr.label(default = ("@@" if str(Label("//:invalid")).startswith("@@") else "@") + "//does/not:exist"),
     },
+    environ = [
+        "HOME",
+        "JDK_JAVA_OPTIONS",
+        "RJE_VERBOSE",
+        "USERPROFILE",
+    ],
     implementation = _pinned_coursier_fetch_impl,
 )
 
@@ -1725,6 +1731,7 @@ coursier_fetch = repository_rule(
         ),
     },
     environ = [
+        "HOME",
         "JAVA_HOME",
         "JDK_JAVA_OPTIONS",
         "http_proxy",
@@ -1740,6 +1747,7 @@ coursier_fetch = repository_rule(
         "REPIN",
         "RULES_JVM_EXTERNAL_REPIN",
         "RJE_VERBOSE",
+        "USERPROFILE",
         "XDG_CACHE_HOME",
     ],
     implementation = _coursier_fetch_impl,

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
@@ -94,9 +94,10 @@ public abstract class AbstractMain {
 
     ResolutionRequest request = config.getResolutionRequest();
     String rjeUnsafeCache = System.getenv("RJE_UNSAFE_CACHE");
-    boolean cacheResults = false;
-    if (rjeUnsafeCache != null) {
-      cacheResults = "1".equals(rjeUnsafeCache) || Boolean.parseBoolean(rjeUnsafeCache);
+    boolean cacheResults = true;
+    if (rjeUnsafeCache != null
+        && ("0".equals(rjeUnsafeCache) || !Boolean.parseBoolean(rjeUnsafeCache))) {
+      cacheResults = false;
     }
 
     Downloader downloader =

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfig.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfig.java
@@ -123,7 +123,7 @@ public class ResolverConfig {
           maxThreads = Integer.parseInt(args[i]);
           break;
 
-        case "--use_unique_cache":
+        case "--use_isolated_cache":
           request.useUnsafeSharedCache(false);
           break;
 

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfig.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfig.java
@@ -60,10 +60,11 @@ public class ResolverConfig {
       maxThreads = Integer.parseInt(System.getenv("RJE_MAX_THREADS"));
     }
 
+    request.useUnsafeSharedCache(true);
     String envUseUnsafeCache = System.getenv("RJE_UNSAFE_CACHE");
     if (envUseUnsafeCache != null) {
-      if ("1".equals(envUseUnsafeCache) || Boolean.parseBoolean(envUseUnsafeCache)) {
-        request.useUnsafeSharedCache(true);
+      if ("0".equals(envUseUnsafeCache) || "false".equalsIgnoreCase(envUseUnsafeCache)) {
+        request.useUnsafeSharedCache(false);
       }
     }
 
@@ -122,8 +123,8 @@ public class ResolverConfig {
           maxThreads = Integer.parseInt(args[i]);
           break;
 
-        case "--use_unsafe_shared_cache":
-          request.useUnsafeSharedCache(true);
+        case "--use_unique_cache":
+          request.useUnsafeSharedCache(false);
           break;
 
         default:

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleProject.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleProject.java
@@ -66,7 +66,7 @@ public class GradleProject implements AutoCloseable {
 
   public void connect(Path gradlePath) {
     // Use gradleCacheDir as gradle.user.home for complete isolation.
-    // When RJE_UNSAFE_CACHE is set, the user's caches are symlinked into this directory.
+    // Unless RJE_UNSAFE_CACHE is set to 0 or false, the user's caches are symlinked into this directory.
     System.setProperty("org.gradle.parallel", "true");
     connection =
         GradleConnector.newConnector()

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -127,12 +127,14 @@ function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_buil
       rm -rf "${test_home}"
     }
     trap cleanup_test_home EXIT
-    export HOME="${test_home}"
-    export COURSIER_OPTS="-Duser.home=${HOME}${COURSIER_OPTS:+ ${COURSIER_OPTS}}"
+    repo_env=(
+      "--repo_env=HOME=${test_home}"
+      "--repo_env=COURSIER_OPTS=-Duser.home=${test_home}${COURSIER_OPTS:+ ${COURSIER_OPTS}}"
+    )
 
     bazel shutdown >> "$TEST_LOG" 2>&1 || true
 
-    m2local_dir="${HOME}/.m2/repository"
+    m2local_dir="${test_home}/.m2/repository"
     jar_dir="${m2local_dir}/com/example/no-docs/1.0.0"
     rm -rf "${jar_dir}"
     mkdir -p "${m2local_dir}"
@@ -140,13 +142,13 @@ function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_buil
     bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/java_export:without-docs.publish >> "$TEST_LOG" 2>&1
 
     # Force the repo rule to be evaluated again. Without this, the "assuming maven local..." message will not be printed
-    bazel shutdown
+    bazel shutdown >> "$TEST_LOG" 2>&1 || true
 
-    bazel run --repo_env=HOME --repo_env=COURSIER_OPTS @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
+    bazel run "${repo_env[@]}" @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
 
     force_bzlmod_lock_file_to_be_regenerated
 
-    bazel build --repo_env=HOME --repo_env=COURSIER_OPTS @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
+    bazel build "${repo_env[@]}" @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
 
     expect_log "Assuming maven local for artifact: com.example:no-docs:1.0.0"
     expect_log "Successfully pinned resolved artifacts"

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -116,25 +116,41 @@ function test_m2local_testing_found_local_artifact_through_pin_and_build() {
 }
 
 function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build() {
-  m2local_dir="${HOME}/.m2/repository"
-  jar_dir="${m2local_dir}/com/example/no-docs/1.0.0"
-  rm -rf ${jar_dir}
-  mkdir -p ${m2local_dir}
-  # Publish a maven artifact locally - com.example:no-docs:1.0.0
-  bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/java_export:without-docs.publish >> "$TEST_LOG" 2>&1
+  (
+    # Isolate HOME so Coursier's m2local scan sees only the artifact this test
+    # publishes, not unrelated entries from the user's real ~/.m2 repository.
+    original_home="${HOME}"
+    if ! test_home="$(mktemp -d "${original_home}/rje_test_home.XXXXXX" 2>/dev/null)"; then
+      test_home="$(mktemp -d "${PWD}/.rje_test_home.XXXXXX")"
+    fi
+    cleanup_test_home() {
+      rm -rf "${test_home}"
+    }
+    trap cleanup_test_home EXIT
+    export HOME="${test_home}"
+    export COURSIER_OPTS="-Duser.home=${HOME}${COURSIER_OPTS:+ ${COURSIER_OPTS}}"
 
-  # Force the repo rule to be evaluated again. Without this, the "assuming maven local..." message will not be printed
-  bazel clean --expunge >/dev/null 2>&1
+    bazel shutdown >> "$TEST_LOG" 2>&1 || true
 
-  bazel run @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
+    m2local_dir="${HOME}/.m2/repository"
+    jar_dir="${m2local_dir}/com/example/no-docs/1.0.0"
+    rm -rf "${jar_dir}"
+    mkdir -p "${m2local_dir}"
+    # Publish a maven artifact locally - com.example:no-docs:1.0.0
+    bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/java_export:without-docs.publish >> "$TEST_LOG" 2>&1
 
-  force_bzlmod_lock_file_to_be_regenerated
+    # Force the repo rule to be evaluated again. Without this, the "assuming maven local..." message will not be printed
+    bazel shutdown
 
-  bazel build @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
-  rm -rf ${jar_dir}
+    bazel run --repo_env=HOME --repo_env=COURSIER_OPTS @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
 
-  expect_log "Assuming maven local for artifact: com.example:no-docs:1.0.0"
-  expect_log "Successfully pinned resolved artifacts"
+    force_bzlmod_lock_file_to_be_regenerated
+
+    bazel build --repo_env=HOME --repo_env=COURSIER_OPTS @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
+
+    expect_log "Assuming maven local for artifact: com.example:no-docs:1.0.0"
+    expect_log "Successfully pinned resolved artifacts"
+  )
 }
 
 function test_m2local_testing_found_local_artifact_through_build() {

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -118,9 +118,11 @@ function test_m2local_testing_found_local_artifact_through_pin_and_build() {
 function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build() {
   # Isolate HOME so this test's m2local scan doesn't see JARs left in ~/.m2 by
   # earlier Maven-resolver pin steps (which don't write .sha1/.md5 sidecars and
-  # so trip up Coursier's m2local checksum check).
+  # so trip up Coursier's m2local checksum check). The temp dir lives under the
+  # real HOME so Bazel's output_base isn't under /tmp (which CI mounts as tmpfs
+  # and the linux-sandbox refuses).
   local original_home="$HOME"
-  export HOME=$(mktemp -d)
+  export HOME=$(mktemp -d "${original_home}/rje_test_home.XXXXXX")
 
   m2local_dir="${HOME}/.m2/repository"
   jar_dir="${m2local_dir}/com/example/kt/1.0.0"

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -116,35 +116,22 @@ function test_m2local_testing_found_local_artifact_through_pin_and_build() {
 }
 
 function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build() {
-  # Isolate HOME so this test's m2local scan doesn't see JARs left in ~/.m2 by
-  # earlier Maven-resolver pin steps (which don't write .sha1/.md5 sidecars and
-  # so trip up Coursier's m2local checksum check). The temp dir lives under the
-  # real HOME so Bazel's output_base isn't under /tmp (which CI mounts as tmpfs
-  # and the linux-sandbox refuses).
-  #
-  # We also forward HOME into repo-rule subprocesses via --repo_env=HOME, since
-  # coursier.bzl invokes Coursier with environment={} which otherwise clears
-  # the shell env (and Java's user.home falls back to /etc/passwd).
-  local original_home="$HOME"
-  export HOME=$(mktemp -d "${original_home}/rje_test_home.XXXXXX")
-
   m2local_dir="${HOME}/.m2/repository"
-  jar_dir="${m2local_dir}/com/example/kt/1.0.0"
+  jar_dir="${m2local_dir}/com/example/no-docs/1.0.0"
   rm -rf ${jar_dir}
   mkdir -p ${m2local_dir}
-  # Publish a maven artifact locally - com.example.kt:1.0.0
+  # Publish a maven artifact locally - com.example:no-docs:1.0.0
   bazel run --define maven_repo="file://${m2local_dir}" //tests/integration/java_export:without-docs.publish >> "$TEST_LOG" 2>&1
 
   # Force the repo rule to be evaluated again. Without this, the "assuming maven local..." message will not be printed
   bazel clean --expunge >/dev/null 2>&1
 
-  bazel run --repo_env=HOME @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
+  bazel run @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
 
   force_bzlmod_lock_file_to_be_regenerated
 
-  bazel build --repo_env=HOME @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
-  rm -rf "$HOME"
-  export HOME="$original_home"
+  bazel build @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
+  rm -rf ${jar_dir}
 
   expect_log "Assuming maven local for artifact: com.example:no-docs:1.0.0"
   expect_log "Successfully pinned resolved artifacts"

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -121,6 +121,10 @@ function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_buil
   # so trip up Coursier's m2local checksum check). The temp dir lives under the
   # real HOME so Bazel's output_base isn't under /tmp (which CI mounts as tmpfs
   # and the linux-sandbox refuses).
+  #
+  # We also forward HOME into repo-rule subprocesses via --repo_env=HOME, since
+  # coursier.bzl invokes Coursier with environment={} which otherwise clears
+  # the shell env (and Java's user.home falls back to /etc/passwd).
   local original_home="$HOME"
   export HOME=$(mktemp -d "${original_home}/rje_test_home.XXXXXX")
 
@@ -134,11 +138,11 @@ function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_buil
   # Force the repo rule to be evaluated again. Without this, the "assuming maven local..." message will not be printed
   bazel clean --expunge >/dev/null 2>&1
 
-  bazel run @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
+  bazel run --repo_env=HOME @unpinned_m2local_testing_repin//:pin >> "$TEST_LOG" 2>&1
 
   force_bzlmod_lock_file_to_be_regenerated
 
-  bazel build @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
+  bazel build --repo_env=HOME @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
   rm -rf "$HOME"
   export HOME="$original_home"
 

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -116,6 +116,12 @@ function test_m2local_testing_found_local_artifact_through_pin_and_build() {
 }
 
 function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_build() {
+  # Isolate HOME so this test's m2local scan doesn't see JARs left in ~/.m2 by
+  # earlier Maven-resolver pin steps (which don't write .sha1/.md5 sidecars and
+  # so trip up Coursier's m2local checksum check).
+  local original_home="$HOME"
+  export HOME=$(mktemp -d)
+
   m2local_dir="${HOME}/.m2/repository"
   jar_dir="${m2local_dir}/com/example/kt/1.0.0"
   rm -rf ${jar_dir}
@@ -131,7 +137,8 @@ function test_unpinned_m2local_testing_found_local_artifact_through_pin_and_buil
   force_bzlmod_lock_file_to_be_regenerated
 
   bazel build @m2local_testing_repin//:com_example_no_docs >> "$TEST_LOG" 2>&1
-  rm -rf ${jar_dir}
+  rm -rf "$HOME"
+  export HOME="$original_home"
 
   expect_log "Assuming maven local for artifact: com.example:no-docs:1.0.0"
   expect_log "Successfully pinned resolved artifacts"

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
@@ -44,6 +44,9 @@ java_test(
     name = "MavenResolverTest",
     size = "medium",
     srcs = ["MavenResolverTest.java"],
+    env = {
+        "RJE_UNSAFE_CACHE": "0",
+    },
     test_class = "com.github.bazelbuild.rules_jvm_external.resolver.maven.MavenResolverTest",
     deps = [
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external",

--- a/tests/custom_maven_install/m2local_testing_with_pinned_file_install.json
+++ b/tests/custom_maven_install/m2local_testing_with_pinned_file_install.json
@@ -5,11 +5,11 @@
     "repositories": -896170563
   },
   "__RESOLVED_ARTIFACTS_HASH": {
-    "com.example:no-docs": 326625745,
+    "com.example:no-docs": -1087287837,
     "com.google.errorprone:error_prone_annotations": 1527418394,
     "com.google.guava:failureaccess": 1715931538,
-    "com.google.guava:guava": 1755968516,
-    "com.google.guava:listenablefuture": 667768693,
+    "com.google.guava:guava": -1587873388,
+    "com.google.guava:listenablefuture": 1079558157,
     "com.google.j2objc:j2objc-annotations": -1008747351,
     "org.jspecify:jspecify": 117231129
   },
@@ -113,6 +113,7 @@
       "com.google.errorprone:error_prone_annotations",
       "com.google.guava:failureaccess",
       "com.google.guava:guava",
+      "com.google.guava:listenablefuture",
       "com.google.j2objc:j2objc-annotations",
       "org.jspecify:jspecify"
     ]


### PR DESCRIPTION
The shared cache is now used unless RJE_UNSAFE_CACHE is set to "0" or "false". The CLI flag --use_unsafe_shared_cache has been replaced by --use_unique_cache, which opts out of the shared cache.

Maven and Gradle docs updated accordingly. Coursier behaviour is unchanged for now.