### PR TITLE
BOM/POM coordinates condition marked as `skipped` must not be turned into http_file downloads

### DIFF
--- a/private/extensions/download_pinned_deps.bzl
+++ b/private/extensions/download_pinned_deps.bzl
@@ -16,6 +16,9 @@ def download_pinned_deps(mctx, artifacts, http_files, has_m2local):
         if http_file_repository_name in http_files:
             continue
 
+        if not artifact.get("file"):
+            continue        
+
         urls = []
         artifact_urls = artifact["urls"]
 


### PR DESCRIPTION
 Artifacts with no `file` (e.g. BOM/POM coordinates marked as `skipped` in the lock file because they have no jar) must not be turned into  `http_file` downloads: there is nothing to fetch and constructing the  `.jar` URL for them results in spurious 404s. 
See the equivalent guard in `pinned_coursier_fetch_impl` (`if artifact.get("file"):`).
(https://github.com/bazel-contrib/rules_jvm_external/blob/master/private/rules/coursier.bzl#L1290)