### PR TITLE
Refactor: carry a `ResolvedArtifact` for every resolution node when resolving

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolutionResult.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolutionResult.java
@@ -16,7 +16,6 @@ package com.github.bazelbuild.rules_jvm_external.resolver;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.google.common.graph.Graph;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,15 +27,15 @@ public class ResolutionResult {
 
   private final Graph<Coordinates> resolution;
   private final Set<Conflict> conflicts;
-  private final Map<Coordinates, Path> paths;
+  private final Map<Coordinates, ResolvedArtifact> artifacts;
 
   public ResolutionResult(
       Graph<Coordinates> resolution,
       Set<Conflict> conflicts,
-      Map<Coordinates, Path> artifactPaths) {
+      Map<Coordinates, ResolvedArtifact> artifacts) {
     this.resolution = resolution;
     this.conflicts = Set.copyOf(conflicts);
-    this.paths = artifactPaths != null ? Map.copyOf(artifactPaths) : Map.of();
+    this.artifacts = artifacts != null ? Map.copyOf(artifacts) : Map.of();
   }
 
   public Graph<Coordinates> getResolution() {
@@ -47,7 +46,7 @@ public class ResolutionResult {
     return conflicts;
   }
 
-  public Map<Coordinates, Path> getPaths() {
-    return paths;
+  public Map<Coordinates, ResolvedArtifact> getArtifacts() {
+    return artifacts;
   }
 }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolvedArtifact.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolvedArtifact.java
@@ -1,0 +1,66 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver;
+
+import com.github.bazelbuild.rules_jvm_external.Coordinates;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A node in a {@link ResolutionResult}: a coordinate that was resolved, together with the local
+ * path to its artifact if one is known. The path is absent when the resolver has not (yet) fetched
+ * a file for the coordinate.
+ */
+public final class ResolvedArtifact {
+
+  private final Coordinates coordinates;
+  private final Optional<Path> path;
+
+  public ResolvedArtifact(Coordinates coordinates, Path path) {
+    this.coordinates = Objects.requireNonNull(coordinates);
+    this.path = Optional.ofNullable(path);
+  }
+
+  public Coordinates getCoordinates() {
+    return coordinates;
+  }
+
+  public Optional<Path> getPath() {
+    return path;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ResolvedArtifact)) {
+      return false;
+    }
+    ResolvedArtifact that = (ResolvedArtifact) o;
+    return coordinates.equals(that.coordinates) && path.equals(that.path);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(coordinates, path);
+  }
+
+  @Override
+  public String toString() {
+    return "ResolvedArtifact{" + coordinates + ", path=" + path.orElse(null) + "}";
+  }
+}

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolvedArtifact.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolvedArtifact.java
@@ -1,4 +1,4 @@
-// Copyright 2024 The Bazel Authors. All rights reserved.
+// Copyright 2026 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
@@ -99,6 +99,12 @@ public abstract class AbstractMain {
       cacheResults = "1".equals(rjeUnsafeCache) || Boolean.parseBoolean(rjeUnsafeCache);
     }
 
+    Map<Coordinates, Path> knownPaths = new LinkedHashMap<>();
+    resolutionResult
+        .getArtifacts()
+        .forEach(
+            (coords, artifact) -> artifact.getPath().ifPresent(p -> knownPaths.put(coords, p)));
+
     Downloader downloader =
         new Downloader(
             config.getNetrc(),
@@ -106,7 +112,7 @@ public abstract class AbstractMain {
             request.getRepositories(),
             listener,
             cacheResults,
-            resolutionResult.getPaths());
+            knownPaths);
 
     List<CompletableFuture<Set<DependencyInfo>>> futures = new LinkedList<>();
 

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -19,6 +19,7 @@ import com.github.bazelbuild.rules_jvm_external.resolver.Artifact;
 import com.github.bazelbuild.rules_jvm_external.resolver.Conflict;
 import com.github.bazelbuild.rules_jvm_external.resolver.ResolutionRequest;
 import com.github.bazelbuild.rules_jvm_external.resolver.ResolutionResult;
+import com.github.bazelbuild.rules_jvm_external.resolver.ResolvedArtifact;
 import com.github.bazelbuild.rules_jvm_external.resolver.Resolver;
 import com.github.bazelbuild.rules_jvm_external.resolver.events.EventListener;
 import com.github.bazelbuild.rules_jvm_external.resolver.events.LogEvent;
@@ -324,7 +325,12 @@ public class GradleResolver implements Resolver {
     // Only include paths for coordinates that are actually in the final resolved graph
     paths.keySet().retainAll(graph.nodes());
 
-    return new ResolutionResult(graph, conflicts, paths);
+    Map<Coordinates, ResolvedArtifact> artifacts = new HashMap<>();
+    for (Coordinates node : graph.nodes()) {
+      artifacts.put(node, new ResolvedArtifact(node, paths.get(node)));
+    }
+
+    return new ResolutionResult(graph, conflicts, artifacts);
   }
 
   private String makeDepKey(String group, String artifact, String version) {

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
@@ -18,6 +18,7 @@ import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.Conflict;
 import com.github.bazelbuild.rules_jvm_external.resolver.ResolutionRequest;
 import com.github.bazelbuild.rules_jvm_external.resolver.ResolutionResult;
+import com.github.bazelbuild.rules_jvm_external.resolver.ResolvedArtifact;
 import com.github.bazelbuild.rules_jvm_external.resolver.Resolver;
 import com.github.bazelbuild.rules_jvm_external.resolver.events.EventListener;
 import com.github.bazelbuild.rules_jvm_external.resolver.events.LogEvent;
@@ -274,7 +275,13 @@ public class MavenResolver implements Resolver {
             getConflicts(request.getDependencies(), resolvedDependencies),
             graphNormalizationResult.getConflicts());
 
-    return new ResolutionResult(graphNormalizationResult.getNormalizedGraph(), conflicts, Map.of());
+    Graph<Coordinates> normalizedGraph = graphNormalizationResult.getNormalizedGraph();
+    Map<Coordinates, ResolvedArtifact> artifacts = new HashMap<>();
+    for (Coordinates node : normalizedGraph.nodes()) {
+      artifacts.put(node, new ResolvedArtifact(node, null));
+    }
+
+    return new ResolutionResult(normalizedGraph, conflicts, artifacts);
   }
 
   private GraphNormalizationResult makeVersionsConsistent(Graph<Coordinates> dependencyGraph) {

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -877,9 +877,10 @@ public abstract class ResolverTestBase {
     // Validate that the downloaded artifact has the correct SHA for the forced version.
     // This catches bugs where the resolver fetches artifacts via detached configurations
     // that bypass force_version, resulting in the wrong file being downloaded.
-    Map<Coordinates, Path> paths = result.getPaths();
-    if (paths.containsKey(lowerVersion)) {
-      Path downloadedArtifact = paths.get(lowerVersion);
+    Map<Coordinates, ResolvedArtifact> artifacts = result.getArtifacts();
+    ResolvedArtifact lower = artifacts.get(lowerVersion);
+    if (lower != null && lower.getPath().isPresent()) {
+      Path downloadedArtifact = lower.getPath().get();
       Path expectedArtifact = repo.resolve(lowerVersion.toRepoPath());
 
       // Compare SHA256 of downloaded file vs expected file in repo

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolverTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolverTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.MavenRepo;
 import com.github.bazelbuild.rules_jvm_external.resolver.ResolutionResult;
+import com.github.bazelbuild.rules_jvm_external.resolver.ResolvedArtifact;
 import com.github.bazelbuild.rules_jvm_external.resolver.Resolver;
 import com.github.bazelbuild.rules_jvm_external.resolver.ResolverTestBase;
 import com.github.bazelbuild.rules_jvm_external.resolver.cmd.ResolverConfig;
@@ -284,10 +285,11 @@ public class GradleResolverTest extends ResolverTestBase {
     assertEquals("Should resolve to exactly one version", 1, conflictedNodes.size());
     assertTrue("Should resolve to higher version", conflictedNodes.contains(higherVersion));
 
-    // Verify paths map contains only the resolved (higher) version, not the lower version
-    Map<Coordinates, Path> paths = result.getPaths();
-    assertTrue("Paths should contain resolved version", paths.containsKey(higherVersion));
+    // Verify the resolved artifacts contain only the resolved (higher) version, not the lower one
+    Map<Coordinates, ResolvedArtifact> artifacts = result.getArtifacts();
+    assertTrue("Artifacts should contain resolved version", artifacts.containsKey(higherVersion));
     assertFalse(
-        "Paths should not contain conflicting lower version", paths.containsKey(lowerVersion));
+        "Artifacts should not contain conflicting lower version",
+        artifacts.containsKey(lowerVersion));
   }
 }


### PR DESCRIPTION
Replace the `Map<Coordinates, Path>` side-channel on `ResolutionResult` with a `Map<Coordinates, ResolvedArtifact>` that has an entry for every node in the resolved graph. Each `ResolvedArtifact` holds its coordinates and an optional path, so "this node has no known binary" is represented explicitly rather than inferred from an absent map entry.

This refactoring lays the groundwork for being able to better handle gradle module metadata more efficiently when using the gradle resolver.