### PR TITLE
Fix TOML AAR overrides using original artifact copy targets

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -307,6 +307,11 @@ dev_maven.from_toml(
     ],
     libs_versions_toml = "//tests/integration:libs.versions.toml",
 )
+dev_maven.override(
+    name = "from_files",
+    coordinates = "com.google.android.gms:play-services-tasks",
+    target = "@//tests/integration/override_targets:play_services_tasks_override",
+)
 dev_maven.amend_artifact(
     name = "from_files",
     testonly = "true",

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -33,13 +33,14 @@ load("//private/lib:coordinates.bzl", "to_purl", "unpack_coordinates")
 load("//private/lib:urls.bzl", "scheme_and_host")
 
 def _genrule_copy_artifact_from_http_file(artifact, visibilities):
-    http_file_repository = to_repository_name(artifact["coordinates"])
+    output_repository = to_repository_name(artifact["coordinates"])
+    http_file_repository = to_repository_name(artifact.get("repository_coordinates", artifact["coordinates"]))
 
     file = artifact.get("out", artifact["file"])
 
     genrule = [
         "copy_file(",
-        "     name = \"%s_extension\"," % http_file_repository,
+        "     name = \"%s_extension\"," % output_repository,
         "     src = \"@%s//file\"," % http_file_repository,
         "     out = \"%s\"," % file,
         # Windows doesn't care about the executable bit for executables, but copy_file
@@ -534,6 +535,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             raw_artifact = dict(artifact)
             raw_artifact["coordinates"] = "original_" + artifact["coordinates"]
             raw_artifact["maven_coordinates"] = artifact["coordinates"]
+            raw_artifact["repository_coordinates"] = artifact["coordinates"]
             raw_artifact["out"] = "original_" + artifact["file"]
 
             all_imports.extend(_generate_target(

--- a/tests/integration/override_targets/BUILD
+++ b/tests/integration/override_targets/BUILD
@@ -27,6 +27,14 @@ build_test(
     ],
 )
 
+build_test(
+    name = "from_toml_aar_override_original_artifact_test",
+    tags = [] if is_bzlmod_enabled() else ["manual"],
+    targets = [
+        "@from_files//:original_com_google_android_gms_play_services_tasks_aar_18_1_0_extension",
+    ],
+)
+
 java_library(
     name = "additional_deps",
     visibility = ["//visibility:public"],
@@ -36,6 +44,11 @@ java_library(
     runtime_deps = [
         "@override_target_in_deps//:redis_clients_jedis",
     ],
+)
+
+java_library(
+    name = "play_services_tasks_override",
+    visibility = ["//visibility:public"],
 )
 
 genquery(

--- a/tests/unit/dependency_tree_parser_test.bzl
+++ b/tests/unit/dependency_tree_parser_test.bzl
@@ -3,28 +3,28 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//private:dependency_tree_parser.bzl", "parser")
 
-def _repo_ctx():
+def _repo_ctx(maven_install_json = False):
     return struct(
         attr = struct(
             fetch_javadoc = False,
             fetch_sources = False,
             generate_compat_repositories = False,
-            maven_install_json = False,
+            maven_install_json = maven_install_json,
             repositories = ["{ \"repo_url\": \"https://repo1.maven.org/maven2/\" }"],
             strict_visibility = False,
             strict_visibility_value = ["//visibility:public"],
         ),
     )
 
-def _generate_imports(dependencies, exclusions):
+def _generate_imports(dependencies, exclusions, override_targets = {}, maven_install_json = False):
     result = parser.generate_imports(
-        repository_ctx = _repo_ctx(),
+        repository_ctx = _repo_ctx(maven_install_json = maven_install_json),
         dependencies = dependencies,
         explicit_artifacts = {},
         neverlink_artifacts = {},
         testonly_artifacts = {},
         exclusions = exclusions,
-        override_targets = {},
+        override_targets = override_targets,
         override_target_visibilities = {},
         skip_maven_local_dependencies = False,
     )
@@ -144,10 +144,40 @@ def _pom_only_exclusion_removes_generated_export_impl(ctx):
 
 pom_only_exclusion_removes_generated_export_test = unittest.make(_pom_only_exclusion_removes_generated_export_impl)
 
+def _overridden_aar_original_artifact_uses_real_http_file_repo_impl(ctx):
+    env = unittest.begin(ctx)
+
+    generated_imports = _generate_imports(
+        dependencies = [
+            {
+                "coordinates": "com.google.android.gms:play-services-tasks:18.1.0@aar",
+                "deps": [],
+                "file": "v1/https/maven.google.com/com/google/android/gms/play-services-tasks/18.1.0/play-services-tasks-18.1.0.aar",
+                "urls": [
+                    "https://maven.google.com/com/google/android/gms/play-services-tasks/18.1.0/play-services-tasks-18.1.0.aar",
+                ],
+            },
+        ],
+        exclusions = {},
+        override_targets = {
+            "com.google.android.gms:play-services-tasks": "//third_party:play_services_tasks",
+        },
+        maven_install_json = True,
+    )
+
+    asserts.true(env, "name = \"original_com_google_android_gms_play_services_tasks_aar_18_1_0_extension\"," in generated_imports)
+    asserts.true(env, "src = \"@com_google_android_gms_play_services_tasks_aar_18_1_0//file\"," in generated_imports)
+    asserts.false(env, "src = \"@original_com_google_android_gms_play_services_tasks_aar_18_1_0//file\"," in generated_imports)
+
+    return unittest.end(env)
+
+overridden_aar_original_artifact_uses_real_http_file_repo_test = unittest.make(_overridden_aar_original_artifact_uses_real_http_file_repo_impl)
+
 def dependency_tree_parser_test_suite():
     unittest.suite(
         "dependency_tree_parser_tests",
         exclusion_removes_generated_dep_test,
         wildcard_exclusion_removes_all_generated_deps_test,
         pom_only_exclusion_removes_generated_export_test,
+        overridden_aar_original_artifact_uses_real_http_file_repo_test,
     )


### PR DESCRIPTION
When an artifact is overridden, the generated `original_` target should keep using the real resolved artifact repository as its backing file source. The copy rule derived the source repo from the synthetic `original_` coordinates, which created references to non-existent repositories for AAR artifacts parsed from `libs.versions.toml`.

Fixes https://github.com/bazel-contrib/rules_jvm_external/issues/976 and https://github.com/bazel-contrib/rules_jvm_external/issues/1421