### PR TITLE
fix: make :outdated work when runfiles trees are disabled

### DIFF
--- a/private/outdated.sh
+++ b/private/outdated.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
 
-set -e -o pipefail
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
 
-outdated_jar_path=$1
-artifacts_file_path=$2
-boms_file_path=$3
-repositories_file_path=$4
-extra_option_flag=$5
+set -euo pipefail
+
+outdated_jar_path=$(rlocation "$1")
+artifacts_file_path=$(rlocation "$2")
+boms_file_path=$(rlocation "$3")
+repositories_file_path=$(rlocation "$4")
+extra_option_flag=${5:-}
 
 java {proxy_opts} -jar "$outdated_jar_path" \
   --artifacts-file "$artifacts_file_path" \

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -103,10 +103,13 @@ sh_binary(
         "outdated.repositories",
     ],
     args = [
-        "$(location @rules_jvm_external//private/tools/prebuilt:outdated_deploy.jar)",
-        "$(location outdated.artifacts)",
-        "$(location outdated.boms)",
-        "$(location outdated.repositories)",
+        "$(rlocationpath @rules_jvm_external//private/tools/prebuilt:outdated_deploy.jar)",
+        "$(rlocationpath outdated.artifacts)",
+        "$(rlocationpath outdated.boms)",
+        "$(rlocationpath outdated.repositories)",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -255,6 +255,13 @@ function test_outdated_no_external_runfiles() {
   expect_log "junit:junit \[4.12"
 }
 
+function test_outdated_noenable_runfiles() {
+  bazel run @regression_testing_coursier//:outdated --noenable_runfiles >> "$TEST_LOG" 2>&1
+
+  expect_log "Checking for updates of .* artifacts against the following repositories"
+  expect_log "junit:junit \[4.12"
+}
+
 function test_outdated_with_boms() {
   bazel run @regression_testing_maven//:outdated >> "$TEST_LOG" 2>&1
 
@@ -419,6 +426,7 @@ TESTS=(
   "test_duplicate_version_warning_same_version"
   "test_outdated"
   "test_outdated_no_external_runfiles"
+  "test_outdated_noenable_runfiles"
   "test_outdated_with_boms"
   "test_outdated_with_boms_does_not_include_artifacts_without_a_version"
   "test_m2local_testing_found_local_artifact_through_pin_and_build"


### PR DESCRIPTION
`bazel run @maven//:outdated` fails with `Error: Unable to access jarfile ...` when runfiles trees are not materialised (`--noenable_runfiles`, the default on Windows), because the generated `sh_binary` passes `$(location)` rootpaths that are resolved relative to the working directory. Resolve the arguments through the Bash runfiles library instead, as `:pin` has done since #900. Verified against a bzlmod workspace consuming rules_jvm_external as an external repo under default flags, `--noenable_runfiles`, and `--experimental_sibling_repository_layout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)